### PR TITLE
Replace tryReadTMVar with readTMVar when querying the indexers in marconi-sidechain.

### DIFF
--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochState.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/EpochState.hs
@@ -17,13 +17,12 @@ import Control.Concurrent qualified as STM
 import Control.Concurrent.Async qualified as IO
 import Control.Concurrent.STM qualified as STM
 import Control.Exception (catch)
-import Control.Monad (forever, void, when)
+import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson ((.=))
 import Data.Aeson qualified as J
 import Data.ByteString.Lazy qualified as BL
 import Data.List qualified as List
-import Data.Map qualified as Map
 import GHC.Stack (HasCallStack)
 import Hedgehog qualified as H
 import Hedgehog.Extras.Test qualified as HE
@@ -163,14 +162,15 @@ test = integration . HE.runFinallies . TN.workspace "chairman" $ \tempAbsPath ->
          in indexerWorker `catch` handleException :: IO ()
 
   found <- liftIO IO.newEmptyMVar
-  liftIO $ (IO.link =<<) $ IO.async $ forever $ do
-    (_, event) <- IO.readChan indexedTxs
-    case Map.lookup poolVKey (EpochState.epochStateEventSDD event) of
-      Just lovelace ->
-        when (lovelace == totalStakedLovelace) $
-          IO.putMVar found (EpochState.epochStateEventEpochNo event) -- Event found!
-      Nothing ->
-        return ()
+  -- TODO Uncomment once we support notifications.
+  -- liftIO $ (IO.link =<<) $ IO.async $ forever $ do
+  --   (_, event) <- IO.readChan indexedTxs
+  --   case Map.lookup poolVKey (EpochState.epochStateEventSDD event) of
+  --     Just lovelace ->
+  --       when (lovelace == totalStakedLovelace) $
+  --         IO.putMVar found (EpochState.epochStateEventEpochNo event) -- Event found!
+  --     Nothing ->
+  --       return ()
 
   -- This is filled when the epoch stakepool size has been indexed
   Just epochNo <- liftIO $ IO.takeMVar found

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/EpochState.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/EpochState.hs
@@ -6,7 +6,7 @@ module Marconi.Sidechain.Api.Query.Indexers.EpochState (
 ) where
 
 import Cardano.Api qualified as C
-import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, tryReadTMVar)
+import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, readTMVar)
 import Control.Lens ((^.))
 import Control.Monad.Except (runExceptT)
 import Control.Monad.STM (STM, atomically)
@@ -51,18 +51,15 @@ queryActiveSDDByEpochNo
   :: SidechainEnv
   -- ^ Query run time environment
   -> Word64
-  -- ^ Bech32 Address
+  -- ^ Epoch number
   -> IO (Either QueryExceptions GetEpochActiveStakePoolDelegationResult)
-  -- ^ Plutus address conversion error may occur
 queryActiveSDDByEpochNo env epochNo = do
   -- We must stop the indexer inserts before doing the query.
   epochStateIndexer <-
     atomically $
-      tryReadTMVar $
+      readTMVar $
         env ^. sidechainEnvIndexers . sidechainEpochStateIndexer . epochStateIndexerEnvIndexer
-  case epochStateIndexer of
-    Nothing -> pure $ Left $ QueryError "Failed to read EpochState indexer"
-    Just indexer -> query indexer
+  query epochStateIndexer
   where
     query indexer = do
       res <-
@@ -79,18 +76,15 @@ queryNonceByEpochNo
   :: SidechainEnv
   -- ^ Query run time environment
   -> Word64
-  -- ^ Bech32 Address
+  -- ^ Epoch number
   -> IO (Either QueryExceptions GetEpochNonceResult)
-  -- ^ Plutus address conversion error may occur
 queryNonceByEpochNo env epochNo = do
   -- We must stop the indexer inserts before doing the query.
   epochStateIndexer <-
     atomically $
-      tryReadTMVar $
+      readTMVar $
         env ^. sidechainEnvIndexers . sidechainEpochStateIndexer . epochStateIndexerEnvIndexer
-  case epochStateIndexer of
-    Nothing -> pure $ Left $ QueryError "Failed to read EpochState indexer"
-    Just indexer -> query indexer
+  query epochStateIndexer
   where
     query indexer = do
       res <-

--- a/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
@@ -21,7 +21,7 @@ import Marconi.ChainIndex.Types (
   ucTargetAddresses,
   utxoDbName,
  )
-import Marconi.Core.Storable (State, StorableEvent)
+import Marconi.Core.Storable (State)
 import Marconi.Sidechain.Api.Query.Indexers.EpochState qualified as EpochState
 import Marconi.Sidechain.Api.Query.Indexers.MintBurn qualified as MintBurn
 import Marconi.Sidechain.Api.Query.Indexers.Utxo qualified as AddressUtxo
@@ -61,13 +61,12 @@ bootstrapIndexers args env = do
       addressUtxoCallback =
         atomically
           . AddressUtxo.updateEnvState (env ^. CLI.sidechainEnvIndexers . CLI.sidechainAddressUtxoIndexer)
-      epochStateCallback :: (State EpochStateHandle, StorableEvent EpochStateHandle) -> IO ()
+  let epochStateCallback :: State EpochStateHandle -> IO ()
       epochStateCallback =
         atomically
           . EpochState.updateEnvState
             (env ^. CLI.sidechainEnvIndexers . CLI.sidechainEpochStateIndexer . CLI.epochStateIndexerEnvIndexer)
-          . fst
-      mintBurnCallback :: State MintBurnHandle -> IO ()
+  let mintBurnCallback :: State MintBurnHandle -> IO ()
       dbPath = CLI.dbDir args
       mintBurnCallback =
         atomically


### PR DESCRIPTION
With tryReadTMVar, if the read failed because the indexer was not available yet, it would return an empty result. Now, with readTMVar, it restarts until the indexer is available after the write action has finished.

Doing so, we also needed to make sure that each indexer worker calls the callback when the indexer is initially created.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
