### PR TITLE
Add block index to utxo indexer

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
@@ -68,7 +68,7 @@ instance SQL.FromField (C.Hash C.BlockHeader) where
            Left _  -> SQL.returnError SQL.ConversionFailed f "Cannot deserialise C.Hash C.BlockHeader"
            Right x -> pure x
 
--- * Sometime we need to get a count or test if a value exist.{-# LANGUAGE extension #-}
+-- * Sometime we need to get a count or test if a value exist.
 
 instance ToRow Integer where
   toRow = SQL.toRow

--- a/marconi-chain-index/src/Marconi/ChainIndex/Types.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Types.hs
@@ -24,12 +24,16 @@ module Marconi.ChainIndex.Types
        epochStateDbName,
        mintBurnDbName,
        SecurityParam(SecurityParam),
-       IndexingDepth(MinIndexingDepth, MaxIndexingDepth)
+       IndexingDepth(MinIndexingDepth, MaxIndexingDepth),
+       TxIndexInBlock
        ) where
 
 import Cardano.Api qualified as C
+import Data.Aeson qualified as Aeson
 import Data.List.NonEmpty (NonEmpty)
 import Data.Word (Word64)
+import Database.SQLite.Simple.FromField qualified as SQL
+import Database.SQLite.Simple.ToField qualified as SQL
 
 -- | Typre represents non empty list of Bech32 Shelley compatable addresses
 type TargetAddresses = NonEmpty (C.Address C.ShelleyAddr)
@@ -59,6 +63,9 @@ data IndexingDepth = MinIndexingDepth !Word64 | MaxIndexingDepth
 
 newtype SecurityParam = SecurityParam Word64
   deriving newtype (Eq, Ord, Bounded, Enum, Real, Num, Read, Integral, Show)
+
+newtype TxIndexInBlock = TxIndexInBlock Word64
+  deriving newtype (Eq, Ord, Bounded, Enum, Real, Num, Read, Integral, Show, Aeson.FromJSON, Aeson.ToJSON, SQL.ToField, SQL.FromField)
 
 -- * Database file names
 


### PR DESCRIPTION
[PLT-5574](https://input-output.atlassian.net/browse/PLT-5574): The UtxoByAddress response should include the block_index of the transaction

This is where cardano-db-sync does it: https://github.com/input-output-hk/cardano-db-sync/blob/master/cardano-db-sync/src/Cardano/DbSync/Era/Byron/Insert.hs#L154 (added in [this PR](https://github.com/input-output-hk/cardano-db-sync/pull/94/files#diff-8c7f6315feb7f8370eaab00dca87e4abb2c56afda9e97d8796b8c47297c78378R123))

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
