### PR TITLE
Add lower bound slot to utxoByAddress query

### DIFF
--- a/marconi-chain-index/bench/BenchQueries.hs
+++ b/marconi-chain-index/bench/BenchQueries.hs
@@ -46,8 +46,8 @@ import Database.SQLite.Simple.ToField (ToField)
 import Database.SQLite.Simple.ToRow (ToRow)
 import GHC.Generics (Generic)
 import Marconi.ChainIndex.Indexers (runIndexers, utxoWorker)
-import Marconi.ChainIndex.Indexers.Utxo (StorableQuery (UtxoByAddress), StorableResult (UtxoResult, getUtxoResult),
-                                         UtxoHandle, UtxoIndexer)
+import Marconi.ChainIndex.Indexers.Utxo (QueryUtxoByAddress (QueryUtxoByAddress), StorableQuery (QueryWrapper),
+                                         StorableResult (UtxoResult, getUtxoResult), UtxoHandle, UtxoIndexer)
 import Marconi.Core.Storable (QueryInterval (QEverything))
 import Marconi.Core.Storable qualified as Storable
 import System.Environment (getEnv)
@@ -137,7 +137,7 @@ tests databaseDir indexerTVar = do
             Storable.query @UtxoHandle
                 QEverything
                 utxoIndexer
-                (UtxoByAddress addressWithMostUtxos Nothing)
+                (QueryWrapper $ QueryUtxoByAddress addressWithMostUtxos Nothing)
 
     let countRows = \case
             UtxoResult rows -> length rows

--- a/marconi-chain-index/bench/BenchQueries.hs
+++ b/marconi-chain-index/bench/BenchQueries.hs
@@ -48,6 +48,7 @@ import GHC.Generics (Generic)
 import Marconi.ChainIndex.Indexers (runIndexers, utxoWorker)
 import Marconi.ChainIndex.Indexers.Utxo (QueryUtxoByAddress (QueryUtxoByAddress), StorableQuery (QueryWrapper),
                                          StorableResult (UtxoResult, getUtxoResult), UtxoHandle, UtxoIndexer)
+import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.Core.Storable (QueryInterval (QEverything))
 import Marconi.Core.Storable qualified as Storable
 import System.Environment (getEnv)
@@ -137,7 +138,7 @@ tests databaseDir indexerTVar = do
             Storable.query @UtxoHandle
                 QEverything
                 utxoIndexer
-                (QueryWrapper $ QueryUtxoByAddress addressWithMostUtxos Nothing)
+                (QueryWrapper $ QueryUtxoByAddress addressWithMostUtxos Utxo.intervalAtGenesis)
 
     let countRows = \case
             UtxoResult rows -> length rows

--- a/marconi-sidechain/examples/json-rpc-client/src/Main.hs
+++ b/marconi-sidechain/examples/json-rpc-client/src/Main.hs
@@ -33,7 +33,7 @@ main = do
   -- RPC calls
   msg <- rpcEcho "marconi client calling ???" --  return the echo message
   addresses <- rpcTargets ""                  --  get the targetAddresss
-  utxos <- rpcUtxos $ TxOutAtQuery bech32Address Nothing             --  get utxos for this address
+  utxos <- rpcUtxos $ TxOutAtQuery bech32Address 0 Nothing            --  get utxos for this address
   printResults msg
   printResults addresses
   printResults utxos

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -49,7 +49,7 @@ findByAddress
     -> C.AddressAny -- ^ Cardano address to query
     -> Maybe C.SlotNo -- ^ The upper slot number we want to query
     -> IO (Either QueryExceptions [Utxo.UtxoRow])
-findByAddress env addr slot = withQueryAction env (Utxo.UtxoByAddress addr slot)
+findByAddress env addr slot = withQueryAction env (Utxo.QueryWrapper $ Utxo.QueryUtxoByAddress addr slot)
 
 -- | Retrieve the current synced point of the utxo indexer
 currentSyncedPoint

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -132,20 +132,27 @@ newtype EpochNonceResult =
     EpochNonceResult (Maybe EpochState.EpochNonceRow)
     deriving (Eq, Ord, Show, Generic, ToJSON, FromJSON)
 
+-- |
 data TxOutAtQuery
     = TxOutAtQuery
-    { queryAddress :: !String
-    , querySlot    :: !(Maybe Word64)
+    { queryAddress             :: !String -- ^ address to query for
+    , queryCreatedAfterSlotNo  :: !Word64 -- ^ lower bound slotNo to query for
+    , queryUnspentBeforeSlotNo :: !(Maybe Word64) -- ^ optional upper bound slotNo to query for
     } deriving Show
 
 instance FromJSON TxOutAtQuery where
 
-    parseJSON (Object v) = TxOutAtQuery <$> (v .: "address")  <*> (v .:? "slotNo")
-    parseJSON _          = mempty
+    parseJSON (Object v)
+      = TxOutAtQuery
+      <$> (v .: "address")
+      <*> (v .: "createdAfterSlotNot")
+      <*> (v .:? "unspentBeforeSlotNo")
+    parseJSON _ = mempty
 
 instance ToJSON TxOutAtQuery where
     toJSON q =
         object $ catMaybes
            [ Just ("address" .= queryAddress q)
-           , ("slotNo" .=) <$> querySlot q
+           , Just ("createdAfterSlotNot" .= queryCreatedAfterSlotNo q)
+           , ("unspentBeforeSlotNo" .=) <$> queryUnspentBeforeSlotNo q
            ]

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -131,8 +131,8 @@ queryTargetAddressTest = property $ do
     . traverse (\addr ->
         AddressUtxoIndexer.findByAddress
             (env ^. sidechainEnvIndexers . sidechainAddressUtxoIndexer)
-            addr
-            Nothing)
+            (Utxo.QueryUtxoByAddress addr Utxo.intervalAtGenesis)
+            )
     . Set.toList . Set.fromList  -- required to remove the potential duplicate addresses
     . fmap Utxo._address
     . concatMap (Set.toList . Utxo.ueUtxos)
@@ -158,7 +158,7 @@ queryUtxoFromRpcServer address port = do
   -- test will fail if these RPC methods fail.
   void $ rpcEcho "client calling "
   void $ rpcTargets ""
-  rpcUtxos $ TxOutAtQuery address Nothing
+  rpcUtxos $ TxOutAtQuery address 0 Nothing
 
 -- | Create http JSON-RPC client function to test RPC route and handlers
 queryCurrentSyncPointFromRpcServer


### PR DESCRIPTION
Commit-1

1.  Added  QueryWrapper to the Storable Query.
2. Create Slot-Interval 
3. fix all tests

Commit-2

1. Added Slot-Interval to QueryWrapper
2. fix all APIs and test for the new QueryWrapper structure

Commit-3

1. modified existing marconi-chain-index tests to test slotNo interval

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
