### PR TITLE
Utxo-Indexer optionally stores Reference script

### DIFF
--- a/marconi-chain-index/app/Main.hs
+++ b/marconi-chain-index/app/Main.hs
@@ -4,6 +4,7 @@ module Main where
 
 import Marconi.ChainIndex.CLI qualified as Cli
 import Marconi.ChainIndex.Indexers qualified as Indexers
+import Marconi.ChainIndex.Types (UtxoIndexerConfig (UtxoIndexerConfig))
 import System.Directory (createDirectoryIfMissing)
 
 {- | the worker don't have a hook to notify the query part
@@ -16,10 +17,11 @@ main :: IO ()
 main = do
   o <- Cli.parseOptions
   createDirectoryIfMissing True (Cli.optionsDbPath o)
-  let maybeTargetAddresses = Cli.optionsTargetAddresses o
-  let maybeTargetAssets = Cli.optionsTargetAssets o
+  let utxoIndexerConfig@(UtxoIndexerConfig maybeTargetAddresses _) =
+        Cli.mkUtxoIndexerConfig o
+      maybeTargetAssets = Cli.optionsTargetAssets o
       indexers =
-        [ (Indexers.utxoWorker noHook maybeTargetAddresses, Cli.utxoDbPath o)
+        [ (Indexers.utxoWorker noHook utxoIndexerConfig, Cli.utxoDbPath o)
         , (Indexers.addressDatumWorker noHook maybeTargetAddresses, Cli.addressDatumDbPath o)
         , (Indexers.scriptTxWorker noHook, Cli.scriptTxDbPath o)
         , (Indexers.mintBurnWorker noHook maybeTargetAssets, Cli.mintBurnDbPath o)

--- a/marconi-chain-index/bench/BenchQueries.hs
+++ b/marconi-chain-index/bench/BenchQueries.hs
@@ -55,7 +55,7 @@ import Marconi.ChainIndex.Indexers.Utxo (
   UtxoHandle,
   UtxoIndexer,
  )
-import Marconi.ChainIndex.Types (IndexingDepth (MinIndexingDepth))
+import Marconi.ChainIndex.Types (IndexingDepth (MinIndexingDepth), UtxoIndexerConfig (UtxoIndexerConfig), ucEnableUtxoTxOutRef, ucTargetAddresses)
 import Marconi.Core.Storable qualified as Storable
 import System.Environment (getEnv)
 import System.FilePath ((</>))
@@ -105,9 +105,10 @@ runIndexerSyncing
 runIndexerSyncing databaseDir nodeSocketPath indexerTVar = do
   let callbackUtxoIndexer :: UtxoIndexer -> IO ()
       callbackUtxoIndexer utxoIndexer = atomically $ writeTMVar indexerTVar utxoIndexer
-  let indexers =
+      utxoIndexerConfig = UtxoIndexerConfig{ucTargetAddresses = Nothing, ucEnableUtxoTxOutRef = True}
+      indexers =
         [
-          ( utxoWorker callbackUtxoIndexer Nothing
+          ( utxoWorker callbackUtxoIndexer utxoIndexerConfig
           , Just $ databaseDir </> utxoDbFileName
           )
         ]

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -20,7 +20,12 @@ import Control.Monad.Except (ExceptT, runExceptT)
 import Data.Text qualified as Text
 import Marconi.ChainIndex.Experimental.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Logging (logging)
-import Marconi.ChainIndex.Types (SecurityParam)
+import Marconi.ChainIndex.Types (
+  SecurityParam,
+  UtxoIndexerConfig (UtxoIndexerConfig),
+  ucEnableUtxoTxOutRef,
+  ucTargetAddresses,
+ )
 import Marconi.ChainIndex.Utils qualified as Utils
 import Marconi.Core.Experiment qualified as Core
 import Prettyprinter (defaultLayoutOptions, layoutPretty)
@@ -46,7 +51,8 @@ utxoWorker -- Should go in Utxo module?
   -> IO (MVar UtxoIndexer, Core.Worker (C.BlockInMode C.CardanoMode) C.ChainPoint)
 utxoWorker dbPath depth = do
   c <- Utxo.initSQLite dbPath -- TODO handle error
-  let extract (C.BlockInMode block _) = Utxo.getUtxoEventsFromBlock Nothing block
+  let utxoIndexerConfig = UtxoIndexerConfig{ucTargetAddresses = Nothing, ucEnableUtxoTxOutRef = True}
+      extract (C.BlockInMode block _) = Utxo.getUtxoEventsFromBlock utxoIndexerConfig block
   Core.createWorker (pure . extract) $ Utxo.mkMixedIndexer c depth
 
 -- | Process the next event in the queue with the coordinator

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -51,7 +51,9 @@ utxoWorker -- Should go in Utxo module?
   -> IO (MVar UtxoIndexer, Core.Worker (C.BlockInMode C.CardanoMode) C.ChainPoint)
 utxoWorker dbPath depth = do
   c <- Utxo.initSQLite dbPath -- TODO handle error
-  let utxoIndexerConfig = UtxoIndexerConfig{ucTargetAddresses = Nothing, ucEnableUtxoTxOutRef = True}
+  let utxoIndexerConfig =
+        -- TODO We forgot the TargetAddress filtering logic for now for the Experimental Indexers.Utxo module
+        UtxoIndexerConfig{ucTargetAddresses = Nothing, ucEnableUtxoTxOutRef = True}
       extract (C.BlockInMode block _) = Utxo.getUtxoEventsFromBlock utxoIndexerConfig block
   Core.createWorker (pure . extract) $ Utxo.mkMixedIndexer c depth
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -485,7 +485,7 @@ instance MonadIO m => Core.Rollbackable m UtxoEvent Core.SQLiteIndexer where
 getUtxoEventsFromBlock
   :: C.IsCardanoEra era
   => UtxoIndexerConfig
-  -- ^ target addresses to filter for
+  -- ^ utxoIndexerConfig, containing targetAddresses and showReferenceScript flag
   -> C.Block era
   -> UtxoEvent
   -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
@@ -496,7 +496,7 @@ getUtxoEventsFromBlock utxoIndexerConfig (C.Block _ txs) =
 getUtxoEvents
   :: C.IsCardanoEra era
   => UtxoIndexerConfig
-  -- ^ target addresses to filter for
+  -- ^ utxoIndexerConfig, containing targetAddresses and showReferenceScript flag
   -> [C.Tx era]
   -> UtxoEvent
   -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
@@ -548,7 +548,7 @@ getUtxosFromTxBody utxoIndexerConfig txBody@(C.TxBody txBodyContent@C.TxBodyCont
 -- | Extract Utxos from Cardano TxOut
 getUtxoFromTxOut
   :: UtxoIndexerConfig
-  -- ^ Target addresses to filter for
+  -- ^ utxoIndexerConfig, containing targetAddresses and showReferenceScript flag
   -> C.TxIn
   -- ^ unique id and position of this transaction
   -> C.TxOut C.CtxTx era
@@ -645,7 +645,7 @@ isAddressInTarget' targetAddresses utxo =
 balanceUtxoFromTx
   :: C.IsCardanoEra era
   => UtxoIndexerConfig
-  -- ^ target addresses to filter for
+  -- ^ utxoIndexerConfig, containing targetAddresses and showReferenceScript flag
   -> C.Tx era
   -> TxOutBalance
 balanceUtxoFromTx utxoIndexerConfig (C.Tx txBody _) =

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -21,7 +21,16 @@
 
 module Marconi.ChainIndex.Experimental.Indexers.Utxo where
 
-import Control.Lens (folded, imap, makeLenses, view, (&), (.~), (^.), (^..))
+import Control.Lens (
+  folded,
+  imap,
+  makeLenses,
+  view,
+  (&),
+  (.~),
+  (^.),
+  (^..),
+ )
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Either (fromRight)
 import Data.Foldable (fold, foldl')
@@ -44,7 +53,13 @@ import Cardano.Api qualified as Core
 import Cardano.Api.Shelley qualified as C
 import GHC.Generics (Generic)
 import Marconi.ChainIndex.Orphans ()
-import Marconi.ChainIndex.Types (SecurityParam (SecurityParam), TargetAddresses, TxOut, pattern CurrentEra)
+import Marconi.ChainIndex.Types (
+  SecurityParam (SecurityParam),
+  TargetAddresses,
+  TxOut,
+  UtxoIndexerConfig (UtxoIndexerConfig),
+  pattern CurrentEra,
+ )
 import Marconi.Core.Experiment qualified as Core
 
 data Utxo = Utxo
@@ -469,25 +484,25 @@ instance MonadIO m => Core.Rollbackable m UtxoEvent Core.SQLiteIndexer where
 -- | Extract UtxoEvents from Cardano Block
 getUtxoEventsFromBlock
   :: C.IsCardanoEra era
-  => Maybe TargetAddresses
+  => UtxoIndexerConfig
   -- ^ target addresses to filter for
   -> C.Block era
   -> UtxoEvent
   -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
-getUtxoEventsFromBlock maybeTargetAddresses (C.Block _ txs) =
-  getUtxoEvents maybeTargetAddresses txs
+getUtxoEventsFromBlock utxoIndexerConfig (C.Block _ txs) =
+  getUtxoEvents utxoIndexerConfig txs
 
 -- | Extract UtxoEvents from Cardano Transactions
 getUtxoEvents
   :: C.IsCardanoEra era
-  => Maybe TargetAddresses
+  => UtxoIndexerConfig
   -- ^ target addresses to filter for
   -> [C.Tx era]
   -> UtxoEvent
   -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
-getUtxoEvents maybeTargetAddresses txs =
+getUtxoEvents utxoIndexerConfig txs =
   let (TxOutBalance utxos spentTxOuts) =
-        foldMap (balanceUtxoFromTx maybeTargetAddresses) txs
+        foldMap (balanceUtxoFromTx utxoIndexerConfig) txs
 
       resolvedUtxos :: Set Utxo
       resolvedUtxos = Set.fromList $ Map.elems utxos
@@ -511,10 +526,10 @@ getTxOutFromTxBodyContent C.TxBodyContent{C.txOuts, C.txReturnCollateral, C.txSc
 -- | Extract Utxos from Cardano TxBody
 getUtxosFromTxBody
   :: (C.IsCardanoEra era)
-  => Maybe TargetAddresses
+  => UtxoIndexerConfig
   -> C.TxBody era
   -> Map C.TxIn Utxo
-getUtxosFromTxBody maybeTargetAddresses txBody@(C.TxBody txBodyContent@C.TxBodyContent{}) =
+getUtxosFromTxBody utxoIndexerConfig txBody@(C.TxBody txBodyContent@C.TxBodyContent{}) =
   fromRight Map.empty (getUtxos $ getTxOutFromTxBodyContent txBodyContent)
   where
     getUtxos :: C.IsCardanoEra era => [C.TxOut C.CtxTx era] -> Either C.EraCastError (Map C.TxIn Utxo)
@@ -526,13 +541,13 @@ getUtxosFromTxBody maybeTargetAddresses txBody@(C.TxBody txBodyContent@C.TxBodyC
     txoutToUtxo :: Int -> TxOut -> Map C.TxIn Utxo
     txoutToUtxo ix txout =
       let txin = C.TxIn txid (C.TxIx (fromIntegral ix))
-       in case getUtxoFromTxOut maybeTargetAddresses txin txout of
+       in case getUtxoFromTxOut utxoIndexerConfig txin txout of
             Nothing -> Map.empty
             Just utxo -> Map.singleton txin utxo
 
 -- | Extract Utxos from Cardano TxOut
 getUtxoFromTxOut
-  :: Maybe TargetAddresses
+  :: UtxoIndexerConfig
   -- ^ Target addresses to filter for
   -> C.TxIn
   -- ^ unique id and position of this transaction
@@ -540,7 +555,7 @@ getUtxoFromTxOut
   -- ^ Cardano TxOut
   -> Maybe Utxo
   -- ^ Utxo
-getUtxoFromTxOut maybeTargetAddresses txin (C.TxOut addr val dtum refScript) =
+getUtxoFromTxOut (UtxoIndexerConfig maybeTargetAddresses storeScriptRefFlag) txin (C.TxOut addr val dtum refScript) =
   if isAddressInTarget maybeTargetAddresses addrAny
     then
       Just $
@@ -557,7 +572,10 @@ getUtxoFromTxOut maybeTargetAddresses txin (C.TxOut addr val dtum refScript) =
   where
     addrAny = toAddr addr
     (datum', datumHash') = getScriptDataAndHash dtum
-    (inlineScript', inlineScriptHash') = getRefScriptAndHash refScript
+    (inlineScript', inlineScriptHash') =
+      if storeScriptRefFlag
+        then getRefScriptAndHash refScript
+        else (Nothing, Nothing)
 
 -- | get the inlineScript and inlineScriptHash
 getRefScriptAndHash
@@ -626,14 +644,14 @@ isAddressInTarget' targetAddresses utxo =
 
 balanceUtxoFromTx
   :: C.IsCardanoEra era
-  => Maybe TargetAddresses
+  => UtxoIndexerConfig
   -- ^ target addresses to filter for
   -> C.Tx era
   -> TxOutBalance
-balanceUtxoFromTx addrs (C.Tx txBody _) =
+balanceUtxoFromTx utxoIndexerConfig (C.Tx txBody _) =
   let txInputs = getInputs txBody -- adjusted txInput after phase-2 validation
       utxoRefs :: Map C.TxIn Utxo
-      utxoRefs = getUtxosFromTxBody addrs txBody
+      utxoRefs = getUtxosFromTxBody utxoIndexerConfig txBody
    in TxOutBalance utxoRefs txInputs
 
 -- A container to allow balance Utxos in the presensy of Spents

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -167,7 +167,7 @@ utxoWorker_
   -- ^ callback function used in the queryApi thread, needs to be non-blocking
   -> Utxo.Depth
   -> UtxoIndexerConfig
-  -- ^ utxo indexer configuration
+  -- ^ Utxo Indexer Configuration, containing targetAddresses and showReferenceScript flag
   -> Coordinator
   -> TChan (ChainSyncEvent (BlockInMode CardanoMode))
   -> FilePath
@@ -198,7 +198,7 @@ utxoWorker
   :: (Utxo.UtxoIndexer -> IO ())
   -- ^ callback function used in the queryApi thread
   -> UtxoIndexerConfig
-  -- ^ utxo indexer configuration
+  -- ^ Utxo Indexer Configuration, containing targetAddresses and showReferenceScript flag
   -> Worker
 utxoWorker callback utxoIndexerConfig securityParam coordinator path = do
   workerChannel <- atomically . dupTChan $ _channel coordinator

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -87,6 +87,7 @@ import Marconi.ChainIndex.Types (
   IndexingDepth (MaxIndexingDepth, MinIndexingDepth),
   SecurityParam (SecurityParam),
   TargetAddresses,
+  UtxoIndexerConfig,
  )
 import Marconi.ChainIndex.Utils qualified as Utils
 import Marconi.Core.Storable qualified as Storable
@@ -165,13 +166,13 @@ utxoWorker_
   :: (Utxo.UtxoIndexer -> IO ())
   -- ^ callback function used in the queryApi thread, needs to be non-blocking
   -> Utxo.Depth
-  -> Maybe TargetAddresses
-  -- ^ Target addresses to filter for
+  -> UtxoIndexerConfig
+  -- ^ utxo indexer configuration
   -> Coordinator
   -> TChan (ChainSyncEvent (BlockInMode CardanoMode))
   -> FilePath
   -> IO (IO (), C.ChainPoint)
-utxoWorker_ callback depth maybeTargetAddresses Coordinator{_barrier, _errorVar} ch path = do
+utxoWorker_ callback depth utxoIndexerConfig Coordinator{_barrier, _errorVar} ch path = do
   ix <- toException $ Utxo.open path depth False -- open SQLite with depth=depth and DO NOT perform SQLite vacuum
   -- TODO consider adding a CLI param to allow user to perfomr Vaccum or not.
   cp <- toException $ Storable.resumeFromStorage $ view Storable.handle ix
@@ -185,11 +186,10 @@ utxoWorker_ callback depth maybeTargetAddresses Coordinator{_barrier, _errorVar}
       readMVar index >>= callback -- refresh the query STM/CPS with new storage pointers/counters state
       event <- atomically . readTChan $ ch
       case event of
-        RollForward (BlockInMode block _) _ct -> do
-          let utxoEvents = Utxo.getUtxoEventsFromBlock maybeTargetAddresses block
-          void $ updateWith index _errorVar $ Storable.insert utxoEvents
-          loop index
-        RollBackward cp _ct -> do
+        RollForward (BlockInMode block _) _ct ->
+          let utxoEvents = Utxo.getUtxoEventsFromBlock utxoIndexerConfig block
+           in void $ updateWith index _errorVar $ Storable.insert utxoEvents
+        RollBackward cp _ct ->
           void $ updateWith index _errorVar $ Storable.rewind cp
 
       loop index
@@ -197,12 +197,19 @@ utxoWorker_ callback depth maybeTargetAddresses Coordinator{_barrier, _errorVar}
 utxoWorker
   :: (Utxo.UtxoIndexer -> IO ())
   -- ^ callback function used in the queryApi thread
-  -> Maybe TargetAddresses
-  -- ^ Target addresses to filter for
+  -> UtxoIndexerConfig
+  -- ^ utxo indexer configuration
   -> Worker
-utxoWorker callback maybeTargetAddresses securityParam coordinator path = do
+utxoWorker callback utxoIndexerConfig securityParam coordinator path = do
   workerChannel <- atomically . dupTChan $ _channel coordinator
-  (loop, cp) <- utxoWorker_ callback (Utxo.Depth $ fromIntegral securityParam) maybeTargetAddresses coordinator workerChannel path
+  (loop, cp) <-
+    utxoWorker_
+      callback
+      (Utxo.Depth $ fromIntegral securityParam)
+      utxoIndexerConfig
+      coordinator
+      workerChannel
+      path
   void $ forkIO loop
   return cp
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -232,21 +232,14 @@ instance Ord Utxo where
 instance FromJSON Utxo where
   parseJSON (Object v) =
     Utxo
-      <$> v
-        .: "address"
+      <$> v .: "address"
       <*> (C.TxIn <$> v .: "txId" <*> v .: "txIx")
-      <*> v
-        .: "datum"
-      <*> v
-        .: "datumHash"
-      <*> v
-        .: "value"
-      <*> v
-        .: "inlineScript"
-      <*> v
-        .: "inlineScriptHash"
-      <*> v
-        .: "txIndexInBlock"
+      <*> v .: "datum"
+      <*> v .: "datumHash"
+      <*> v .: "value"
+      <*> v .: "inlineScript"
+      <*> v .: "inlineScriptHash"
+      <*> v .: "txIndexInBlock"
   parseJSON _ = mempty
 
 instance ToJSON Utxo where
@@ -277,10 +270,8 @@ toChainPointRow cp = ChainPointRow <$> C.chainPointToSlotNo cp <*> C.chainPointT
 instance FromJSON ChainPointRow where
   parseJSON (Object v) =
     ChainPointRow
-      <$> v
-        .: "slotNo"
-      <*> v
-        .: "blockHeaderHash"
+      <$> v .: "slotNo"
+      <*> v .: "blockHeaderHash"
   parseJSON _ = mempty
 
 instance ToJSON ChainPointRow where
@@ -337,11 +328,9 @@ instance FromJSON UtxoRow where
             (Just s', Just bh', Just txId') -> Just $ SpentInfo (ChainPointRow s' bh') txId'
             _error -> fail "Inconsistent spent info"
      in UtxoRow
-          <$> v
-            .: "utxo"
+          <$> v .: "utxo"
           <*> (ChainPointRow <$> v .: "slotNo" <*> v .: "blockHeaderHash")
-          <*> v
-            .: "blockNo"
+          <*> v .: "blockNo"
           <*> parseSpentInfo
   parseJSON _ = mempty
 
@@ -1063,7 +1052,7 @@ toAddr (C.AddressInEra (C.ShelleyAddressInEra _) addr) = C.AddressShelley addr
 getUtxoEventsFromBlock
   :: C.IsCardanoEra era
   => UtxoIndexerConfig
-  -- ^ UtxoIndexer configuratio
+  -- ^ Utxo Indexer Configuration, containing targetAddresses and showReferenceScript flag
   -> C.Block era
   -> StorableEvent UtxoHandle
   -- ^ UtxoEvents are stored in storage after conversion to UtxoRow
@@ -1074,7 +1063,7 @@ getUtxoEventsFromBlock utxoIndexerConfig (C.Block (C.BlockHeader slotNo hsh bloc
 getUtxoEvents
   :: C.IsCardanoEra era
   => UtxoIndexerConfig
-  -- ^ UtxoIndexer configuratio
+  -- ^ Utxo Indexer Configuration, containing targetAddresses and showReferenceScript flag
   -> [C.Tx era]
   -> C.ChainPoint
   -> C.BlockNo
@@ -1102,10 +1091,11 @@ getTxOutFromTxBodyContent C.TxBodyContent{C.txOuts, C.txReturnCollateral, C.txSc
   where
     collateral C.TxReturnCollateralNone = []
     collateral (C.TxReturnCollateral _ txout) = [txout]
+
 getUtxosFromTxBody
   :: (C.IsCardanoEra era)
   => UtxoIndexerConfig
-  -- ^ UtxoIndexer configuratio
+  -- ^ Utxo Injdexer Configuration, containing targetAddresses and showReferenceScript flag
   -> C.TxBody era
   -> TxIndexInBlock
   -> Map C.TxIn Utxo
@@ -1127,7 +1117,7 @@ getUtxosFromTxBody utxoIndexerConfig txBody@(C.TxBody txBodyContent@C.TxBodyCont
 
 getUtxoFromTxOut
   :: UtxoIndexerConfig
-  -- ^ UtxoIndexer configuration
+  -- ^ Utxo Indexer Configuration, containing targetAddresses and showReferenceScript flag
   -> C.TxIn
   -- ^ unique id and position of this transaction
   -> C.TxOut C.CtxTx era
@@ -1154,7 +1144,7 @@ getUtxoFromTxOut (UtxoIndexerConfig maybeTargetAddresses storeReferenceScript) _
     (_inlineScript, _inlineScriptHash) =
       if storeReferenceScript
         then getRefScriptAndHash refScript
-        else (Nothing, Nothing)
+        else (Nothing, Nothing) -- supress saving ReferenceScript and its hash
 
 -- | get the inlineScript and inlineScriptHash
 getRefScriptAndHash
@@ -1224,7 +1214,7 @@ isAddressInTarget' targetAddresses utxo =
 balanceUtxoFromTx
   :: C.IsCardanoEra era
   => UtxoIndexerConfig
-  -- ^ UtxoIndexer configuration
+  -- ^ Utxo Indexer Configuration, containing targetAddresses and showReferenceScript flag
   -> (C.Tx era, TxIndexInBlock)
   -> TxOutBalance
 balanceUtxoFromTx utxoIndexerConfig (C.Tx txBody _, txIndexInBlock') =

--- a/marconi-chain-index/src/Marconi/ChainIndex/Types.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Types.hs
@@ -8,6 +8,9 @@ module Marconi.ChainIndex.Types (
   -- * Addresses alias used to query marconi
   TargetAddresses,
 
+  -- * Utxo indexer related configs
+  UtxoIndexerConfig (..),
+
   -- * Aliases for the current Cardano era
   CurrentEra,
   pattern AsCurrentEra,
@@ -21,7 +24,6 @@ module Marconi.ChainIndex.Types (
   -- * Database file names
   utxoDbName,
   addressDatumDbName,
-  datumDbName,
   scriptTxDbName,
   epochStateDbName,
   mintBurnDbName,
@@ -39,6 +41,13 @@ import Database.SQLite.Simple.ToField qualified as SQL
 
 -- | Typre represents non empty list of Bech32 Shelley compatable addresses
 type TargetAddresses = NonEmpty (C.Address C.ShelleyAddr)
+
+data UtxoIndexerConfig = UtxoIndexerConfig
+  { ucTargetAddresses :: Maybe TargetAddresses
+  -- ^ List of address utxo indexer to follow
+  , ucEnableUtxoTxOutRef :: Bool
+  -- ^ enable utxo indexer to store txOut refScript
+  }
 
 -- | An alias for the current era, to ease the transition from one era to the next one
 type CurrentEra = C.BabbageEra
@@ -77,9 +86,6 @@ utxoDbName = "utxo.db"
 
 addressDatumDbName :: FilePath
 addressDatumDbName = "addressdatum.db"
-
-datumDbName :: FilePath
-datumDbName = "datum.db"
 
 scriptTxDbName :: FilePath
 scriptTxDbName = "scripttx.db"

--- a/marconi-chain-index/src/Marconi/ChainIndex/Types.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Types.hs
@@ -8,7 +8,7 @@ module Marconi.ChainIndex.Types (
   -- * Addresses alias used to query marconi
   TargetAddresses,
 
-  -- * Utxo indexer related configs
+  -- * Utxo Indexer Configuration, containing targetAddresses and showReferenceScript flag
   UtxoIndexerConfig (..),
 
   -- * Aliases for the current Cardano era
@@ -39,7 +39,7 @@ import Data.Word (Word64)
 import Database.SQLite.Simple.FromField qualified as SQL
 import Database.SQLite.Simple.ToField qualified as SQL
 
--- | Typre represents non empty list of Bech32 Shelley compatable addresses
+-- | Type represents non empty list of Bech32 Shelley compatable addresses
 type TargetAddresses = NonEmpty (C.Address C.ShelleyAddr)
 
 data UtxoIndexerConfig = UtxoIndexerConfig

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
@@ -26,6 +26,7 @@ import Marconi.ChainIndex.Indexers.MintBurn (MintBurnHandle)
 import Marconi.ChainIndex.Indexers.Utxo (UtxoHandle)
 import Marconi.ChainIndex.Types as Export (IndexingDepth, TargetAddresses)
 import Marconi.Core.Storable (State, StorableQuery)
+
 import Network.Wai.Handler.Warp (Settings)
 
 -- | Type represents http port for JSON-RPC
@@ -36,6 +37,8 @@ data CliArgs = CliArgs
   -- ^ Path to the node config
   , dbDir :: !FilePath
   -- ^ Directory path containing the SQLite database files
+  , enableUtxoTxOutRef :: !Bool
+  -- ^ enable storing txout refScript,
   , httpPort :: !(Maybe Int)
   -- ^ optional tcp/ip port number for JSON-RPC http server
   , networkId :: !C.NetworkId

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
@@ -37,8 +37,6 @@ data CliArgs = CliArgs
   -- ^ Path to the node config
   , dbDir :: !FilePath
   -- ^ Directory path containing the SQLite database files
-  , enableUtxoTxOutRef :: !Bool
-  -- ^ enable storing txout refScript,
   , httpPort :: !(Maybe Int)
   -- ^ optional tcp/ip port number for JSON-RPC http server
   , networkId :: !C.NetworkId

--- a/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
@@ -78,7 +78,7 @@ bootstrapIndexers args env = do
           { ucTargetAddresses = CLI.targetAddresses args
           , ucEnableUtxoTxOutRef = False --  we do not save scriptRef for sidechain
           }
-  let indexers =
+      indexers =
         [
           ( utxoWorker addressUtxoCallback utxoIndexerConfig
           , Just $ dbPath </> utxoDbName

--- a/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
@@ -22,6 +22,10 @@ parserCliArgs =
           <> Opt.help "Path to node configuration which you are connecting to."
       )
     <*> Cli.commonDbDir
+    <*> Opt.switch
+      ( Opt.long "enable-utxo-reference-script"
+          <> Opt.help "enable utxo indexers to store reference script of a Utxo."
+      )
     <*> Cli.commonMaybePort
     <*> Cli.pNetworkId
     <*> Cli.commonMinIndexingDepth

--- a/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
@@ -22,10 +22,6 @@ parserCliArgs =
           <> Opt.help "Path to node configuration which you are connecting to."
       )
     <*> Cli.commonDbDir
-    <*> Opt.switch
-      ( Opt.long "enable-utxo-reference-script"
-          <> Opt.help "enable utxo indexers to store reference script of a Utxo."
-      )
     <*> Cli.commonMaybePort
     <*> Cli.pNetworkId
     <*> Cli.commonMinIndexingDepth


### PR DESCRIPTION
Add CLI parameter to the Utxo indexer  to optionally enabling persisting the  ReferenceScript, inlineScript and the corresponding hash in the Utxo SQLite table, unspentTransactions.

- For sidechain, this parameter will be set to `False` indicating we do not save ReferenceSctips.

- For marconi-chain-index, this parameter by default is set to Enabled, saving the ReferenceScript. Users may turn it off using CLI parameter.  

For additional detail, see [PLT-5571](https://input-output.atlassian.net/browse/PLT-5571)


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
