### PR TITLE
Attempt get cardano-db-sync and Marconi have same output for epoch stakepool sizes (SDD)

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -294,19 +294,27 @@ epochStateWorker_
     cp <- toException $ Storable.resumeFromStorage $ view Storable.handle indexer
     indexerMVar <- newMVar indexer
 
-    let loop currentLedgerState currentEpochNo previousEpochNo = do
+    let loop currentLedgerState currentEpochNo = do
             signalQSemN _barrier 1
             failWhenFull _errorVar
             chainSyncEvent <- atomically $ readTChan ch
 
-            newLedgerState <- case chainSyncEvent of
+            (newLedgerState, newEpochNo) <- case chainSyncEvent of
               RollForward blockInMode@(C.BlockInMode (C.Block (C.BlockHeader slotNo bh bn) _) _) chainTip -> do
+
+                  let newLedgerState' = O.lrResult
+                       $ O.tickThenReapplyLedgerResult
+                            hfLedgerConfig
+                            (C.toConsensusBlock blockInMode)
+                            currentLedgerState
+                      newEpochNo = EpochState.getEpochNo newLedgerState'
+
                   -- If the block is rollbackable, we always store the LedgerState. If the block is
                   -- immutable, we only store it right at the beginning of a new epoch.
-                  let isFirstEventOfEpoch = currentEpochNo > previousEpochNo
+                  let isFirstEventOfEpoch = newEpochNo > currentEpochNo
                   let storableEvent =
                           EpochState.toStorableEvent
-                            currentLedgerState
+                            newLedgerState'
                             slotNo
                             bh
                             bn
@@ -317,17 +325,15 @@ epochStateWorker_
                   onInsert (newIndexer, storableEvent)
 
                   -- Compute new LedgerState given block and old LedgerState
