### PR TITLE
Add ADR for the computation of the SDD per epoch

### DIFF
--- a/marconi-sidechain/doc/adr/01-sdd-computation.adoc
+++ b/marconi-sidechain/doc/adr/01-sdd-computation.adoc
@@ -31,26 +31,24 @@ TBD
 
 We will describe all the potential and discussed solutions to index the SDD of each epoch in the following sections.
 
-As a summary, we provide the following caracteristics table and indicate how each solution responds to them.
-This assessment is measured in regards to two components: Cardano Node and Marconi.
+As a summary, we provide the following characteristics table and indicate how each solution responds to them.
+This assessment is measured in regard to two components: Cardano Node and Marconi.
 
-
-
-.Comparison of solutions using a list of caracteristics
+.Comparison of solutions using a list of characteristics
 [cols="1,1,1,1,1"]
 |===
-|Caracteristics | Marconi LedgerState computation | Read LedgerEvents from node | SDD using N2C | Marconi as a node
+|Characteristics | Marconi LedgerState computation | Read LedgerEvents from node | SDD using N2C | Marconi as a node
 
 |Number of LedgerState computations | 2 | 1 | 1 | 1
 |Initial node resync required | No | Yes | Yes | Yes
-|Required node resync after Marconi logic change | No | No | Yes | Yes
+|Required node resync after Marconi logic change | No | No | Yes | No
 |Change to cardano-node | No | Yes | No | No
 |===
 
-.Description of the caracteristics
+.Description of the characteristics
 [cols="1,1"]
 |===
-|Caracteristics | Description
+|Characteristics | Description
 
 |Number of LedgerState computations
 |As it suggest, corresponds to total number of independent computations of the LedgerState.
@@ -72,10 +70,6 @@ For more details, read the sections below.
 
 This is the approach that `cardano-db-sync` currently uses to compute the SDD for each epoch.
 
-A container diagram of this solution would look like:
-
-image::http://www.plantuml.com/plantuml/png/jL0_Q-Cm5D_zANIU4ZZ7SDnqKovkbz8w9g5pKAJNM4H_XFJKr9H-zqfAunfAe4ityNx_jVH87GObYrz2Cnaua1xH-dzrxUXfSH3OXttmu9ZH21eNpAZQIggJflB8fTZNpT-gIwV7X_jQKO_WucdNH0KL6jp2_eZ_3LXf1fL4EQ1e3OUPj-OtARVTcl0HB-VajIZ6FZEd8sK3aWuaQShv1DlR1AwaOKVIESC34_fmeQr4L6NvcHRBgg05emYUdEAMCXxRFosnpg1XHaRDn5lHD5D4piUhye83woCQYSbwPEIAJu2iZywPKVb1CmBFeD6VOvehCQDf-eZBc_otzXmonJyRCIfbzhtRhjjgqpNZt0dTNHdzjKtnLXJRmIEetUqBpY0h6-eurOPem9Dnnp4Xe-wx7xe4pOEIxm00[]
-
 Here is a general outline of the computation of the `LedgerState`:
 
 . At the start of `marconi-sidechain`, initialize the `LedgerState` (or `NewEpochState`) given the node genesis file
@@ -84,7 +78,11 @@ Here is a general outline of the computation of the `LedgerState`:
 . Compute the SDD from the new LedgerState and store in the database
 . Repeat from step 2
 
-While this approach is the "easiest" to implement, it suffers from major drawbacks such as:
+A container diagram of this solution would look like:
+
+image::http://www.plantuml.com/plantuml/png/jL0_Q-Cm5D_zANIU4ZZ7SDnqKovkbz8w9g5pKAJNM4H_XFJKr9H-zqfAunfAe4ityNx_jVH87GObYrz2Cnaua1xH-dzrxUXfSH3OXttmu9ZH21eNpAZQIggJflB8fTZNpT-gIwV7X_jQKO_WucdNH0KL6jp2_eZ_3LXf1fL4EQ1e3OUPj-OtARVTcl0HB-VajIZ6FZEd8sK3aWuaQShv1DlR1AwaOKVIESC34_fmeQr4L6NvcHRBgg05emYUdEAMCXxRFosnpg1XHaRDn5lHD5D4piUhye83woCQYSbwPEIAJu2iZywPKVb1CmBFeD6VOvehCQDf-eZBc_otzXmonJyRCIfbzhtRhjjgqpNZt0dTNHdzjKtnLXJRmIEetUqBpY0h6-eurOPem9Dnnp4Xe-wx7xe4pOEIxm00[]
+
+While this approach is the "easiest" to implement, it suffers from major drawbacks, such as:
 
 * adding an additional 10-16GB of RAM in `marconi-sidechain` just from computing the `LedgerState`
 * slowing down indexing.
@@ -130,12 +128,12 @@ A container diagram of this solution would look like:
 
 image::http://www.plantuml.com/plantuml/png/jL7DRfmm4Bxp52ud8fL5gdhgAGsRIvKIb5NFaR67nOf_B7ieHLNVlRPtbmLfLVMI0vAPxsU-cRdtI1sEIcOVX6Pov406HEk_L9MZq-ueS1YxqODZHYDet36ZAYkfZfhI8vUYg-hFPHjBFxu_LOfw11TAhtLGKA71xUox-E_1IZEhA4eDiiPmABmr7qb-Q9y9N_3yZlpEiYLFuNIWl82aCucQ_6w5TJQ23zAmDz8wmqSczF52Un11bUGdMWYhHYqOHV1a2hFaeTXyQeXr1WqpCcYktlkkqC7d2VWHtEDFqBZl0d_rxmF_qk4MTN82OUDPA1fN9m9uVfLUS613GCzc2oEDtGEo8QHDZDBFcX58hK_HwoNwLdqxZmFAjt6Mvl48bpVvQcsqZrzFUpf1VtPVqQ-3C2fbYlFjyDoKBsszR7v5T__O_sQ8Frbsc3s2UdtyXGKaNKqTfzeG3JWPzxRu9zJzxsNlGVDHoRy0[]
 
-The benefits:
+To summarize, the benefits are:
 
 * removal of the additional 10-16GB of memory needed to compute the `LedgerState` in `marconi-sidechain`
 * enables any chain-indexers (`cardano-db-sync`, `Kupo`, etc) to read the stored `LedgerEvent` in order to index various information like SDD and rewards without using a large amount of memory
 
