### PR TITLE
Add standalone index-state to cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,6 +11,8 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
+index-state: 2023-04-11T00:00:00Z
+
 -- See CONTRIBUTING.adoc for how to update index-state
 index-state:
   , hackage.haskell.org 2023-04-11T00:00:00Z


### PR DESCRIPTION
Seemingly redundant, but needed by certain versions/functions of haskell.nix, which would otherwise error out.