### PR TITLE
Changed querySecurityParam function so that it can query the security parameter before Babbage

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Utils.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Utils.hs
@@ -1,4 +1,9 @@
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings  #-}
+
+{- |
+This module contains a bunch of utility functions for working in `marconi-chain-index`.
+-}
 module Marconi.ChainIndex.Utils
     ( isBlockRollbackable
     , getBlockNoFromChainTip
@@ -27,19 +32,46 @@ getBlockNoFromChainTip chainTip =
       C.ChainTipAtGenesis -> 0
       (C.ChainTip _ _ bn) -> bn
 
--- | Query security param from node
-querySecurityParam :: C.NetworkId -> FilePath -> ExceptT IndexerError IO SecurityParam
-querySecurityParam = querySecurityParamEra C.BabbageEraInCardanoMode
+-- | Query security param from the local node.
+-- It queries the current era first, and uses that to query the security parameter.
+querySecurityParam
+    :: C.NetworkId
+    -> FilePath -- ^ Node socket file path
+    -> ExceptT IndexerError IO SecurityParam
+querySecurityParam networkId socketPath = do
+    (C.AnyCardanoEra era) <- queryCurrentEra networkId socketPath
+    case shelleyBasedToCardanoEra era of
+      Nothing -> throwError $ CantStartIndexer "The security parameter can only be queried in shelley based era."
+      Just shelleyBasedEra -> querySecurityParamEra shelleyBasedEra networkId socketPath
 
--- | Query security param from node
+-- | Query the current era of the local node's current state.
+queryCurrentEra
+  :: C.NetworkId
+  -> FilePath -- ^ Node socket file path
+  -> ExceptT IndexerError IO C.AnyCardanoEra
+queryCurrentEra networkId socketPath = do
+    result <- lift $ C.queryNodeLocalState localNodeConnectInfo Nothing queryInMode
+    case result of
+      Left err -> toError err
+      Right x  -> pure x
+ where
+    localNodeConnectInfo :: C.LocalNodeConnectInfo C.CardanoMode
+    localNodeConnectInfo = C.mkLocalNodeConnectInfo networkId socketPath
+
+    queryInMode :: C.QueryInMode C.CardanoMode C.AnyCardanoEra
+    queryInMode = C.QueryCurrentEra C.CardanoModeIsMultiEra
+
+    toError :: Show a => a -> ExceptT IndexerError IO b
+    toError = throwError . CantStartIndexer . pack . show
+
+-- | Query security param from the local node given a Shelley based era.
 querySecurityParamEra
   :: forall era
-   . C.IsShelleyBasedEra era
-  => C.EraInMode era C.CardanoMode
+   . C.ShelleyBasedEra era
   -> C.NetworkId
-  -> FilePath
+  -> FilePath -- ^ Node socket file path
   -> ExceptT IndexerError IO SecurityParam
-querySecurityParamEra eraInMode networkId socketPath = do
+querySecurityParamEra shelleyBasedEra networkId socketPath = do
   result <- lift $ C.queryNodeLocalState localNodeConnectInfo Nothing queryInMode
   genesisParameters <- case result of
       Left err         -> toError err
@@ -52,8 +84,8 @@ querySecurityParamEra eraInMode networkId socketPath = do
     localNodeConnectInfo = C.mkLocalNodeConnectInfo networkId socketPath
 
     queryInMode :: C.QueryInMode C.CardanoMode (Either EraMismatch C.GenesisParameters)
-    queryInMode = C.QueryInEra eraInMode
-      $ C.QueryInShelleyBasedEra (C.shelleyBasedEra @era) C.QueryGenesisParameters
+    queryInMode = C.QueryInEra (toShelleyEraInCardanoMode shelleyBasedEra)
+      $ C.QueryInShelleyBasedEra shelleyBasedEra C.QueryGenesisParameters
 
     toError :: Show a => a -> ExceptT IndexerError IO b
     toError = throwError . CantStartIndexer . pack . show
@@ -64,3 +96,23 @@ chainPointOrGenesis :: [C.ChainPoint] -> C.ChainPoint
 chainPointOrGenesis result = case result of
   []     -> C.ChainPointAtGenesis
   cp : _ -> cp
+
+-- TODO This should be moved to `cardano-api`.
+toShelleyEraInCardanoMode :: C.ShelleyBasedEra era -> C.EraInMode era C.CardanoMode
+toShelleyEraInCardanoMode C.ShelleyBasedEraShelley = C.ShelleyEraInCardanoMode
+toShelleyEraInCardanoMode C.ShelleyBasedEraAllegra = C.AllegraEraInCardanoMode
+toShelleyEraInCardanoMode C.ShelleyBasedEraMary    = C.MaryEraInCardanoMode
+toShelleyEraInCardanoMode C.ShelleyBasedEraAlonzo  = C.AlonzoEraInCardanoMode
+toShelleyEraInCardanoMode C.ShelleyBasedEraBabbage = C.BabbageEraInCardanoMode
+toShelleyEraInCardanoMode C.ShelleyBasedEraConway  = C.ConwayEraInCardanoMode
+
+-- | Converts a 'CardanoEra' to the more specific 'ShelleyBasedEra'.
+-- TODO This should be moved to `cardano-api`.
+shelleyBasedToCardanoEra :: C.CardanoEra era -> Maybe (C.ShelleyBasedEra era)
+shelleyBasedToCardanoEra C.ByronEra   = Nothing
+shelleyBasedToCardanoEra C.ShelleyEra = Just C.ShelleyBasedEraShelley
+shelleyBasedToCardanoEra C.AllegraEra = Just C.ShelleyBasedEraAllegra
+shelleyBasedToCardanoEra C.MaryEra    = Just C.ShelleyBasedEraMary
+shelleyBasedToCardanoEra C.AlonzoEra  = Just C.ShelleyBasedEraAlonzo
+shelleyBasedToCardanoEra C.BabbageEra = Just C.ShelleyBasedEraBabbage
+shelleyBasedToCardanoEra C.ConwayEra  = Just C.ShelleyBasedEraConway


### PR DESCRIPTION
Changed querySecurityParam function so that it can query the security parameter before Babbage era (as it's currently hardcoded to Babbage).

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