-The drawbacks:
+and the drawbacks are:
 
 * requires a change to `cardano-node` in order to store those LedgerEvents. This implies lots of discussions with the `cardano-node` team to accept such a change.
 * needs the SPO to resync the relay node from scratch in order to save the `LedgerEvent` on disk. However, such a resync will only be required once, even after an upgrade on `marconi-sidechain`.
@@ -157,12 +155,12 @@ As a direct consequence of this solution, the user would be required to delete t
 
 The container diagram is the same as the link:#compute-sdd-by-tracking-the-ledgerstate[Compute SDD by tracking the LedgerState] solution.
 
-The benefits:
+To summarize, the benefits are:
 
 * no change to `cardano-node` are required
 * uses the existing infrastructure to get the required information
 
-The drawbacks:
+and the drawbacks:
 
 * needs the SPO to resync the relay node from scratch
 * any change in the indexing logic of `marconi-sidechain` would require resyncing from scratch the local node (thus deleting the node database)
@@ -172,27 +170,27 @@ The drawbacks:
 === 4. Transform `marconi-sidechain` to a Cardano relay node
 
 `marconi-sidechain` could be changed to become _a_ Cardano node and replace the SPO's relay node.
-Then, it would have the same functionality as a relay (using node-to-node protocol), but also index
-the necessary for the Sidechain team.
+Then, it would have the same functionality as a relay (using node-to-node protocol), but also index the necessary data for the Sidechain team.
 
-Ultimately, the `marconi-sidechain` process would run two computations in parallel: the N2N protocol
-and the indexers.
-Then, we would need to find a way to get the `LedgerState` that's computed by the node's consensus
-layer and wire it to the indexers.
+Ultimately, the `marconi-sidechain` process would run two computations in parallel: the N2N protocol and the indexers.
+Then, we would need to find a way to get the `LedgerState` (used to compute the SDD) that's computed by the node's consensus layer and wire it to the indexers.
+Lastly, we would need a resuming strategy for the indexer.
+The node already keeps the volatile `LedgerState` in memory, therefore any rollbacks to the `LedgerState` would be automatically handled.
+However, in the case of the SDD indexer, we would need to checkpoint the `LedgerState` at the beginning of the latest epoch in order to support resuming.
 
 A container diagram of this solution would look like:
 
 image::http://www.plantuml.com/plantuml/png/jO_1JW8n48RlVOgw9qY4JOmdJyZgnSYoWNWcfPr0GzjfsccG6D_TLW8BYIPUl4sdt_pppIII29IiOJVQIPCKy2sHZmzr7SH-lD6qJUiK8KXq18x64ctjZN1bPXH96Rskc_jHLrflizVQYaWGSclLe2EX7OIn_vVy9_063xOCVIzWBIeOH8-tl5fsSwxE_zMGVp1szXcilSlCrA3SyIwWIbAx3I_ZrV2Iiw9ewSpEZXLVW1674pdL-Tb3nrI9rYQdfI28V9_FgtAplMkv3qWeqLolY5g1tEQwI9zg_kXznahwnNzl8uKniUI-BEVjQD4rHvaVyT-LcYkbJyQMXqXWLy_lD81GX1eHb7387T0Um-wy1KAV_yUJ9-1KikOB[]
 
-The benefits:
+To summarize, the benefits are:
 
 * no change to `cardano-node` are required
 * only one computation of `LedgerState` is required
 
-The drawbacks:
+and the drawbacks:
 
 * uncertainty of capability to use `cardano-node` as a library
-* any change in the indexing logic of `marconi-sidechain` would require resyncing from scratch the local node (thus deleting the node database)
+* need to checkpoint (save on disk) the `LedgerState` at regular interval
 * needs the SPO to resync the relay node from scratch
 
 === 5. Use Mithril SDD snapshots
