### PR TITLE
Fixed error when reading Conway genesis config for the EpochState indexer

### DIFF
--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -376,6 +376,7 @@ test-suite marconi-chain-index-test-compare-cardano-db-sync
     , iohk-monitoring
     , ouroboros-consensus
     , ouroboros-consensus-cardano
+    , ouroboros-consensus-diffusion
     , ouroboros-network
     , plutus-core
     , plutus-ledger-api


### PR DESCRIPTION
* Fixed readNetworkConfig to use the absolute path for the Conway genesis file.
* Fixed readConwayGenesis to render the NEConwayConfig error message instead of NEAlonzoConfig error message
* Re-grouped function in the `Marconi.ChainIndex.Node.Client.GenesisConfig` into something more cohesive.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
