### PR TITLE
Changed the query in EpochState to query for the active SDD of an epoch

### DIFF
--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochState.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochState.hs
@@ -177,9 +177,9 @@ test = integration . HE.runFinallies . TN.workspace "chairman" $ \tempAbsPath ->
 
   -- Let's find it in the database as well
   indexer <- liftIO $ STM.readMVar indexerMVar
-  queryResult <- liftIO $ raiseException $ Storable.query indexer (EpochState.SDDByEpochNoQuery epochNo)
+  queryResult <- liftIO $ raiseException $ Storable.query indexer (EpochState.ActiveSDDByEpochNoQuery epochNo)
   case queryResult of
-    EpochState.SDDByEpochNoResult stakeMap ->
+    EpochState.ActiveSDDByEpochNoResult stakeMap ->
       let actualTotalStakedLovelace =
             fmap
               EpochState.epochSDDRowLovelace

--- a/marconi-sidechain/doc/API.adoc
+++ b/marconi-sidechain/doc/API.adoc
@@ -732,9 +732,9 @@ TBD
 TBD
 
 
-=== getStakePoolDelegationByEpoch
+=== getActiveStakePoolDelegationByEpoch
 
-Retrieves the stake pool delegation per epoch.
+Retrieves the active stake pool delegation per epoch.
 
 ==== JSON Schema
 

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/HttpServer.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/HttpServer.hs
@@ -21,8 +21,8 @@ import Marconi.Sidechain.Api.Query.Indexers.Utxo qualified as Q.Utxo
 import Marconi.Sidechain.Api.Routes (
   API,
   GetCurrentSyncedBlockResult,
+  GetEpochActiveStakePoolDelegationResult,
   GetEpochNonceResult,
-  GetEpochStakePoolDelegationResult,
   GetTxsBurningAssetIdParams (assetName, mintBurnSlot, policyId),
   GetTxsBurningAssetIdResult (GetTxsBurningAssetIdResult),
   GetUtxosFromAddressParams (queryAddress, queryCreatedAfterSlotNo, queryUnspentBeforeSlotNo),
@@ -163,11 +163,11 @@ getEpochStakePoolDelegationHandler
   -- ^ Utxo Environment to access Utxo Storage running on the marconi thread
   -> Word64
   -- ^ EpochNo
-  -> Handler (Either (JsonRpcErr String) GetEpochStakePoolDelegationResult)
+  -> Handler (Either (JsonRpcErr String) GetEpochActiveStakePoolDelegationResult)
 getEpochStakePoolDelegationHandler env epochNo =
   liftIO $
     first toRpcErr
-      <$> EpochState.querySDDByEpochNo env epochNo
+      <$> EpochState.queryActiveSDDByEpochNo env epochNo
 
 -- | Handler for retrieving stake pool delegation per epoch
 getEpochNonceHandler

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -33,7 +33,7 @@ type RpcAPI =
     :<|> RpcCurrentSyncedBlockMethod
     :<|> RpcPastAddressUtxoMethod
     :<|> RpcMintingPolicyHashTxMethod
-    :<|> RpcEpochStakePoolDelegationMethod
+    :<|> RpcEpochActiveStakePoolDelegationMethod
     :<|> RpcEpochNonceMethod
 
 type RpcEchoMethod = JsonRpc "echo" String String String
@@ -61,12 +61,12 @@ type RpcMintingPolicyHashTxMethod =
     String
     GetTxsBurningAssetIdResult
 
-type RpcEpochStakePoolDelegationMethod =
+type RpcEpochActiveStakePoolDelegationMethod =
   JsonRpc
-    "getStakePoolDelegationByEpoch"
+    "getActiveStakePoolDelegationByEpoch"
     Word64
     String
-    GetEpochStakePoolDelegationResult
+    GetEpochActiveStakePoolDelegationResult
 
 type RpcEpochNonceMethod =
   JsonRpc
@@ -253,6 +253,10 @@ instance FromJSON AssetIdTxResult where
 
 newtype GetEpochStakePoolDelegationResult
   = GetEpochStakePoolDelegationResult [EpochState.EpochSDDRow]
+  deriving (Eq, Ord, Show, Generic, ToJSON, FromJSON)
+
+newtype GetEpochActiveStakePoolDelegationResult
+  = GetEpochActiveStakePoolDelegationResult [EpochState.EpochSDDRow]
   deriving (Eq, Ord, Show, Generic, ToJSON, FromJSON)
 
 newtype GetEpochNonceResult

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Routes.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Routes.hs
@@ -22,8 +22,8 @@ import Marconi.Sidechain.Api.Routes (
   AddressUtxoResult (AddressUtxoResult),
   AssetIdTxResult (AssetIdTxResult),
   GetCurrentSyncedBlockResult (GetCurrentSyncedBlockResult),
+  GetEpochActiveStakePoolDelegationResult (GetEpochActiveStakePoolDelegationResult),
   GetEpochNonceResult (GetEpochNonceResult),
-  GetEpochStakePoolDelegationResult (GetEpochStakePoolDelegationResult),
   GetTxsBurningAssetIdParams (GetTxsBurningAssetIdParams),
   GetTxsBurningAssetIdResult (GetTxsBurningAssetIdResult),
   GetUtxosFromAddressParams (GetUtxosFromAddressParams),
@@ -46,7 +46,7 @@ tests =
             "propJSONRountripCurrentSyncedBlockResult"
             propJSONRountripCurrentSyncedBlockResult
         , testPropertyNamed
-            "GetEpochStakePoolDelegationResult"
+            "GetEpochActiveStakePoolDelegationResult "
             "propJSONRountripEpochStakePoolDelegationResult"
             propJSONRountripEpochStakePoolDelegationResult
         , testPropertyNamed
@@ -165,7 +165,7 @@ propJSONRountripGetTxsBurningAssetIdResult = property $ do
 
 propJSONRountripEpochStakePoolDelegationResult :: Property
 propJSONRountripEpochStakePoolDelegationResult = property $ do
-  sdds <- fmap GetEpochStakePoolDelegationResult $ forAll $ Gen.list (Range.linear 1 10) $ do
+  sdds <- fmap GetEpochActiveStakePoolDelegationResult $ forAll $ Gen.list (Range.linear 1 10) $ do
     EpochSDDRow
       <$> Gen.genEpochNo
       <*> Gen.genPoolId
@@ -316,7 +316,7 @@ goldenEpochStakePoolDelegationResult = do
       blockNo = C.BlockNo 64903
 
   let sdds = fmap (\poolId -> EpochSDDRow epochNo poolId lovelace slotNo blockHeaderHash blockNo) poolIds
-      result = GetEpochStakePoolDelegationResult sdds
+      result = GetEpochActiveStakePoolDelegationResult sdds
   pure $ Aeson.encodePretty result
 
 goldenEpochNonceResult :: IO ByteString


### PR DESCRIPTION
It was a trivial change. See the Note [Active stake pool delegation query] to understand the rationale of the implementation.

* Changed the EpochSDD query of the EpochState indexer to provide the *active* SDD.
* Refactored a bit the db-sync comparison test
* Changed the EpochSDD query of db-sync to match the change in the EpochState indexer.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