@@ -210,5 +208,5 @@ Therefore, our intuition is that Mithril could be used to _bootstrap_ `marconi-s
 
 === 2023/05/03
 
-Discussing with @abailly-iohk, seems like the "ideal" solution would be to transform `marconi-sidechain` to a Cardano node using the node-to-node protocol and replace the SPO's relay node.
+Discussing with @abailly-iohk and the Marconi team, it seems like the "ideal" solution would be to transform `marconi-sidechain` to a Cardano node using the node-to-node protocol and replace the SPO's relay node.
 However, we require product input from the Sidechain team given the changes that an SPO would have to do.

--- a/marconi-sidechain/doc/adr/01-sdd-computation.adoc
+++ b/marconi-sidechain/doc/adr/01-sdd-computation.adoc
@@ -34,6 +34,10 @@ TBD
 
 === Compute SDD by tracking the `LedgerState`
 
+A container diagram of this solution would look like:
+
+image::http://www.plantuml.com/plantuml/png/jL0_Q-Cm5D_zANIU4ZZ7SDnqKovkbz8w9g5pKAJNM4H_XFJKr9H-zqfAunfAe4ityNx_jVH87GObYrz2Cnaua1xH-dzrxUXfSH3OXttmu9ZH21eNpAZQIggJflB8fTZNpT-gIwV7X_jQKO_WucdNH0KL6jp2_eZ_3LXf1fL4EQ1e3OUPj-OtARVTcl0HB-VajIZ6FZEd8sK3aWuaQShv1DlR1AwaOKVIESC34_fmeQr4L6NvcHRBgg05emYUdEAMCXxRFosnpg1XHaRDn5lHD5D4piUhye83woCQYSbwPEIAJu2iZywPKVb1CmBFeD6VOvehCQDf-eZBc_otzXmonJyRCIfbzhtRhjjgqpNZt0dTNHdzjKtnLXJRmIEetUqBpY0h6-eurOPem9Dnnp4Xe-wx7xe4pOEIxm00[]
+
 This is the approach that `cardano-db-sync` currently uses to compute the SDD for each epoch.
 
 Here is a general outline of the steps:
@@ -54,6 +58,10 @@ While this approach is the "easiest" to implement, it suffers from major drawbac
 These drawbacks are significant enough that alternative solutions need to be explored.
 
 === Add an option to cardano-node for storing LedgerEvents
+
+A container diagram of this solution would look like:
+
+image::http://www.plantuml.com/plantuml/png/jL7DRfmm4Bxp52ud8fL5gdhgAGsRIvKIb5NFaR67nOf_B7ieHLNVlRPtbmLfLVMI0vAPxsU-cRdtI1sEIcOVX6Pov406HEk_L9MZq-ueS1YxqODZHYDet36ZAYkfZfhI8vUYg-hFPHjBFxu_LOfw11TAhtLGKA71xUox-E_1IZEhA4eDiiPmABmr7qb-Q9y9N_3yZlpEiYLFuNIWl82aCucQ_6w5TJQ23zAmDz8wmqSczF52Un11bUGdMWYhHYqOHV1a2hFaeTXyQeXr1WqpCcYktlkkqC7d2VWHtEDFqBZl0d_rxmF_qk4MTN82OUDPA1fN9m9uVfLUS613GCzc2oEDtGEo8QHDZDBFcX58hK_HwoNwLdqxZmFAjt6Mvl48bpVvQcsqZrzFUpf1VtPVqQ-3C2fbYlFjyDoKBsszR7v5T__O_sQ8Frbsc3s2UdtyXGKaNKqTfzeG3JWPzxRu9zJzxsNlGVDHoRy0[]
 
 As we said, `cardano-node` already computes and keeps an up-to-date `LedgerState` while syncing.
 As `marconi-sidechain` is connecting to a Cardano node, it should be possible to get the `LedgerState` directly from the node instead of computing it in `marconi-sidechain`.
@@ -100,7 +108,9 @@ The drawbacks:
 
 === Index SDD from the state query client of the node-to-client protocol
 
-The alternative solution takes advantage of the only way currently to get the SDD from a `cardano-node` by using the state query client of the node-to-client protocol.
+The container diagram is the same as the link:#compute-sdd-by-tracking-the-ledgerstate[Compute SDD by tracking the LedgerState] solution.
+
+This alternative solution takes advantage of the only way currently to get the SDD from a `cardano-node` by using the state query client of the node-to-client protocol.
 However, the query will only return the latest SDD given the slot from which the Cardano node is synced to.
 In order to take advantage of this functionality, we would need to change the deployment method of `marconi-sidechain` to something as follows:
 
@@ -125,6 +135,10 @@ The drawbacks:
 `marconi-sidechain` could be changed to become _a_ Cardano node and replace the SPO's relay node.
 Then, it would have the same functionality as a relay (using node-to-node protocol), but also index
 the necessary for the Sidechain team.
+
+A container diagram of this solution would look like:
+
+image::http://www.plantuml.com/plantuml/png/jO_1JW8n48RlVOgw9qY4JOmdJyZgnSYoWNWcfPr0GzjfsccG6D_TLW8BYIPUl4sdt_pppIII29IiOJVQIPCKy2sHZmzr7SH-lD6qJUiK8KXq18x64ctjZN1bPXH96Rskc_jHLrflizVQYaWGSclLe2EX7OIn_vVy9_063xOCVIzWBIeOH8-tl5fsSwxE_zMGVp1szXcilSlCrA3SyIwWIbAx3I_ZrV2Iiw9ewSpEZXLVW1674pdL-Tb3nrI9rYQdfI28V9_FgtAplMkv3qWeqLolY5g1tEQwI9zg_kXznahwnNzl8uKniUI-BEVjQD4rHvaVyT-LcYkbJyQMXqXWLy_lD81GX1eHb7387T0Um-wy1KAV_yUJ9-1KikOB[]
 
 The benefits:
 

--- a/marconi-sidechain/doc/adr/01-sdd-computation.adoc
+++ b/marconi-sidechain/doc/adr/01-sdd-computation.adoc
@@ -1,0 +1,145 @@
+= ADR 1: Stake pool delegation distribution computation
+
+Date: 2023-05-01
+
+== Author(s)
+
+@koslambrou <konstantinos.lambrou@iohk.io>
+
+== Status
+
+Draft
+
+== Context
+
+The Sidechain application needs to know the stake pool delegation distribution (SDD) per epoch.
+Additionnaly, it needs to know the SDD for all epochs from the start of the sidechain in order the select the committee (Sidechain jargon which I'm not familiar with).
+
+Here's list of assumptions:
+
+* `marconi-sidechain` will be run by a Stake Pool Operator (SPO)
+* `marconi-sidechain` will communicate with a relay node (not the block producing node)
+
+The main architectural goal we are trying to achieve is to reduce as much as possible the hardware resource usage of a SPO.
+
+Questions to be answered:
+
+* at what points in time (lower and upper bounds) does Sidechain need to know the SDD per epoch?
+
+== Decision(s)
+
+TBD
+
+== Possible solutions
+
+=== Compute SDD by tracking the `LedgerState`
+
+This is the approach that `cardano-db-sync` currently uses to compute the SDD for each epoch.
+
+Here is a general outline of the steps:
+
+. At the start of `marconi-sidechain`, initialize the `LedgerState` (or `NewEpochState`) given the node genesis file
+. Get block from the chain sync protocol
+. Update the `LedgerState` given the block
+. Compute the SDD from the new LedgerState and store in the database
+. Repeat from step 2
+
+While this approach is the "easiest" to implement, it suffers from major drawbacks such as:
+
+* using 10-16GB of RAM in `marconi-sidechain` on top of the additional 10-16GB used by the local relay node
+* slowing down indexing - computation of the `LedgerState` is _the_ bottleneck in `marconi-sidechain`
+* duplicating the computation of the LedgerState which is already computed by the Cardano node which `marconi-sidechain` is connected to
+
+These drawbacks are significant enough that alternative solutions need to be explored.
+
+=== Add an option to cardano-node for storing LedgerEvents
+
+As we said, `cardano-node` already computes and keeps an up-to-date `LedgerState` while syncing.
+As `marconi-sidechain` is connecting to a Cardano node, it should be possible to get the `LedgerState` directly from the node instead of computing it in `marconi-sidechain`.
+This would result in a significant improvement in memory usage.
+
+However, there is an important issue with this approach.
+Other than the state query client of the node-to-client protocol which only gives you the latest `LedgerState`, there is no support for querying historical `LedgerState` values (i.e. for any block or epoch in the chain).
+
+NOTE: we discuss an alternative solution to the problem using the state query client of the node-to-client protocol in the section below.
+
+Therefore, this solution would require either
+
+* changing `cardano-node` directly to optionally store on disk the `LedgerState` (or more specifically the `LedgerEvent`) for each epoch (or slot, but with the consequence of reducing syncing speed) with a CLI option.
+
+or
+
+* providing a forked node which stores this information (if that change will not be accepted in the `cardano-node` repository)
+
+In either of those case, the SPO would need to replace one of it's relay nodes with a node which
+saves on disk the `LedgerEvent` for each epoch.
+Then, any chain-indexer (like `marconi-sidechain`) will read these `LedgerEvent` and index the required information (the SDD in our scenario).
+
+NOTE: at this stage, it is important to note why we suggest to store `LedgerEvent` and not the full `LedgerState`. A `LedgerEvent` is derived from the `LedgerState` and describes changes to the `LedgerState` after each block is applied. Thus, it is a smaller datastructure when compared to `LedgerState`. See https://github.com/input-output-hk/cardano-ledger/blob/master/docs/LedgerEvents.md for more information.
+
+The benefits:
+
+* no more needing to keep track of the `LedgerState` in `marconi-sidechain` which reduces memory consumption
+* enables any chain-indexers (`cardano-db-sync`, `Kupo`, etc) to read the stored `LedgerEvent` in order to index various information like SDD and rewards without using a large amount of memory
+
+The drawbacks:
+
+* requires a change to `cardano-node` in order to store those LedgerEvents. This implies lots of discussions with the `cardano-node` team to accept such a change.
+* needs the SPO to resync the relay node from scratch in order to save the `LedgerEvent` on disk. However, such a resync will only be required once, even after an upgrade on `marconi-sidechain`.
+* need to maintain a separate fork of the `cardano-node` in the event of the node team not agreeing to merge those changes
+
+=== Index SDD from the state query client of the node-to-client protocol
+
+The alternative solution takes advantage of the only way currently to get the SDD from a `cardano-node` by using the state query client of the node-to-client protocol.
+However, the query will only return the latest SDD given the slot from which the Cardano node is synced to.
+In order to take advantage of this functionnality, we would need to change the deployment method of `marconi-sidechain` to something as follows:
+
+. The SPO needs to stop the relay node and delete the `cardano-node` database
+. Start `marconi-sidechain` which will wait for the node to start
+. Start the relay node
+. Once Marconi has noticed that the node has started syncing, it will start querying the local query state for the SDD for each new epoch and index it in the database.
+
+The benefits:
+
+* no change to `cardano-node` are required
+* uses the existing infrastructure to get the required information
+
+The drawbacks:
+
+* needs the SPO to resync the relay node from scratch
+* any indexing logic or database schema change to Marconi would require reindexing the local node (thus deleting the node database)
+* need to continously poll the relay node when a new epoch occurs
+
+=== Transform `marconi-sidechain` to a Cardano relay node
+
+`marconi-sidechain` could be changed to become _a_ Cardano node and replace the SPO's relay node.
+Then, it would have the same functionnality as a relay (using node-to-node protocol), but also index
+the necessary for the Sidechain team.
+
+The benefits:
+
+* no change to `cardano-node` are required
+* only one computation of `LedgerState` is required
+
+The drawbacks:
+
+* uncertainty of capability to use `cardano-node` as a library
+* this version of `marconi-sidechain` would use the same amount of memory as the relay node. Therefore, it would not be able to be deployed on a AWS small instance as initially requested by the Sidechain team
+
+=== Use Mithril SDD snapshots
+
+A approach that has been proposed would be to use the SDD snapshots provided by Mithril.
+Then, `marconi-sidechain` would simply fetch those snapshots and index them in its database.
+
+However, it is unclear at what points in time the snapshots will available.
+We expect the Sidechain team to need SDD for epochs close to the tip of the Cardano chain.
+Therefore, our intuition is that Mithril could be used to _bootstrap_ `marconi-sidechain` for faster syncing, but we would still need to implement one of the previous solutions to index the SDD that occur on epochs after the latest Mithril snapshot.
+
+== Implications
+
+== Notes
+
+=== 2023/05/03
+
+Discussing with @abailly-iohk, seems like the "ideal" solution would be to transform `marconi-sidechain` to a Cardano node using the node-to-node protocol and replace the SPO's relay node.
+However, we need product input from the Sidechain team given the changes that an SPO would have to do.

--- a/marconi-sidechain/doc/adr/01-sdd-computation.adoc
+++ b/marconi-sidechain/doc/adr/01-sdd-computation.adoc
@@ -13,9 +13,9 @@ Draft
 == Context
 
 The Sidechain application needs to know the stake pool delegation distribution (SDD) per epoch.
-Additionnaly, it needs to know the SDD for all epochs from the start of the sidechain in order the select the committee (Sidechain jargon which I'm not familiar with).
+Additionnally, it needs to know the SDD for all epochs from the start of the sidechain in order to select the committee (Sidechain jargon which I'm not familiar with).
 
-Here's list of assumptions:
+Here's the list of assumptions:
 
 * `marconi-sidechain` will be run by a Stake Pool Operator (SPO)
 * `marconi-sidechain` will communicate with a relay node (not the block producing node)
@@ -47,7 +47,8 @@ Here is a general outline of the steps:
 While this approach is the "easiest" to implement, it suffers from major drawbacks such as:
 
 * using 10-16GB of RAM in `marconi-sidechain` on top of the additional 10-16GB used by the local relay node
-* slowing down indexing - computation of the `LedgerState` is _the_ bottleneck in `marconi-sidechain`
+* slowing down indexing.
+  Computation of the `LedgerState` is _the_ bottleneck in `marconi-sidechain`
 * duplicating the computation of the LedgerState which is already computed by the Cardano node which `marconi-sidechain` is connected to
 
 These drawbacks are significant enough that alternative solutions need to be explored.
@@ -61,7 +62,10 @@ This would result in a significant improvement in memory usage.
 However, there is an important issue with this approach.
 Other than the state query client of the node-to-client protocol which only gives you the latest `LedgerState`, there is no support for querying historical `LedgerState` values (i.e. for any block or epoch in the chain).
 
-NOTE: we discuss an alternative solution to the problem using the state query client of the node-to-client protocol in the section below.
+[NOTE]
+====
+We discuss an alternative solution to the problem using the state query client of the node-to-client protocol in the section below.
+====
 
 Therefore, this solution would require either
 
@@ -71,11 +75,17 @@ or
 
 * providing a forked node which stores this information (if that change will not be accepted in the `cardano-node` repository)
 
-In either of those case, the SPO would need to replace one of it's relay nodes with a node which
+In either of those case, the SPO would need to replace one of its relay nodes with a node which
 saves on disk the `LedgerEvent` for each epoch.
 Then, any chain-indexer (like `marconi-sidechain`) will read these `LedgerEvent` and index the required information (the SDD in our scenario).
 
-NOTE: at this stage, it is important to note why we suggest to store `LedgerEvent` and not the full `LedgerState`. A `LedgerEvent` is derived from the `LedgerState` and describes changes to the `LedgerState` after each block is applied. Thus, it is a smaller datastructure when compared to `LedgerState`. See https://github.com/input-output-hk/cardano-ledger/blob/master/docs/LedgerEvents.md for more information.
+[NOTE]
+====
+At this stage, it is important to note why we suggest to store `LedgerEvent` and not the full `LedgerState`.
+A `LedgerEvent` is derived from the `LedgerState` and describes changes to the `LedgerState` after each block is applied.
+Thus, it is a smaller data structure when compared to `LedgerState`.
+See https://github.com/input-output-hk/cardano-ledger/blob/master/docs/LedgerEvents.md for more information.
+====
 
 The benefits:
 
@@ -92,7 +102,7 @@ The drawbacks:
 
 The alternative solution takes advantage of the only way currently to get the SDD from a `cardano-node` by using the state query client of the node-to-client protocol.
 However, the query will only return the latest SDD given the slot from which the Cardano node is synced to.
-In order to take advantage of this functionnality, we would need to change the deployment method of `marconi-sidechain` to something as follows:
+In order to take advantage of this functionality, we would need to change the deployment method of `marconi-sidechain` to something as follows:
 
 . The SPO needs to stop the relay node and delete the `cardano-node` database
 . Start `marconi-sidechain` which will wait for the node to start
@@ -108,12 +118,12 @@ The drawbacks:
 
 * needs the SPO to resync the relay node from scratch
 * any indexing logic or database schema change to Marconi would require reindexing the local node (thus deleting the node database)
-* need to continously poll the relay node when a new epoch occurs
+* need to continuously poll the relay node when a new epoch occurs
 
 === Transform `marconi-sidechain` to a Cardano relay node
 
 `marconi-sidechain` could be changed to become _a_ Cardano node and replace the SPO's relay node.
-Then, it would have the same functionnality as a relay (using node-to-node protocol), but also index
+Then, it would have the same functionality as a relay (using node-to-node protocol), but also index
 the necessary for the Sidechain team.
 
 The benefits:
@@ -124,11 +134,12 @@ The benefits:
 The drawbacks:
 
 * uncertainty of capability to use `cardano-node` as a library
-* this version of `marconi-sidechain` would use the same amount of memory as the relay node. Therefore, it would not be able to be deployed on a AWS small instance as initially requested by the Sidechain team
+* this version of `marconi-sidechain` would use the same amount of memory as the relay node.
+  Therefore, it would not be able to be deployed on an AWS small instance as initially requested by the Sidechain team
 
 === Use Mithril SDD snapshots
 
-A approach that has been proposed would be to use the SDD snapshots provided by Mithril.
+An approach that has been proposed would be to use the SDD snapshots provided by Mithril.
 Then, `marconi-sidechain` would simply fetch those snapshots and index them in its database.
 
 However, it is unclear at what points in time the snapshots will available.
@@ -142,4 +153,4 @@ Therefore, our intuition is that Mithril could be used to _bootstrap_ `marconi-s
 === 2023/05/03
 
 Discussing with @abailly-iohk, seems like the "ideal" solution would be to transform `marconi-sidechain` to a Cardano node using the node-to-node protocol and replace the SPO's relay node.