-                  pure $ O.lrResult
-                       $ O.tickThenReapplyLedgerResult
-                            hfLedgerConfig
-                            (C.toConsensusBlock blockInMode)
-                            currentLedgerState
+                  pure (newLedgerState', newEpochNo)
 
               RollBackward C.ChainPointAtGenesis _ct -> do
                   void $ updateWith indexerMVar _errorVar $ Storable.rewind C.ChainPointAtGenesis
-                  pure initialLedgerState
+                  pure (initialLedgerState, Nothing)
+
               RollBackward cp' _ct -> do
                   newIndex <- updateWith indexerMVar _errorVar $ Storable.rewind cp'
+
                   -- We query the LedgerState from disk at the point where we need to rollback to.
                   -- For that to work, we need to be sure that any volatile LedgerState are stored
                   -- on disk. For immutable LedgerStates, they are only stored on disk at the first
@@ -335,20 +341,20 @@ epochStateWorker_
                   maybeLedgerState <-
                          runExceptT $ Storable.query newIndex (EpochState.LedgerStateAtPointQuery cp')
                   case maybeLedgerState of
-                    Right (EpochState.LedgerStateAtPointResult (Just ledgerState)) -> pure ledgerState
+                    Right (EpochState.LedgerStateAtPointResult (Just ledgerState)) -> pure (ledgerState, EpochState.getEpochNo ledgerState)
                     Right (EpochState.LedgerStateAtPointResult Nothing) -> do
                         void $ tryPutMVar _errorVar
                             $ CantRollback "Could not find LedgerState from which to rollback from in EpochState indexer. Should not happen!"
-                        pure initialLedgerState
+                        pure (initialLedgerState, Nothing)
                     Right _ -> do
                         void $ tryPutMVar _errorVar
                             $ CantRollback "LedgerStateAtPointQuery returned a result mismatch when applying a rollback. Should not happen!"
-                        pure initialLedgerState
+                        pure (initialLedgerState, Nothing)
                     Left err         -> do
                         void $ tryPutMVar _errorVar err
-                        pure initialLedgerState
+                        pure (initialLedgerState, Nothing)
 
-            loop newLedgerState (EpochState.getEpochNo newLedgerState) currentEpochNo
+            loop newLedgerState newEpochNo
 
     pure (loop initialLedgerState (EpochState.getEpochNo initialLedgerState) Nothing, cp, indexerMVar)
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -356,7 +356,7 @@ epochStateWorker_
 
             loop newLedgerState newEpochNo
 
-    pure (loop initialLedgerState (EpochState.getEpochNo initialLedgerState) Nothing, cp, indexerMVar)
+    pure (loop initialLedgerState (EpochState.getEpochNo initialLedgerState), cp, indexerMVar)
 
 epochStateWorker
     :: FilePath

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochState.hs
@@ -178,7 +178,7 @@ toStorableEvent
     -> C.BlockNo
     -> C.ChainTip
     -> SecurityParam
-    -> Bool -- ^ Is the last event of the current epoch
+    -> Bool -- ^ Is the first event of the current epoch
     -> StorableEvent EpochStateHandle
 toStorableEvent extLedgerState slotNo bhh bn chainTip securityParam isFirstEventOfEpoch = do
     let doesStoreLedgerState =

--- a/marconi-chain-index/test-compare-cardano-db-sync/Spec.hs
+++ b/marconi-chain-index/test-compare-cardano-db-sync/Spec.hs
@@ -12,9 +12,10 @@
 
 3. Run this test by setting the env variables:
 
-     - CARDANO_NODE_SOCKET_PATH:
+     - CARDANO_NODE_SOCKET_PATH
      - CARDANO_NODE_CONFIG_PATH
      - MARCONI_DB_DIRECTORY_PATH
+     - DBSYNC_PGPASSWORD: The default password for cardano-db-sync's postgres database is in its repo in the file: config/secrets/postgres_password
 
    And then run the command:
 

--- a/marconi-chain-index/test-compare-cardano-db-sync/Spec.hs
+++ b/marconi-chain-index/test-compare-cardano-db-sync/Spec.hs
@@ -16,6 +16,7 @@
      - CARDANO_NODE_CONFIG_PATH
      - MARCONI_DB_DIRECTORY_PATH
      - DBSYNC_PGPASSWORD: The default password for cardano-db-sync's postgres database is in its repo in the file: config/secrets/postgres_password
+     - NETWORK_MAGIC: "mainnet" or number
 
    And then run the command:
 
@@ -44,6 +45,7 @@ import Database.PostgreSQL.Simple.FromField qualified as PG
 import Database.PostgreSQL.Simple.ToField qualified as PG
 import System.Environment (lookupEnv)
 import System.FilePath ((</>))
+import Text.Read (readMaybe)
 
 import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as C
@@ -159,8 +161,14 @@ openEpochStateIndexer = do
   socketPath <- envOrFail "CARDANO_NODE_SOCKET_PATH"
   nodeConfigPath <- envOrFail "CARDANO_NODE_CONFIG_PATH"
   dbDir <- envOrFail "MARCONI_DB_DIRECTORY_PATH"
+  networkMagicStr <- envOrFail "NETWORK_MAGIC"
+  networkMagic <- case networkMagicStr of
+    "mainnet" -> return C.Mainnet
+    _ -> case readMaybe networkMagicStr of
+      Nothing     -> fail $ "Can't parse network magic: " <> networkMagicStr
+      Just word32 -> return $ C.Testnet $ C.NetworkMagic word32
   liftIO $ do
-    securityParam <- throwIndexerError $ Utils.querySecurityParamEra C.BabbageEraInCardanoMode C.Mainnet socketPath
+    securityParam <- throwIndexerError $ Utils.querySecurityParamEra C.BabbageEraInCardanoMode networkMagic socketPath
     topLevelConfig <- topLevelConfigFromNodeConfig nodeConfigPath
     let dbPath = dbDir </> epochStateDbName
         ledgerStateDirPath = dbDir </> "ledgerStates"

--- a/marconi-chain-index/test-compare-cardano-db-sync/Spec.hs
+++ b/marconi-chain-index/test-compare-cardano-db-sync/Spec.hs
@@ -89,10 +89,12 @@ propEpochStakepoolSize = H.withTests 1 $ H.property $ do
         dbSyncResult <- liftIO $ dbSyncStakepoolSizes conn epochNo
         marconiResult <- liftIO $ indexerStakepoolSizes epochNo indexer
         liftIO $ putStr
-          $ "\nComparing random epoch " <> show epochNo
+          $ "\nComparing epoch " <> show epochNo
           <> ", number of stakepools in epoch " <> show (Map.size dbSyncResult)
-          <> ", epoch chosen from between " <> show (coerce @_ @Word64 minEpochNo) <> " and " <> show (coerce @_ @Word64 maxEpochNo) <> ")"
         dbSyncResult === marconiResult
+  liftIO $ putStrLn
+     $ "Min and max epoch in cardano-db-sync postgres: "
+    <> show (coerce @_ @Word64 minEpochNo) <> " and " <> show (coerce @_ @Word64 maxEpochNo) <> ")"
   forM_ [minEpochNo .. maxEpochNo] compareEpoch
 
 dbSyncStakepoolSizes :: PG.Connection -> C.EpochNo -> IO (Map.Map C.PoolId C.Lovelace)


### PR DESCRIPTION
Test a change to epoch state indexer.

There may have been an off-by-one error in how epoch number and stakepool sizes are matched up, but will shelve this, if this branch doesn't fix the issue.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
