### PR TITLE
PLT-6068 Improve Utxo indexer performance

### DIFF
--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -107,6 +107,7 @@ library
   ------------------------
   build-depends:
     , aeson
+    , async
     , base
     , base16-bytestring
     , bytestring

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -257,8 +257,8 @@ data UtxoRow = UtxoRow
 
 $(makeLenses ''UtxoRow)
 
-urSpendSlotNo :: Traversal' UtxoRow C.SlotNo
-urSpendSlotNo = urSpentInfo . _Just . siSpentPoint . cpSlotNo
+urSpentSlotNo :: Traversal' UtxoRow C.SlotNo
+urSpentSlotNo = urSpentInfo . _Just . siSpentPoint . cpSlotNo
 
 urCreationSlotNo :: Lens' UtxoRow C.SlotNo
 urCreationSlotNo = urCreationPoint . cpSlotNo
@@ -295,7 +295,7 @@ instance ToJSON UtxoRow where
     [ "utxo" .= view urUtxo ur
     , "slotNo" .= view urCreationSlotNo ur
     , "blockHeaderHash" .= view urCreationBlockHash ur
-    , "spentSlotNo" .= preview urSpendSlotNo ur
+    , "spentSlotNo" .= preview urSpentSlotNo ur
     , "spentBlockHeaderHash" .= preview urSpentBlockHash ur
     , "spentTxId" .= preview urSpentTxId ur
     ]
@@ -493,7 +493,7 @@ open dbPath (Depth k) isToVacuume = do
                       , txIx INT NOT NULL
                       , slotNo INT NOT NULL
                       , blockHash BLOB NOT NULL
-                      , spendTxId TEXT NOT NULL)|]
+                      , spentTxId TEXT NOT NULL)|]
 
     lift $ SQL.execute_ c [r|CREATE INDEX IF NOT EXISTS
                       spent_slotNo ON spent (slotNo)|]
@@ -554,7 +554,7 @@ instance Buffered UtxoHandle where
            [r|INSERT
               INTO spent (
                 txId,
-                txIx, slotNo, blockHash, spendTxId
+                txIx, slotNo, blockHash, spentTxId
               ) VALUES
               (?, ?, ?, ?, ?)|] spents)))
     -- We want to perform vacuum about once every 100
@@ -806,7 +806,7 @@ utxoAtAddressQuery c bufferResult filters params
                   u.blockHash,
                   s.slotNo,
                   s.blockHash,
-                  s.spendTxId
+                  s.spentTxId
                FROM
                   unspent_transactions u
                FULL OUTER JOIN spent s ON u.txId = s.txId

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -109,6 +109,7 @@ upperBound = \case
     LessThanOrEqual x -> Just x
     InRange _ x       -> Just x
 
+-- | Smart constructor for 'Interval ', return an error if the lower bound is greater than the upper bound
 interval
   :: (Ord r, Show r)
   => Maybe r -- ^ lower bound
@@ -133,15 +134,16 @@ interval (Just p) p' =
 
   in wrap InRange p p'
 
+-- | Check if a given chainpoint is in the given interval
 isInInterval :: Interval C.SlotNo -> C.ChainPoint -> Bool
 isInInterval slotNoInterval = \case
   C.ChainPointAtGenesis -> case slotNoInterval of
     LessThanOrEqual _ -> True
     InRange _ _       -> False
 
-  (C.ChainPoint slotNo _)  -> case slotNoInterval of
+  C.ChainPoint slotNo _  -> case slotNoInterval of
     LessThanOrEqual slotNo' -> slotNo' >= slotNo
-    InRange l h             -> l <= slotNo &&  h >= slotNo
+    InRange l h             -> l <= slotNo && h >= slotNo
 
 type UtxoIndexer = Storable.State UtxoHandle
 
@@ -300,7 +302,9 @@ instance ToJSON UtxoRow where
 
 data instance StorableResult UtxoHandle
     = UtxoResult { getUtxoResult :: ![UtxoRow] }
+    -- ^ Result of a 'QueryUtxoByAddress' query
     | LastSyncPointResult { getLastSyncPoint :: !C.ChainPoint }
+    -- ^ Result of a 'LastSyncPoint' query
     deriving (Eq, Show, Ord)
 
 data instance StorableEvent UtxoHandle = UtxoEvent

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -236,7 +236,7 @@ allQueryUtxosSpentInTheFutureHaveASpentTxId = property $ do
       futureSpentHasSpentTxId u = let
          futureSpents = foldMap getFutureSpent events
          txin = u ^. Utxo.urUtxo . Utxo.txIn
-         in txin `Set.notMember` futureSpents || isJust (u ^. Utxo.urSpentInfo)
+         in txin `Set.notMember` futureSpents || isJust (u ^. Utxo.urSpendInfo)
 
   -- A property of the generator is that there is at least one unspent transaction
   -- this property also ensures that the next test will not succeed for the trivila case

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -236,7 +236,7 @@ allQueryUtxosSpentInTheFutureHaveASpentTxId = property $ do
       futureSpentHasSpentTxId u = let
          futureSpents = foldMap getFutureSpent events
          txin = u ^. Utxo.urUtxo . Utxo.txIn
-         in txin `Set.notMember` futureSpents || isJust (u ^. Utxo.urSpendInfo)
+         in txin `Set.notMember` futureSpents || isJust (u ^. Utxo.urSpentInfo)
 
   -- A property of the generator is that there is at least one unspent transaction
   -- this property also ensures that the next test will not succeed for the trivila case


### PR DESCRIPTION
Reverting the SQL representation of UTXO to two tables (unspent/spent). Add an index on TxId/TxIx to speed up the queries.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