-However, we need product input from the Sidechain team given the changes that an SPO would have to do.
+However, we require product input from the Sidechain team given the changes that an SPO would have to do.

--- a/marconi-sidechain/doc/adr/01-sdd-computation.adoc
+++ b/marconi-sidechain/doc/adr/01-sdd-computation.adoc
@@ -27,8 +27,11 @@ Therefore, indexing the SDD per epoch should be as resource efficient as possibl
 
 TBD
 
-Thus far, we believe the best options are solution 2, 4 and 5.
+Thus far, we (Plutus Tools team) believe that the viable options are solutions 2, 4 and 5.
 However, each of them come with drawbacks that need to be discussed with the Sidechain team before going forward.
+
+The Plutus Tools team would like to recommend solution 4, but we would need to see if the impacts to the client of the Sidechain application are reasonable.
+A discussion with the Sidechain tribe is the next logical step.
 
 == Rationale
 
@@ -44,7 +47,7 @@ This assessment is measured in regard to two components: Cardano Node and Marcon
 .Comparison of solutions using a list of characteristics
 [cols="1,1,1,1,1,1"]
 |===
-|Characteristics | Marconi LedgerState computation | Read LedgerEvents from node | SDD using N2C | Marconi as a node | Reimplementation of the SDD ledger logic
+|Characteristics | 1-Marconi LedgerState computation | 2-Read LedgerEvents from node | 3-SDD using N2C | 4-Marconi as a node | 5-Reimplementation of the SDD ledger logic
 
 |Number of LedgerState computations | 2 | 1 | 1 | 1 | 1
 |Initial node resync required | No | Yes | Yes | Yes | No

