### PR TITLE
Wait longer before checking workers state in test

### DIFF
--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -880,7 +880,7 @@ stopCoordinatorProperty gen runner = let
 
     cRunner = coordinatorIndexerRunner runner
     r = cRunner ^. indexerRunner
-    waitForKill = GenM.run $ liftIO $ Con.threadDelay 100
+    waitForKill = GenM.run $ liftIO $ Con.threadDelay 1000
     forgedError = Core.OtherIndexError "STOP"
 
     seedError ix
@@ -916,7 +916,7 @@ stopCoordinatorTest
     -> Tasty.TestTree
 stopCoordinatorTest runner =
     Tasty.testProperty "stops coordinator workers"
-        $ Test.withMaxSuccess 10000
+        $ Test.withMaxSuccess 1000
         $ stopCoordinatorProperty (view defaultChain <$> Test.arbitrary) runner
 
 resumeLastSyncProperty


### PR DESCRIPTION
It should fix a failure in the test that checks if the coordinator stops the indexers correctly in error that happen in CI when the Darwin cluster is overloaded

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [x] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
