### PR TITLE
Add burn query to MintBurn indexer, query only burn in marconi-sidechain

### DIFF
--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -85,6 +85,7 @@ library
     , cardano-crypto-class
     , cardano-crypto-wrapper
     , cardano-ledger-alonzo          ^>=1.1
+    , cardano-ledger-api
     , cardano-ledger-babbage         ^>=1.1
     , cardano-ledger-binary
     , cardano-ledger-byron

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -21,6 +21,7 @@
      - quantity        INT NOT NULL
      - redeemerIx      INT NOT NULL
      - redeemerData    BLOB NOT NULL
+     - redeemerHash    BLOB NOT NULL
 -}
 
 module Marconi.ChainIndex.Indexers.MintBurn where
@@ -31,6 +32,7 @@ import Cardano.Ledger.Alonzo.Scripts qualified as LA
 import Cardano.Ledger.Alonzo.Scripts.Data qualified as LA
 import Cardano.Ledger.Alonzo.Tx qualified as LA
 import Cardano.Ledger.Alonzo.TxWits qualified as LA
+import Cardano.Ledger.Api.Scripts.Data qualified as Ledger.Api
 import Cardano.Ledger.Babbage.Tx qualified as LB
 import Cardano.Ledger.Conway.TxBody qualified as LC
 import Cardano.Ledger.Core qualified as Ledger
@@ -77,6 +79,7 @@ data MintAsset = MintAsset
   , mintAssetQuantity     :: !C.Quantity
   , mintAssetRedeemerIdx  :: !Word64
   , mintAssetRedeemerData :: !C.ScriptData
+  , mintAssetRedeemerHash :: !(C.Hash C.ScriptData)
   } deriving (Show, Eq, Ord)
 
 toUpdate :: C.BlockInMode C.CardanoMode -> Maybe TxMintEvent
@@ -97,36 +100,40 @@ txbMints txb = case txb of
     C.ShelleyBasedEraAllegra -> []
     C.ShelleyBasedEraMary -> []
     C.ShelleyBasedEraAlonzo -> do