--- a/marconi-sidechain/doc/adr/01-sdd-computation.adoc
+++ b/marconi-sidechain/doc/adr/01-sdd-computation.adoc
@@ -34,9 +34,12 @@ We will describe all the potential and discussed solutions to index the SDD of e
 As a summary, we provide the following caracteristics table and indicate how each solution responds to them.
 This assessment is measured in regards to two components: Cardano Node and Marconi.
 
+
+
+.Comparison of solutions using a list of caracteristics
 [cols="1,1,1,1,1"]
 |===
-|Caracteristics | Solution 1 | Solution 2 | Solution 3 | Solution 4
+|Caracteristics | Marconi LedgerState computation | Read LedgerEvents from node | SDD using N2C | Marconi as a node
 
 |Number of LedgerState computations | 2 | 1 | 1 | 1
 |Initial node resync required | No | Yes | Yes | Yes
@@ -44,6 +47,7 @@ This assessment is measured in regards to two components: Cardano Node and Marco
 |Change to cardano-node | No | Yes | No | No
 |===
 
+.Description of the caracteristics
 [cols="1,1"]
 |===
 |Caracteristics | Description
@@ -148,6 +152,9 @@ In order to take advantage of this functionality, we would need to change the de
 . Start the relay node
 . Once Marconi has noticed that the node has started syncing, it will start querying the local query state for the SDD for each new epoch and index it in the database.
 
+Is is important to note that any changes in the indexers of `marconi-sidechain` would require a complete resync of `marconi-sidechain`.
+As a direct consequence of this solution, the user would be required to delete the node database in order to reindex everything.
+
 The container diagram is the same as the link:#compute-sdd-by-tracking-the-ledgerstate[Compute SDD by tracking the LedgerState] solution.
 
 The benefits:
@@ -158,14 +165,20 @@ The benefits:
 The drawbacks:
 
 * needs the SPO to resync the relay node from scratch
