### PR TITLE
Replaced ChainPoint in UtxoEvent with BlockInfo

### DIFF
--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -28,7 +28,7 @@ import Gen.Marconi.ChainIndex.Mockchain (
   genTxBodyContentFromTxinsWihtPhase2Validation,
  )
 import Hedgehog (Gen)
-import Marconi.ChainIndex.Indexers.Utxo (StorableEvent (UtxoEvent), Utxo (Utxo), UtxoHandle, _address)
+import Marconi.ChainIndex.Indexers.Utxo (BlockInfo (BlockInfo), StorableEvent (UtxoEvent), Utxo (Utxo), UtxoHandle, _address)
 import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Types (TxIndexInBlock)
 import Test.Gen.Cardano.Api.Typed qualified as CGen
@@ -68,7 +68,8 @@ genUtxoEventsWithTxs' txOutToUtxo = do
             Set.fromList $
               mapMaybe (`Map.lookup` utxoMap) $
                 Set.toList utxos
-       in UtxoEvent resolvedUtxos spentTxOuts (C.ChainPoint slotNo blockHeaderHash) blockNo
+       in -- We don't care about the timestamp or the epochNo, so we put default values.
+          UtxoEvent resolvedUtxos spentTxOuts (BlockInfo slotNo blockHeaderHash blockNo 0 1)
 
     getUtxosFromTx :: (C.Tx C.BabbageEra, TxIndexInBlock) -> Map C.TxIn Utxo
     getUtxosFromTx (C.Tx txBody@(C.TxBody txBodyContent) _, txIndexInBlock) =

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -30,8 +30,8 @@ import Marconi.ChainIndex.Indexers.Utxo (
   datumHash,
   txIn,
   txIndexInBlock,
-  urBlockNo,
   urCreationBlockHeaderHash,
+  urCreationBlockNo,
   urCreationSlotNo,
   urSpentSlotNo,
   urSpentTxId,
@@ -167,7 +167,7 @@ withQueryAction env query =
                 AddressUtxoResult
                   (row ^. urCreationSlotNo)
                   (row ^. urCreationBlockHeaderHash)
-                  (row ^. urBlockNo)
+                  (row ^. urCreationBlockNo)
                   (row ^. urUtxo . txIndexInBlock)
                   (row ^. urUtxo . txIn)
                   (row ^. urUtxo . address)


### PR DESCRIPTION
In the UtxoEvent, we used to have `ChainPoint` which could be `ChainPointAtGenesis`. However, it should be impossible to create an event which is at genesis. Therefore, we can just use `BlockInfo` instead which contains additional info such as `BlockNo`, `BlockTimestamp` and `EpochNo`. 

This change also means that we don't need to handle the `Genesis` case in most of the code, thus we gain some nice refactoring.

@berewt Part I've contemplated is if we should put the `BlockInfo` in a separate table, and then the `utxo` table and the `spent` table would point to the correct row in the `BlockInfo` table. Thoughts?

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