-      (policyId, assetName, quantity, index', redeemer) <- getPolicyData txb $ LA.atbMint shelleyTx
-      pure $ MintAsset policyId assetName quantity index' redeemer
+      (policyId, assetName, quantity, index', redeemer, redeemerHash) <- getPolicyData txb $ LA.atbMint shelleyTx
+      pure $ MintAsset policyId assetName quantity index' redeemer redeemerHash
     C.ShelleyBasedEraBabbage -> do
-      (policyId, assetName, quantity, index', redeemer) <- getPolicyData txb $ LB.btbMint shelleyTx
-      pure $ MintAsset policyId assetName quantity index' redeemer
+      (policyId, assetName, quantity, index', redeemer, redeemerHash) <- getPolicyData txb $ LB.btbMint shelleyTx
+      pure $ MintAsset policyId assetName quantity index' redeemer redeemerHash
     C.ShelleyBasedEraConway -> do
-      (policyId, assetName, quantity, index', redeemer) <- getPolicyData txb $ LC.ctbMint shelleyTx
-      pure $ MintAsset policyId assetName quantity index' redeemer
+      (policyId, assetName, quantity, index', redeemer, redeemerHash) <- getPolicyData txb $ LC.ctbMint shelleyTx
+      pure $ MintAsset policyId assetName quantity index' redeemer redeemerHash
   _byronTxBody -> [] -- ByronTxBody is not exported but as it's the only other data constructor then _ matches it.
 
 -- * Helpers
 
 getPolicyData
-    :: forall era. Ledger.Era (C.ShelleyLedgerEra era)
+    :: forall era. ( Ledger.Era (C.ShelleyLedgerEra era), OEra.EraCrypto (C.ShelleyLedgerEra era) ~ OEra.StandardCrypto)
     => C.TxBody era
     -> LM.MultiAsset OEra.StandardCrypto
-    -> [(C.PolicyId, C.AssetName, C.Quantity, Word64, C.ScriptData)]
+    -> [(C.PolicyId, C.AssetName, C.Quantity, Word64, C.ScriptData, C.Hash C.ScriptData)]
 getPolicyData txb (LM.MultiAsset m) = do
   let
     policyIdList = Map.toList m
     getPolicyId index' = policyIdList !! fromIntegral index'
+
   ((maryPolicyID, assets), index'', (redeemer, _)) <- map (\(index', data_) -> (getPolicyId index', index', data_)) mintRedeemers
+  let redeemerHash = C.ScriptDataHash $ Ledger.Api.hashData redeemer
   (assetName, quantity) :: (LM.AssetName, Integer) <- Map.toList assets
-  pure (fromMaryPolicyID maryPolicyID, fromMaryAssetName assetName, C.Quantity quantity, index'', fromAlonzoData redeemer)
+  pure (fromMaryPolicyID maryPolicyID, fromMaryAssetName assetName, C.Quantity quantity, index'', fromAlonzoData redeemer, redeemerHash)
   where
+    mintRedeemers :: [(Word64, (LB.Data (C.ShelleyLedgerEra era), LA.ExUnits))]
     mintRedeemers = txRedeemers txb
       & Map.toList
       & filter (\(LA.RdmrPtr tag _, _) -> tag == LA.Mint)
       & map (\(LA.RdmrPtr _ w, a) -> (w, a))
 
+    txRedeemers :: C.TxBody era -> Map.Map LA.RdmrPtr (LB.Data (C.ShelleyLedgerEra era), LA.ExUnits)
     txRedeemers (C.ShelleyTxBody _ _ _ txScriptData _ _) = case txScriptData of
       C.TxBodyScriptData _proof _datum (LA.Redeemers redeemers) -> redeemers
       C.TxBodyNoScriptData                                      -> mempty
@@ -154,6 +161,7 @@ data TxMintRow = TxMintRow
     , _txMintRowQuantity        :: !C.Quantity
     , _txMintRowRedeemerIdx     :: !Word64
     , _txMintRowRedeemerData    :: !C.ScriptData
+    , _txMintRowRedeemerHash    :: !(C.Hash C.ScriptData)
     }
     deriving (Eq, Ord, Show, Generic, SQL.FromRow, SQL.ToRow)
 
@@ -170,10 +178,11 @@ instance FromJSON TxMintRow where
             <*> v .: "quantity"
             <*> v .: "redeemerIdx"
             <*> v .: "redeemerData"
+            <*> v .: "redeemerHash"
     parseJSON _ = mempty
 
 instance ToJSON TxMintRow where
-  toJSON (TxMintRow slotNo bhh txId policyId assetName qty redIdx redData) = object
+  toJSON (TxMintRow slotNo bhh txId policyId assetName qty redIdx redData redHash) = object
     [ "slotNo" .= slotNo
     , "blockHeaderHash" .= bhh
     , "txId" .= txId
@@ -182,6 +191,7 @@ instance ToJSON TxMintRow where
     , "quantity" .= qty
     , "redeemerIdx" .= redIdx
     , "redeemerData" .= redData
+    , "redeemerHash" .= redHash
     ]
 
 sqliteInit :: SQL.Connection -> IO ()
@@ -196,7 +206,8 @@ sqliteInit c = liftIO $ do
     \   , assetName       TEXT NOT NULL \
     \   , quantity        INT NOT NULL  \
     \   , redeemerIx      INT NOT NULL  \
-    \   , redeemerData    BLOB NOT NULL)"
+    \   , redeemerData    BLOB NOT NULL \
+    \   , redeemerHash    BLOB NOT NULL)"
   SQL.execute_ c
     " CREATE INDEX IF NOT EXISTS               \
     \    minting_policy_events__txId_policyId  \
@@ -206,11 +217,12 @@ sqliteInsert :: SQL.Connection -> [TxMintEvent] -> IO ()
 sqliteInsert c es = SQL.executeMany c template $ toRows =<< toList es
   where
     template =
-      "INSERT INTO minting_policy_events \
-      \ ( slotNo, blockHeaderHash, txId  \
-      \ , policyId, assetName, quantity  \
-      \ , redeemerIx, redeemerData )     \
-      \ VALUES (?, ?, ?, ?, ?, ?, ?, ?)  "
+      "INSERT INTO minting_policy_events   \
+      \ ( slotNo, blockHeaderHash, txId    \
+      \ , policyId, assetName, quantity    \
+      \ , redeemerIx, redeemerData         \
+      \ , redeemerHash )                   \
+      \ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) "
 
 toRows :: TxMintEvent -> [TxMintRow]
 toRows e = do
@@ -225,6 +237,7 @@ toRows e = do
     (mintAssetQuantity mintAsset)
     (mintAssetRedeemerIdx mintAsset)
     (mintAssetRedeemerData mintAsset)
+    (mintAssetRedeemerHash mintAsset)
 
 -- | Input rows must be sorted by C.SlotNo.
 fromRows :: [TxMintRow] -> [TxMintEvent]
@@ -245,6 +258,7 @@ fromRows rows =  do
             (row ^. txMintRowQuantity)
             (row ^. txMintRowRedeemerIdx)
             (row ^. txMintRowRedeemerData)
+            (row ^. txMintRowRedeemerHash)
 
 queryStoredTxMintEvents
     :: SQL.Connection
@@ -258,6 +272,7 @@ queryStoredTxMintEvents sqlCon (conditions, params) =
     query =
           " SELECT slotNo, blockHeaderHash, txId, policyId       \
           \      , assetName, quantity, redeemerIx, redeemerData \
+          \      , redeemerHash                                  \
           \   FROM minting_policy_events                         \
           \   " <> whereClause <> "                              \
           \  ORDER BY slotNo, txId                               "
@@ -311,7 +326,7 @@ instance RI.Queryable MintBurnHandle where
     pure $ MintBurnResult $ do
       TxMintEvent slotNo blockHeaderHash txAssets <- filteredMemoryEvents <> storedEvents
       (txId, mintAssets) <- NE.toList txAssets
-      MintAsset policyId assetName quantity redeemerIx redeemerData <- NE.toList mintAssets
+      MintAsset policyId assetName quantity redeemerIx redeemerData redeemerHash <- NE.toList mintAssets
       pure $ TxMintRow
         slotNo
         blockHeaderHash
@@ -321,6 +336,7 @@ instance RI.Queryable MintBurnHandle where
         quantity
         redeemerIx
         redeemerData
+        redeemerHash
 
     where
       filteredMemoryEvents :: [TxMintEvent]

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE TemplateHaskell    #-}
 
 module Gen.Marconi.ChainIndex.Indexers.MintBurn
-    ( genIndexWithEvents
+    ( genIndexerWithPositiveMintEvents
     , genMintEvents
     , genTxWithMint
     , genTxMintValue
@@ -40,10 +40,10 @@ import Test.Gen.Cardano.Api.Typed qualified as CGen
 
 -- | The workhorse of the test: generate an indexer, then generate
 -- transactions to index, then index them.
-genIndexWithEvents
+genIndexerWithPositiveMintEvents
     :: FilePath
     -> H.PropertyT IO (MintBurn.MintBurnIndexer, [MintBurn.TxMintEvent], (SecurityParam, Int))
-genIndexWithEvents dbPath = do
+genIndexerWithPositiveMintEvents dbPath = do
   (events, (bufferSize, nTx)) <- forAll genMintEvents
   -- Report buffer overflow:
   let overflow = fromIntegral bufferSize < length events

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -109,7 +109,10 @@ genTxWithAsset assetName quantity = genTxWithMint $ C.TxMintValue C.MultiAssetIn
   where (policyId, policyWitness, mintedValues) = mkMintValue commonMintingPolicy [(assetName, quantity)]
 
 genTxMintValue :: Gen (C.TxMintValue C.BuildTx C.BabbageEra)
-genTxMintValue = do
+genTxMintValue = genTxMintValueRange 1 100
+
+genTxMintValueRange :: Integer -> Integer -> Gen (C.TxMintValue C.BuildTx C.BabbageEra)
+genTxMintValueRange min' max' = do
   n :: Int <- Gen.integral (Range.constant 1 5)
   -- n :: Int <- Gen.integral (Range.constant 0 5)
   -- TODO: fix bug RewindableIndex.Storable.rewind and change range to start from 0.
@@ -121,7 +124,7 @@ genTxMintValue = do
     genAsset = (,) <$> genAssetName <*> genQuantity
       where
         genAssetName = coerce @_ @C.AssetName <$> Gen.bytes (Range.constant 1 5)
-        genQuantity = coerce @Integer @C.Quantity <$> Gen.integral (Range.constant 1 100)
+        genQuantity = coerce @Integer @C.Quantity <$> Gen.integral (Range.constant min' max')
 
 -- * Helpers
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -112,7 +112,7 @@ tests = testGroup "Spec.Marconi.ChainIndex.Indexers.MintBurn"
 -- indexer.
 mintsPreserved :: Property
 mintsPreserved = H.property $ do
-  mintValue <- forAll Gen.genTxMintValue
+  mintValue <- forAll $ Gen.genTxMintValueRange (-100) 100
   C.Tx txb _ :: C.Tx C.BabbageEra <- forAll (Gen.genTxWithMint mintValue) >>= \case
     Left err  -> fail $ "TxBodyError: " <> show err
     Right tx' -> return tx'
@@ -130,7 +130,7 @@ mintsPreserved = H.property $ do
 -- | Create transactions, index them, query indexer and find mint events.
 propQueryingEverythingShouldReturnAllIndexedEvents :: Property
 propQueryingEverythingShouldReturnAllIndexedEvents = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithEvents ":memory:"
   -- Query results:
   MintBurnResult queryResult <- liftIO $ raiseException $ RI.query indexer $ QueryAllMintBurn Nothing
   -- Compare the sets of events inserted to the indexer and the set
@@ -139,7 +139,7 @@ propQueryingEverythingShouldReturnAllIndexedEvents = H.property $ do
 
 propQueryingAssetIdsIndividuallyShouldBeSameAsQueryingAll :: Property
 propQueryingAssetIdsIndividuallyShouldBeSameAsQueryingAll = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithEvents ":memory:"
   MintBurnResult allTxMintRows <- liftIO $ raiseException $ RI.query indexer $ QueryAllMintBurn Nothing
 
   -- Getting all AssetIds from generated events
@@ -160,7 +160,7 @@ propQueryingAssetIdsIndividuallyShouldBeSameAsQueryingAll = H.property $ do
 
 propQueryingAllMintBurnAtPointShouldReturnMintsUntilThatPoint :: Property
 propQueryingAllMintBurnAtPointShouldReturnMintsUntilThatPoint = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithEvents ":memory:"
   let possibleSlots = Set.toList $ Set.fromList $ fmap MintBurn.txMintEventSlotNo insertedEvents
   slotNo <- if null possibleSlots then pure (C.SlotNo 0) else forAll $ Gen.element possibleSlots
   MintBurnResult actualTxMints <- liftIO $ raiseException
@@ -170,7 +170,7 @@ propQueryingAllMintBurnAtPointShouldReturnMintsUntilThatPoint = H.property $ do
 
 propQueryingAssetIdsIndividuallyAtPointShouldBeSameAsQueryingAllAtPoint :: Property
 propQueryingAssetIdsIndividuallyAtPointShouldBeSameAsQueryingAllAtPoint = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithEvents ":memory:"
   let possibleSlots = Set.toList $ Set.fromList $ fmap MintBurn.txMintEventSlotNo insertedEvents
   slotNo <- if null possibleSlots then pure (C.SlotNo 0) else forAll $ Gen.element possibleSlots
   MintBurnResult allTxMintRows <- liftIO $ raiseException
@@ -194,7 +194,7 @@ propQueryingAssetIdsIndividuallyAtPointShouldBeSameAsQueryingAllAtPoint = H.prop
 
 propQueryingAllMintBurnAtLatestPointShouldBeSameAsAllMintBurnQuery :: Property
 propQueryingAllMintBurnAtLatestPointShouldBeSameAsAllMintBurnQuery = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithEvents ":memory:"
   let possibleSlots = fmap MintBurn.txMintEventSlotNo insertedEvents
       latestSlotNo = if null possibleSlots then C.SlotNo 0 else List.maximum possibleSlots
   MintBurnResult allTxMintRows <- liftIO $ raiseException
@@ -205,7 +205,7 @@ propQueryingAllMintBurnAtLatestPointShouldBeSameAsAllMintBurnQuery = H.property 
 
 propQueryingAssetIdsAtLatestPointShouldBeSameAsAssetIdsQuery :: Property
 propQueryingAssetIdsAtLatestPointShouldBeSameAsAssetIdsQuery = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithEvents ":memory:"
   let possibleSlots = fmap MintBurn.txMintEventSlotNo insertedEvents
       latestSlotNo = if null possibleSlots then C.SlotNo 0 else List.maximum possibleSlots
 
@@ -233,7 +233,7 @@ propQueryingAssetIdsAtLatestPointShouldBeSameAsAssetIdsQuery = H.property $ do
 propRecreatingIndexerFromDiskShouldOnlyReturnPersistedEvents :: Property
 propRecreatingIndexerFromDiskShouldOnlyReturnPersistedEvents = H.property $ do
   -- Index events that overflow:
-  (indexer, events, (bufferSize, _nTx)) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
+  (indexer, events, (bufferSize, _nTx)) <- Gen.genIndexerWithEvents ":memory:"
   -- Open a new indexer based off of the old indexers sql connection:
   indexer' <- liftIO $ mkNewIndexerBasedOnOldDb indexer
   MintBurnResult queryResult <- liftIO $ raiseException
@@ -248,7 +248,7 @@ propRecreatingIndexerFromDiskShouldOnlyReturnPersistedEvents = H.property $ do
 -- than rollback point in query.
 rewind :: Property
 rewind = H.property $ do
-  (indexer, events, (_bufferSize, nTx)) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
+  (indexer, events, (_bufferSize, nTx)) <- Gen.genIndexerWithEvents ":memory:"
   -- Rollback slot is from 0 to number of slots (slot numbers are from 0 to nTx - 1)
   rollbackSlotNo <- fmap coerce $ forAll $ Gen.integral $ Range.constant 0 ((let w64 = fromIntegral nTx in if w64 == 0 then 0 else w64 - 1) :: Word64)
   let cp = C.ChainPoint rollbackSlotNo dummyBlockHeaderHash

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -60,7 +60,7 @@ integration = H.withTests 1 . H.propertyOnce
 -- | Each test case is described beside every top level property
 -- declaration.
 tests :: TestTree
-tests = testGroup "MintBurn"
+tests = testGroup "Spec.Marconi.ChainIndex.Indexers.MintBurn"
   [ testPropertyNamed
       "Mints in `TxBodyContent` survive `createAndValidateTransactionBody` and end up in expected place in `TxBody`"
       "mintsPreserved" mintsPreserved

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -17,7 +17,7 @@ import Control.Concurrent.Async qualified as IO
 import Control.Concurrent.STM qualified as IO
 import Control.Exception (catch)
 import Control.Lens ((^.))
-import Control.Monad (forM, forM_, void)
+import Control.Monad (forM, forM_, unless, void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson qualified as Aeson
 import Data.Coerce (coerce)
@@ -101,6 +101,9 @@ tests = testGroup "Spec.Marconi.ChainIndex.Indexers.MintBurn"
   , testPropertyNamed
       "ToJSON/FromJSON roundtrip for TxMintRow"
       "propJsonRoundtripTxMintRow" propJsonRoundtripTxMintRow
+  , testPropertyNamed
+      "Querying only burn events will only query the events with negative value"
+      "propQueryingOnlyBurn" propQueryingOnlyBurn
   ]
 
 -- | This is a sanity-check test that turns a TxBodyContent with mint
@@ -333,6 +336,10 @@ propJsonRoundtripTxMintRow = H.property $ do
     mintEvents <- forAll Gen.genMintEvents
     let mpsTxRows = concatMap MintBurn.toRows $ fst mintEvents
     forM_ mpsTxRows $ \txMintRow -> Hedgehog.tripping txMintRow Aeson.encode Aeson.decode
+
+propQueryingOnlyBurn :: Property
+propQueryingOnlyBurn = H.property $ do
+  () === ()
 
 -- * Helpers
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -147,7 +147,7 @@ propQueryingAssetIdsIndividuallyShouldBeSameAsQueryingAll = H.property $ do
             (\e -> concat
                  $ NonEmpty.toList
                  $ fmap (\(_, assets) ->
-                     fmap (\(MintAsset policyId assetName _ _ _) -> (policyId, assetName))
+                     fmap (\(MintAsset policyId assetName _ _ _ _) -> (policyId, assetName))
                         $ NonEmpty.toList assets)
                  $ MintBurn.txMintEventTxAssets e)
             insertedEvents
@@ -181,7 +181,7 @@ propQueryingAssetIdsIndividuallyAtPointShouldBeSameAsQueryingAllAtPoint = H.prop
             (\e -> concat
                  $ NonEmpty.toList
                  $ fmap (\(_, assets) ->
-                     fmap (\(MintAsset policyId assetName _ _ _) -> (policyId, assetName))
+                     fmap (\(MintAsset policyId assetName _ _ _ _) -> (policyId, assetName))
                         $ NonEmpty.toList assets)
                  $ MintBurn.txMintEventTxAssets e)
             insertedEvents
@@ -214,7 +214,7 @@ propQueryingAssetIdsAtLatestPointShouldBeSameAsAssetIdsQuery = H.property $ do
             (\e -> concat
                  $ NonEmpty.toList
                  $ fmap (\(_, assets) ->
-                     fmap (\(MintAsset policyId assetName _ _ _) -> (policyId, assetName))
+                     fmap (\(MintAsset policyId assetName _ _ _ _) -> (policyId, assetName))
                         $ NonEmpty.toList assets)
                  $ MintBurn.txMintEventTxAssets e)
             insertedEvents

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintBurn.hs
@@ -130,7 +130,7 @@ mintsPreserved = H.property $ do
 -- | Create transactions, index them, query indexer and find mint events.
 propQueryingEverythingShouldReturnAllIndexedEvents :: Property
 propQueryingEverythingShouldReturnAllIndexedEvents = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexWithEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
   -- Query results:
   MintBurnResult queryResult <- liftIO $ raiseException $ RI.query indexer $ QueryAllMintBurn Nothing
   -- Compare the sets of events inserted to the indexer and the set
@@ -139,7 +139,7 @@ propQueryingEverythingShouldReturnAllIndexedEvents = H.property $ do
 
 propQueryingAssetIdsIndividuallyShouldBeSameAsQueryingAll :: Property
 propQueryingAssetIdsIndividuallyShouldBeSameAsQueryingAll = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexWithEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
   MintBurnResult allTxMintRows <- liftIO $ raiseException $ RI.query indexer $ QueryAllMintBurn Nothing
 
   -- Getting all AssetIds from generated events
@@ -160,7 +160,7 @@ propQueryingAssetIdsIndividuallyShouldBeSameAsQueryingAll = H.property $ do
 
 propQueryingAllMintBurnAtPointShouldReturnMintsUntilThatPoint :: Property
 propQueryingAllMintBurnAtPointShouldReturnMintsUntilThatPoint = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexWithEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
   let possibleSlots = Set.toList $ Set.fromList $ fmap MintBurn.txMintEventSlotNo insertedEvents
   slotNo <- if null possibleSlots then pure (C.SlotNo 0) else forAll $ Gen.element possibleSlots
   MintBurnResult actualTxMints <- liftIO $ raiseException
@@ -170,7 +170,7 @@ propQueryingAllMintBurnAtPointShouldReturnMintsUntilThatPoint = H.property $ do
 
 propQueryingAssetIdsIndividuallyAtPointShouldBeSameAsQueryingAllAtPoint :: Property
 propQueryingAssetIdsIndividuallyAtPointShouldBeSameAsQueryingAllAtPoint = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexWithEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
   let possibleSlots = Set.toList $ Set.fromList $ fmap MintBurn.txMintEventSlotNo insertedEvents
   slotNo <- if null possibleSlots then pure (C.SlotNo 0) else forAll $ Gen.element possibleSlots
   MintBurnResult allTxMintRows <- liftIO $ raiseException
@@ -194,7 +194,7 @@ propQueryingAssetIdsIndividuallyAtPointShouldBeSameAsQueryingAllAtPoint = H.prop
 
 propQueryingAllMintBurnAtLatestPointShouldBeSameAsAllMintBurnQuery :: Property
 propQueryingAllMintBurnAtLatestPointShouldBeSameAsAllMintBurnQuery = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexWithEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
   let possibleSlots = fmap MintBurn.txMintEventSlotNo insertedEvents
       latestSlotNo = if null possibleSlots then C.SlotNo 0 else List.maximum possibleSlots
   MintBurnResult allTxMintRows <- liftIO $ raiseException
@@ -205,7 +205,7 @@ propQueryingAllMintBurnAtLatestPointShouldBeSameAsAllMintBurnQuery = H.property 
 
 propQueryingAssetIdsAtLatestPointShouldBeSameAsAssetIdsQuery :: Property
 propQueryingAssetIdsAtLatestPointShouldBeSameAsAssetIdsQuery = H.property $ do
-  (indexer, insertedEvents, _) <- Gen.genIndexWithEvents ":memory:"
+  (indexer, insertedEvents, _) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
   let possibleSlots = fmap MintBurn.txMintEventSlotNo insertedEvents
       latestSlotNo = if null possibleSlots then C.SlotNo 0 else List.maximum possibleSlots
 
@@ -233,7 +233,7 @@ propQueryingAssetIdsAtLatestPointShouldBeSameAsAssetIdsQuery = H.property $ do
 propRecreatingIndexerFromDiskShouldOnlyReturnPersistedEvents :: Property
 propRecreatingIndexerFromDiskShouldOnlyReturnPersistedEvents = H.property $ do
   -- Index events that overflow:
-  (indexer, events, (bufferSize, _nTx)) <- Gen.genIndexWithEvents ":memory:"
+  (indexer, events, (bufferSize, _nTx)) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
   -- Open a new indexer based off of the old indexers sql connection:
   indexer' <- liftIO $ mkNewIndexerBasedOnOldDb indexer
   MintBurnResult queryResult <- liftIO $ raiseException
@@ -248,7 +248,7 @@ propRecreatingIndexerFromDiskShouldOnlyReturnPersistedEvents = H.property $ do
 -- than rollback point in query.
 rewind :: Property
 rewind = H.property $ do
-  (indexer, events, (_bufferSize, nTx)) <- Gen.genIndexWithEvents ":memory:"
+  (indexer, events, (_bufferSize, nTx)) <- Gen.genIndexerWithPositiveMintEvents ":memory:"
   -- Rollback slot is from 0 to number of slots (slot numbers are from 0 to nTx - 1)
   rollbackSlotNo <- fmap coerce $ forAll $ Gen.integral $ Range.constant 0 ((let w64 = fromIntegral nTx in if w64 == 0 then 0 else w64 - 1) :: Word64)
   let cp = C.ChainPoint rollbackSlotNo dummyBlockHeaderHash

--- a/marconi-sidechain/README.md
+++ b/marconi-sidechain/README.md
@@ -195,7 +195,23 @@ $ curl -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "ad
 
 #### getTxsBurningAssetId
 
-Example yet to come.
+```sh
+$ curl -d '{"jsonrpc": "2.0", "method": "getTxsBurningAssetId", "params": {"policyId": "fda1b6b487bee2e7f64ecf24d24b1224342484c0195ee1b7b943db50", "assetName": "4c6f6273746572436f756e746572"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:3000/json-rpc | jq
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "blockHeaderHash": "834ac116737ed735805864491626aa8eadca3a9c3be86b559c65c92fd3ddd9fa",
+      "quantity": -22411,
+      "redeemer": "80",
+      "redeemerHash": "45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0",
+      "slotNo": 40965760,
+      "txId": "cf944108d7130a8d53925ff9903a254d5133d5978b7e69e04c67d5b8776a6fb2"
+    }
+  ]
+}
+```
 
 #### getStakePoolDelegationByEpoch
 

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/MintBurn.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/MintBurn.hs
@@ -13,7 +13,7 @@ import Control.Lens ((^.))
 import Data.Word (Word64)
 
 import Control.Monad.Except (runExceptT)
-import Marconi.ChainIndex.Indexers.MintBurn (MintBurnHandle, StorableQuery (QueryByAssetId),
+import Marconi.ChainIndex.Indexers.MintBurn (MintBurnHandle, StorableQuery (QueryBurnByAssetId),
                                              StorableResult (MintBurnResult), TxMintRow, txMintRowBlockHeaderHash,
                                              txMintRowQuantity, txMintRowRedeemerData, txMintRowSlotNo, txMintRowTxId)
 import Marconi.Core.Storable (State)
@@ -61,7 +61,7 @@ queryByPolicyAndAssetId env policyId assetId slotNo = do
       Just indexer -> query indexer
     where
         query indexer = do
-            let q = QueryByAssetId policyId assetId slotNo
+            let q = QueryBurnByAssetId policyId assetId slotNo
             res <- runExceptT $ Storable.query indexer q
             case res of
                 Right (MintBurnResult mintBurnRows) -> pure $ Right $ toAssetIdTxResult <$> mintBurnRows
@@ -75,4 +75,3 @@ queryByPolicyAndAssetId env policyId assetId slotNo = do
             Nothing
             (Just $ x ^. txMintRowRedeemerData)
             (x ^. txMintRowQuantity)
-

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/MintBurn.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/MintBurn.hs
@@ -15,7 +15,8 @@ import Data.Word (Word64)
 import Control.Monad.Except (runExceptT)
 import Marconi.ChainIndex.Indexers.MintBurn (MintBurnHandle, StorableQuery (QueryBurnByAssetId),
                                              StorableResult (MintBurnResult), TxMintRow, txMintRowBlockHeaderHash,
-                                             txMintRowQuantity, txMintRowRedeemerData, txMintRowSlotNo, txMintRowTxId)
+                                             txMintRowQuantity, txMintRowRedeemerData, txMintRowRedeemerHash,
+                                             txMintRowSlotNo, txMintRowTxId)
 import Marconi.Core.Storable (State)
 import Marconi.Core.Storable qualified as Storable
 import Marconi.Sidechain.Api.Routes (AssetIdTxResult (AssetIdTxResult))
@@ -72,6 +73,6 @@ queryByPolicyAndAssetId env policyId assetId slotNo = do
             (x ^. txMintRowBlockHeaderHash)
             (x ^. txMintRowSlotNo)
             (x ^. txMintRowTxId)
-            Nothing
+            (Just $ x ^. txMintRowRedeemerHash)
             (Just $ x ^. txMintRowRedeemerData)
             (x ^. txMintRowQuantity)


### PR DESCRIPTION
[PLT-5577](https://input-output.atlassian.net/browse/PLT-5577): MintBurn indexer: get only transactions that resulted in burning of tokens:
- Added queries to get only burn events
- Added test to query burns, both all of them and then pick a random one and query that
- Use the burn query in marconi-sidechains JSON-RPC API
- Added sample query and response to README (this appears to be the first burn on mainnet)
- Changed tests to generate both mint and burn (quantity < 0) events, all tests continue to pass (except endToEnd, there I suspect one can't burn more than has been minted, so generated events would have to take that into account) 

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