-* any indexing logic or database schema change to Marconi would require reindexing the local node (thus deleting the node database)
-* need to continuously poll the relay node when a new epoch occurs
+* any change in the indexing logic of `marconi-sidechain` would require resyncing from scratch the local node (thus deleting the node database)
+* overhead of needing to continuously poll the relay node to identify when a new epoch occurs
+* race condition between node and `marconi-sidechain`. If a node syncs too fast and `marconi-sidechain` is stalled because of some heavy processing, we might miss an epoch (unlikely, but possible).
 
 === 4. Transform `marconi-sidechain` to a Cardano relay node
 
 `marconi-sidechain` could be changed to become _a_ Cardano node and replace the SPO's relay node.
 Then, it would have the same functionality as a relay (using node-to-node protocol), but also index
 the necessary for the Sidechain team.
+
+Ultimately, the `marconi-sidechain` process would run two computations in parallel: the N2N protocol
+and the indexers.
+Then, we would need to find a way to get the `LedgerState` that's computed by the node's consensus
+layer and wire it to the indexers.
 
 A container diagram of this solution would look like:
 
@@ -179,10 +192,8 @@ The benefits:
 The drawbacks:
 
 * uncertainty of capability to use `cardano-node` as a library
-* this version of `marconi-sidechain` would use the same amount of memory as the relay node.
-  Therefore, it would not be able to be deployed on an AWS small instance as initially requested by the Sidechain team
+* any change in the indexing logic of `marconi-sidechain` would require resyncing from scratch the local node (thus deleting the node database)
 * needs the SPO to resync the relay node from scratch
-* any indexing logic or database schema change to Marconi would require reindexing the Marconi node (thus deleting the node database)
 
 === 5. Use Mithril SDD snapshots
 

--- a/marconi-sidechain/doc/adr/01-sdd-computation.adoc
+++ b/marconi-sidechain/doc/adr/01-sdd-computation.adoc
@@ -12,8 +12,8 @@ Draft
 
 == Context
 
-The Sidechain application needs to know the stake pool delegation distribution (SDD) per epoch.
-Additionnally, it needs to know the SDD for all epochs from the start of the sidechain in order to select the committee (Sidechain jargon which I'm not familiar with).
+The Sidechain application needs to know the Cardano blockchain active stake pool delegation distribution (SDD) for epoch `n`.
+It will use that information to register the committee that will be used to validate sidechain blocks in epoch `n+1`.
 
 Here's the list of assumptions:
 
@@ -21,10 +21,7 @@ Here's the list of assumptions:
 * `marconi-sidechain` will communicate with a relay node (not the block producing node)
 
 The main architectural goal we are trying to achieve is to reduce as much as possible the hardware resource usage of a SPO.
-
-Questions to be answered:
-
-* at what points in time (lower and upper bounds) does Sidechain need to know the SDD per epoch?
+Therefore, indexing the SDD per epoch should be as resource efficient as possible.
 
 == Decision(s)
 
@@ -32,15 +29,50 @@ TBD
 
 == Possible solutions
 
-=== Compute SDD by tracking the `LedgerState`
+We will describe all the potential and discussed solutions to index the SDD of each epoch in the following sections.
+
+As a summary, we provide the following caracteristics table and indicate how each solution responds to them.
+This assessment is measured in regards to two components: Cardano Node and Marconi.
+
+[cols="1,1,1,1,1"]
+|===
+|Caracteristics | Solution 1 | Solution 2 | Solution 3 | Solution 4
+
+|Number of LedgerState computations | 2 | 1 | 1 | 1
+|Initial node resync required | No | Yes | Yes | Yes
+|Required node resync after Marconi logic change | No | No | Yes | Yes
+|Change to cardano-node | No | Yes | No | No
+|===
+
+[cols="1,1"]
+|===
+|Caracteristics | Description
+
+|Number of LedgerState computations
+|As it suggest, corresponds to total number of independent computations of the LedgerState.
+
+|Initial node resync
+|Yes if a resync of the relay node is required. No otherwise.
+
+|Node resync after schema change
+|Yes if a resync of the relay node is required after any changes to the indexing logic of Marconi.
+
+|Change to cardano-node
+|Yes if the solution requires a change to the cardano-node codebase.
+
+|===
+
+For more details, read the sections below.
+
+=== 1. Compute SDD by computing the `LedgerState`
+
+This is the approach that `cardano-db-sync` currently uses to compute the SDD for each epoch.
 
 A container diagram of this solution would look like:
 
 image::http://www.plantuml.com/plantuml/png/jL0_Q-Cm5D_zANIU4ZZ7SDnqKovkbz8w9g5pKAJNM4H_XFJKr9H-zqfAunfAe4ityNx_jVH87GObYrz2Cnaua1xH-dzrxUXfSH3OXttmu9ZH21eNpAZQIggJflB8fTZNpT-gIwV7X_jQKO_WucdNH0KL6jp2_eZ_3LXf1fL4EQ1e3OUPj-OtARVTcl0HB-VajIZ6FZEd8sK3aWuaQShv1DlR1AwaOKVIESC34_fmeQr4L6NvcHRBgg05emYUdEAMCXxRFosnpg1XHaRDn5lHD5D4piUhye83woCQYSbwPEIAJu2iZywPKVb1CmBFeD6VOvehCQDf-eZBc_otzXmonJyRCIfbzhtRhjjgqpNZt0dTNHdzjKtnLXJRmIEetUqBpY0h6-eurOPem9Dnnp4Xe-wx7xe4pOEIxm00[]
 
-This is the approach that `cardano-db-sync` currently uses to compute the SDD for each epoch.
-
-Here is a general outline of the steps:
+Here is a general outline of the computation of the `LedgerState`:
 
 . At the start of `marconi-sidechain`, initialize the `LedgerState` (or `NewEpochState`) given the node genesis file
 . Get block from the chain sync protocol
@@ -50,25 +82,21 @@ Here is a general outline of the steps:
 
 While this approach is the "easiest" to implement, it suffers from major drawbacks such as:
 
-* using 10-16GB of RAM in `marconi-sidechain` on top of the additional 10-16GB used by the local relay node
+* adding an additional 10-16GB of RAM in `marconi-sidechain` just from computing the `LedgerState`
 * slowing down indexing.
   Computation of the `LedgerState` is _the_ bottleneck in `marconi-sidechain`
 * duplicating the computation of the LedgerState which is already computed by the Cardano node which `marconi-sidechain` is connected to
 
 These drawbacks are significant enough that alternative solutions need to be explored.
 
-=== Add an option to cardano-node for storing LedgerEvents
-
-A container diagram of this solution would look like:
-
-image::http://www.plantuml.com/plantuml/png/jL7DRfmm4Bxp52ud8fL5gdhgAGsRIvKIb5NFaR67nOf_B7ieHLNVlRPtbmLfLVMI0vAPxsU-cRdtI1sEIcOVX6Pov406HEk_L9MZq-ueS1YxqODZHYDet36ZAYkfZfhI8vUYg-hFPHjBFxu_LOfw11TAhtLGKA71xUox-E_1IZEhA4eDiiPmABmr7qb-Q9y9N_3yZlpEiYLFuNIWl82aCucQ_6w5TJQ23zAmDz8wmqSczF52Un11bUGdMWYhHYqOHV1a2hFaeTXyQeXr1WqpCcYktlkkqC7d2VWHtEDFqBZl0d_rxmF_qk4MTN82OUDPA1fN9m9uVfLUS613GCzc2oEDtGEo8QHDZDBFcX58hK_HwoNwLdqxZmFAjt6Mvl48bpVvQcsqZrzFUpf1VtPVqQ-3C2fbYlFjyDoKBsszR7v5T__O_sQ8Frbsc3s2UdtyXGKaNKqTfzeG3JWPzxRu9zJzxsNlGVDHoRy0[]
+=== 2. Add an option to cardano-node for storing LedgerEvents
 
 As we said, `cardano-node` already computes and keeps an up-to-date `LedgerState` while syncing.
 As `marconi-sidechain` is connecting to a Cardano node, it should be possible to get the `LedgerState` directly from the node instead of computing it in `marconi-sidechain`.
 This would result in a significant improvement in memory usage.
 
 However, there is an important issue with this approach.
-Other than the state query client of the node-to-client protocol which only gives you the latest `LedgerState`, there is no support for querying historical `LedgerState` values (i.e. for any block or epoch in the chain).
+Other than the state query client of the node-to-client protocol, which only gives you the latest `LedgerState`, there is no support for querying historical `LedgerState` values (i.e. for any block or epoch in the chain).
 
 [NOTE]
 ====
@@ -77,14 +105,13 @@ We discuss an alternative solution to the problem using the state query client o
 
 Therefore, this solution would require either
 
-* changing `cardano-node` directly to optionally store on disk the `LedgerState` (or more specifically the `LedgerEvent`) for each epoch (or slot, but with the consequence of reducing syncing speed) with a CLI option.
+* adding a CLI option for the `cardano-node` executable to optionally store on disk the `LedgerState` (or more specifically the `LedgerEvent`) for each epoch (or slot, but with the consequence of reducing syncing speed)
 
 or
 
 * providing a forked node which stores this information (if that change will not be accepted in the `cardano-node` repository)
 
-In either of those case, the SPO would need to replace one of its relay nodes with a node which
-saves on disk the `LedgerEvent` for each epoch.
+In either of those case, the SPO would need to replace one of its relay nodes with a node which saves on disk the `LedgerEvent` for each epoch.
 Then, any chain-indexer (like `marconi-sidechain`) will read these `LedgerEvent` and index the required information (the SDD in our scenario).
 
 [NOTE]
@@ -95,9 +122,13 @@ Thus, it is a smaller data structure when compared to `LedgerState`.
 See https://github.com/input-output-hk/cardano-ledger/blob/master/docs/LedgerEvents.md for more information.
 ====
 
+A container diagram of this solution would look like:
+
+image::http://www.plantuml.com/plantuml/png/jL7DRfmm4Bxp52ud8fL5gdhgAGsRIvKIb5NFaR67nOf_B7ieHLNVlRPtbmLfLVMI0vAPxsU-cRdtI1sEIcOVX6Pov406HEk_L9MZq-ueS1YxqODZHYDet36ZAYkfZfhI8vUYg-hFPHjBFxu_LOfw11TAhtLGKA71xUox-E_1IZEhA4eDiiPmABmr7qb-Q9y9N_3yZlpEiYLFuNIWl82aCucQ_6w5TJQ23zAmDz8wmqSczF52Un11bUGdMWYhHYqOHV1a2hFaeTXyQeXr1WqpCcYktlkkqC7d2VWHtEDFqBZl0d_rxmF_qk4MTN82OUDPA1fN9m9uVfLUS613GCzc2oEDtGEo8QHDZDBFcX58hK_HwoNwLdqxZmFAjt6Mvl48bpVvQcsqZrzFUpf1VtPVqQ-3C2fbYlFjyDoKBsszR7v5T__O_sQ8Frbsc3s2UdtyXGKaNKqTfzeG3JWPzxRu9zJzxsNlGVDHoRy0[]
+
 The benefits:
 
-* no more needing to keep track of the `LedgerState` in `marconi-sidechain` which reduces memory consumption
+* removal of the additional 10-16GB of memory needed to compute the `LedgerState` in `marconi-sidechain`
 * enables any chain-indexers (`cardano-db-sync`, `Kupo`, etc) to read the stored `LedgerEvent` in order to index various information like SDD and rewards without using a large amount of memory
 
 The drawbacks:
@@ -106,9 +137,7 @@ The drawbacks:
 * needs the SPO to resync the relay node from scratch in order to save the `LedgerEvent` on disk. However, such a resync will only be required once, even after an upgrade on `marconi-sidechain`.
 * need to maintain a separate fork of the `cardano-node` in the event of the node team not agreeing to merge those changes
 
-=== Index SDD from the state query client of the node-to-client protocol
-
-The container diagram is the same as the link:#compute-sdd-by-tracking-the-ledgerstate[Compute SDD by tracking the LedgerState] solution.
+=== 3. Index SDD from the state query client of the node-to-client protocol
 
 This alternative solution takes advantage of the only way currently to get the SDD from a `cardano-node` by using the state query client of the node-to-client protocol.
 However, the query will only return the latest SDD given the slot from which the Cardano node is synced to.
@@ -118,6 +147,8 @@ In order to take advantage of this functionality, we would need to change the de
 . Start `marconi-sidechain` which will wait for the node to start
 . Start the relay node
 . Once Marconi has noticed that the node has started syncing, it will start querying the local query state for the SDD for each new epoch and index it in the database.
+
+The container diagram is the same as the link:#compute-sdd-by-tracking-the-ledgerstate[Compute SDD by tracking the LedgerState] solution.
 
 The benefits:
 
@@ -130,7 +161,7 @@ The drawbacks:
 * any indexing logic or database schema change to Marconi would require reindexing the local node (thus deleting the node database)
 * need to continuously poll the relay node when a new epoch occurs
 
-=== Transform `marconi-sidechain` to a Cardano relay node
+=== 4. Transform `marconi-sidechain` to a Cardano relay node
 
 `marconi-sidechain` could be changed to become _a_ Cardano node and replace the SPO's relay node.
 Then, it would have the same functionality as a relay (using node-to-node protocol), but also index
@@ -150,8 +181,10 @@ The drawbacks:
 * uncertainty of capability to use `cardano-node` as a library
 * this version of `marconi-sidechain` would use the same amount of memory as the relay node.
   Therefore, it would not be able to be deployed on an AWS small instance as initially requested by the Sidechain team
+* needs the SPO to resync the relay node from scratch
+* any indexing logic or database schema change to Marconi would require reindexing the Marconi node (thus deleting the node database)
 
-=== Use Mithril SDD snapshots
+=== 5. Use Mithril SDD snapshots
 
 An approach that has been proposed would be to use the SDD snapshots provided by Mithril.
 Then, `marconi-sidechain` would simply fetch those snapshots and index them in its database.

--- a/marconi-sidechain/doc/adr/01-sdd-computation.adoc
+++ b/marconi-sidechain/doc/adr/01-sdd-computation.adoc
@@ -1,6 +1,6 @@
 = ADR 1: Stake pool delegation distribution computation
 
-Date: 2023-05-01
+Date: 2023-05-16
 
 == Author(s)
 
@@ -27,6 +27,13 @@ Therefore, indexing the SDD per epoch should be as resource efficient as possibl
 
 TBD
 
+Thus far, we believe the best options are solution 2, 4 and 5.
+However, each of them come with drawbacks that need to be discussed with the Sidechain team before going forward.
+
+== Rationale
+
+TBD
+
 == Possible solutions
 
 We will describe all the potential and discussed solutions to index the SDD of each epoch in the following sections.
@@ -35,14 +42,15 @@ As a summary, we provide the following characteristics table and indicate how ea
 This assessment is measured in regard to two components: Cardano Node and Marconi.
 
 .Comparison of solutions using a list of characteristics
-[cols="1,1,1,1,1"]
+[cols="1,1,1,1,1,1"]
 |===
-|Characteristics | Marconi LedgerState computation | Read LedgerEvents from node | SDD using N2C | Marconi as a node
+|Characteristics | Marconi LedgerState computation | Read LedgerEvents from node | SDD using N2C | Marconi as a node | Reimplementation of the SDD ledger logic
 
-|Number of LedgerState computations | 2 | 1 | 1 | 1
-|Initial node resync required | No | Yes | Yes | Yes
-|Required node resync after Marconi logic change | No | No | Yes | No
-|Change to cardano-node | No | Yes | No | No
+|Number of LedgerState computations | 2 | 1 | 1 | 1 | 1
+|Initial node resync required | No | Yes | Yes | Yes | No
+|Required node resync after Marconi logic change | No | No | Yes | No | No
+|Change to cardano-node | No | Yes | No | No | No
+|Maintenance burden | Low | Medium | Low | Low | High
 |===
 
 .Description of the characteristics
@@ -61,6 +69,9 @@ This assessment is measured in regard to two components: Cardano Node and Marcon
 
 |Change to cardano-node
 |Yes if the solution requires a change to the cardano-node codebase.
+
+|Maintenance burden
+|The amout of required effort of a solution relative to the other solutions
 
 |===
 
@@ -135,9 +146,8 @@ To summarize, the benefits are:
 
 and the drawbacks are:
 
-* requires a change to `cardano-node` in order to store those LedgerEvents. This implies lots of discussions with the `cardano-node` team to accept such a change.
+* need to maintain a separate fork of the `cardano-node` to store those `LedgerEvent` (with the future possibility of upstreaming the changes)
 * needs the SPO to resync the relay node from scratch in order to save the `LedgerEvent` on disk. However, such a resync will only be required once, even after an upgrade on `marconi-sidechain`.
-* need to maintain a separate fork of the `cardano-node` in the event of the node team not agreeing to merge those changes
 
 === 3. Index SDD from the state query client of the node-to-client protocol
 
@@ -193,7 +203,37 @@ and the drawbacks:
 * need to checkpoint (save on disk) the `LedgerState` at regular interval
 * needs the SPO to resync the relay node from scratch
 
-=== 5. Use Mithril SDD snapshots
+=== 5. Reimplementation of the SDD ledger logic
+
+The above solutions all rely on the fact that we can compute the SDD using the `LedgerState` logic that `cardano-ledger` provides us.
+However, an alternative solution would be to reimplement the SDD logic ourselves.
+
+We already implemented the Address-Utxo indexer using a similar idea.
+Instead of using the `LedgerState` to provide us the set of UTXOs after applying a given block, we reimplemented the cardano-ledger logic to maintain the UTXO state.
+The main reasons we did that was to reduce memory usage, and that the re-implementation of the UTXO ledger rule is not overly complicated (although it does add a maintenance burden).
+
+Similary to the UTXO rule, to compute the SDD, we can use the blocks we receive from the chain-sync client from the N2C protocol.
+Those blocks contain transactions which include certificates, such as:
+
+* stake address registration and deregistration certificates
+* stake address delegation to stake pool certificate
+* take pool registration and deregistration certificates
+
+Using those certificates, alongside the Address-Utxo indexer, we can compute the SDD for each stake pool in an epoch.
+
+To summarize, the benefits are:
+
+* no change to `cardano-node` are required
+* remove the need to use the `LedgerState`
+* no change to the client infrastructure: `marconi-sidechain` would be a client application which communicates with the local node using the N2C protocol.
+
+and the drawbacks:
+
+* burden of maintaining the SDD ledger rule following changes to cardano-ledger
+* error-prone implementation
+* not future-proof: if new requirements need other parts of the `LedgerState`, then we would need to reimplement the ledger rules for those
+
+=== 6. Use Mithril SDD snapshots
 
 An approach that has been proposed would be to use the SDD snapshots provided by Mithril.
 Then, `marconi-sidechain` would simply fetch those snapshots and index them in its database.


### PR DESCRIPTION
Added an ADR describing the possible solutions for computing the SDD per epoch in `marconi-sidechain`.

The current implemented approach suffers from a large memory consumption because of the `LedgerState` computation which is used to extract the SDD.

We introduce different alternative solutions to the issue. All come with drawbacks. 

Hopefully, this will inform our decision on how to move forward.

Here is the rendered link of the document: https://github.com/input-output-hk/marconi/blob/PLT-5592-document-architectural-solutions-for-alternative-sdd-computation-for-marconi/marconi-sidechain/doc/adr/01-sdd-computation.adoc
