### PR TITLE
Reduce the need of `Point` type family

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -40,7 +40,7 @@ type UtxoIndexer = Core.MixedIndexer Core.SQLiteIndexer Core.ListIndexer Utxo.Ut
 -- | Extract the timed information from a block
 blockTimedEvent
   :: C.BlockInMode C.CardanoMode
-  -> Core.TimedEvent (C.BlockInMode C.CardanoMode)
+  -> Core.TimedEvent C.ChainPoint (C.BlockInMode C.CardanoMode)
 blockTimedEvent b@(C.BlockInMode (C.Block (C.BlockHeader slotNo hsh _) _) _) =
   Core.TimedEvent (C.ChainPoint slotNo hsh) b
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -38,11 +38,11 @@ type instance Core.Point (C.BlockInMode C.CardanoMode) = C.ChainPoint
 type UtxoIndexer = Core.MixedIndexer Core.SQLiteIndexer Core.ListIndexer Utxo.UtxoEvent
 
 -- | Extract the timed information from a block
-blockTimedEvent
+blockTimed
   :: C.BlockInMode C.CardanoMode
-  -> Core.TimedEvent C.ChainPoint (C.BlockInMode C.CardanoMode)
-blockTimedEvent b@(C.BlockInMode (C.Block (C.BlockHeader slotNo hsh _) _) _) =
-  Core.TimedEvent (C.ChainPoint slotNo hsh) b
+  -> Core.Timed C.ChainPoint (C.BlockInMode C.CardanoMode)
+blockTimed b@(C.BlockInMode (C.Block (C.BlockHeader slotNo hsh _) _) _) =
+  Core.Timed (C.ChainPoint slotNo hsh) b
 
 -- | Create a worker for the utxo indexer
 utxoWorker -- Should go in Utxo module?
@@ -75,7 +75,7 @@ mkEventStream q =
   let processEvent
         :: ChainSyncEvent (C.BlockInMode C.CardanoMode)
         -> Core.ProcessedInput (C.BlockInMode C.CardanoMode)
-      processEvent (RollForward x _) = Core.Index $ blockTimedEvent x
+      processEvent (RollForward x _) = Core.Index $ blockTimed x
       processEvent (RollBackward x _) = Core.Rollback x
    in S.mapM_ $ atomically . writeTBQueue q . processEvent
 

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -51,9 +51,9 @@ genUtxoEvents' txOutToUtxo = do
   Core.indexAll timedEvents Core.mkListIndexer
 
 -- | Generate ShelleyEra UtxoEvent
-genShelleyEraUtxoEvents :: Gen (Core.TimedEvent Utxo.UtxoEvent)
+genShelleyEraUtxoEvents :: Gen (Core.TimedEvent C.ChainPoint Utxo.UtxoEvent)
 genShelleyEraUtxoEvents = do
-  events :: [Core.TimedEvent Utxo.UtxoEvent] <- genUtxoEventsWithTxs <&> fmap fst
+  events :: [Core.TimedEvent C.ChainPoint Utxo.UtxoEvent] <- genUtxoEventsWithTxs <&> fmap fst
   utxoEvents' :: [Utxo.UtxoEvent] <-
     forM
       events
@@ -65,9 +65,9 @@ genShelleyEraUtxoEvents = do
       cp = foldr max C.ChainPointAtGenesis (events ^.. folded . Core.point)
   pure $ Core.TimedEvent cp (fold utxoEvents')
 
-genShelleyEraUtxoEventsAtChainPoint :: C.ChainPoint -> Gen (Core.TimedEvent Utxo.UtxoEvent)
+genShelleyEraUtxoEventsAtChainPoint :: C.ChainPoint -> Gen (Core.TimedEvent C.ChainPoint Utxo.UtxoEvent)
 genShelleyEraUtxoEventsAtChainPoint cp = do
-  events :: [Core.TimedEvent Utxo.UtxoEvent] <-
+  events :: [Core.TimedEvent C.ChainPoint Utxo.UtxoEvent] <-
     genUtxoEventsWithTxs <&> fmap fst
   utxoEvent' :: [Utxo.UtxoEvent] <-
     forM
@@ -78,16 +78,16 @@ genShelleyEraUtxoEventsAtChainPoint cp = do
       )
   pure $ Core.TimedEvent cp (fold utxoEvent')
 
-genUtxoEventsWithTxs :: Gen [(Core.TimedEvent Utxo.UtxoEvent, MockBlock C.BabbageEra)]
+genUtxoEventsWithTxs :: Gen [(Core.TimedEvent C.ChainPoint Utxo.UtxoEvent, MockBlock C.BabbageEra)]
 genUtxoEventsWithTxs = genUtxoEventsWithTxs' convertTxOutToUtxo
 
 genUtxoEventsWithTxs'
   :: (C.TxIn -> C.TxOut C.CtxTx C.BabbageEra -> Utxo)
-  -> Gen [(Core.TimedEvent Utxo.UtxoEvent, MockBlock C.BabbageEra)]
+  -> Gen [(Core.TimedEvent C.ChainPoint Utxo.UtxoEvent, MockBlock C.BabbageEra)]
 genUtxoEventsWithTxs' txOutToUtxo =
   fmap (\block -> (getTimedEventFromBlock block, block)) <$> genMockchain
   where
-    getTimedEventFromBlock :: MockBlock C.BabbageEra -> Core.TimedEvent Utxo.UtxoEvent
+    getTimedEventFromBlock :: MockBlock C.BabbageEra -> Core.TimedEvent C.ChainPoint Utxo.UtxoEvent
     getTimedEventFromBlock (MockBlock (BlockHeader slotNo blockHeaderHash _blockNo) txs) =
       let (TxOutBalance utxos spentTxOuts) = foldMap txOutBalanceFromTx txs
           utxoMap = foldMap getUtxosFromTx txs

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -51,44 +51,44 @@ genUtxoEvents' txOutToUtxo = do
   Core.indexAll timedEvents Core.mkListIndexer
 
 -- | Generate ShelleyEra UtxoEvent
-genShelleyEraUtxoEvents :: Gen (Core.TimedEvent C.ChainPoint Utxo.UtxoEvent)
+genShelleyEraUtxoEvents :: Gen (Core.Timed C.ChainPoint Utxo.UtxoEvent)
 genShelleyEraUtxoEvents = do
-  events :: [Core.TimedEvent C.ChainPoint Utxo.UtxoEvent] <- genUtxoEventsWithTxs <&> fmap fst
+  events :: [Core.Timed C.ChainPoint Utxo.UtxoEvent] <- genUtxoEventsWithTxs <&> fmap fst
   utxoEvents' :: [Utxo.UtxoEvent] <-
     forM
       events
-      ( \(Core.TimedEvent _ uev@(Utxo.UtxoEvent utxos _)) -> do
+      ( \(Core.Timed _ uev@(Utxo.UtxoEvent utxos _)) -> do
           utxos' <- forM (Set.toList utxos) (\u -> CGen.genAddressShelley <&> flip utxoAddressOverride u)
           pure $ uev{Utxo._ueUtxos = Set.fromList utxos'}
       )
   let cp :: C.ChainPoint
       cp = foldr max C.ChainPointAtGenesis (events ^.. folded . Core.point)
-  pure $ Core.TimedEvent cp (fold utxoEvents')
+  pure $ Core.Timed cp (fold utxoEvents')
 
-genShelleyEraUtxoEventsAtChainPoint :: C.ChainPoint -> Gen (Core.TimedEvent C.ChainPoint Utxo.UtxoEvent)
+genShelleyEraUtxoEventsAtChainPoint :: C.ChainPoint -> Gen (Core.Timed C.ChainPoint Utxo.UtxoEvent)
 genShelleyEraUtxoEventsAtChainPoint cp = do
-  events :: [Core.TimedEvent C.ChainPoint Utxo.UtxoEvent] <-
+  events :: [Core.Timed C.ChainPoint Utxo.UtxoEvent] <-
     genUtxoEventsWithTxs <&> fmap fst
   utxoEvent' :: [Utxo.UtxoEvent] <-
     forM
       events
-      ( \(Core.TimedEvent _ uev@(Utxo.UtxoEvent utxos _)) -> do
+      ( \(Core.Timed _ uev@(Utxo.UtxoEvent utxos _)) -> do
           utxos' <- forM (Set.toList utxos) (\u -> CGen.genAddressShelley <&> flip utxoAddressOverride u)
           pure $ uev{Utxo._ueUtxos = Set.fromList utxos'}
       )
-  pure $ Core.TimedEvent cp (fold utxoEvent')
+  pure $ Core.Timed cp (fold utxoEvent')
 
-genUtxoEventsWithTxs :: Gen [(Core.TimedEvent C.ChainPoint Utxo.UtxoEvent, MockBlock C.BabbageEra)]
+genUtxoEventsWithTxs :: Gen [(Core.Timed C.ChainPoint Utxo.UtxoEvent, MockBlock C.BabbageEra)]
 genUtxoEventsWithTxs = genUtxoEventsWithTxs' convertTxOutToUtxo
 
 genUtxoEventsWithTxs'
   :: (C.TxIn -> C.TxOut C.CtxTx C.BabbageEra -> Utxo)
-  -> Gen [(Core.TimedEvent C.ChainPoint Utxo.UtxoEvent, MockBlock C.BabbageEra)]
+  -> Gen [(Core.Timed C.ChainPoint Utxo.UtxoEvent, MockBlock C.BabbageEra)]
 genUtxoEventsWithTxs' txOutToUtxo =
-  fmap (\block -> (getTimedEventFromBlock block, block)) <$> genMockchain
+  fmap (\block -> (getTimedFromBlock block, block)) <$> genMockchain
   where
-    getTimedEventFromBlock :: MockBlock C.BabbageEra -> Core.TimedEvent C.ChainPoint Utxo.UtxoEvent
-    getTimedEventFromBlock (MockBlock (BlockHeader slotNo blockHeaderHash _blockNo) txs) =
+    getTimedFromBlock :: MockBlock C.BabbageEra -> Core.Timed C.ChainPoint Utxo.UtxoEvent
+    getTimedFromBlock (MockBlock (BlockHeader slotNo blockHeaderHash _blockNo) txs) =
       let (TxOutBalance utxos spentTxOuts) = foldMap txOutBalanceFromTx txs
           utxoMap = foldMap getUtxosFromTx txs
           resolvedUtxos :: Set Utxo.Utxo =
@@ -97,7 +97,7 @@ genUtxoEventsWithTxs' txOutToUtxo =
                 Set.toList utxos
           cp = C.ChainPoint slotNo blockHeaderHash
           spents :: Set Utxo.Spent = Set.map Utxo.Spent spentTxOuts
-       in Core.TimedEvent cp (Utxo.UtxoEvent resolvedUtxos spents)
+       in Core.Timed cp (Utxo.UtxoEvent resolvedUtxos spents)
     getUtxosFromTx :: C.Tx C.BabbageEra -> Map C.TxIn Utxo
     getUtxosFromTx (C.Tx txBody@(C.TxBody txBodyContent) _) =
       let txId = C.getTxId txBody

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/Utxo/UtxoIndex.hs
@@ -85,14 +85,6 @@ tests =
         propLastChainPointOnRewindIndexer
     ]
 
--- Fro test purpose only. We do not address ChainPoint, `Point`
--- We do not address Ord or Eq of `Point`. Tests are such that Points are constant.
-instance Eq e => Eq (Core.TimedEvent e) where
-  u == u' = u ^. Core.event == u' ^. Core.event
-
-instance Ord e => Ord (Core.TimedEvent e) where
-  u `compare` u' = (u ^. Core.event) `compare` (u' ^. Core.event)
-
 {- | The purpose of test is to make sure All Queried Utxo's are unSpent.
   The Utxo store consists of:
   * in-memory store:  UtxoEvents before they're flushed to SQlite
@@ -110,7 +102,7 @@ instance Ord e => Ord (Core.TimedEvent e) where
 allqueryUtxosShouldBeUnspent :: Property
 allqueryUtxosShouldBeUnspent = property $ do
   cp <- forAll $ genChainPoint' genBlockNo genSlotNo -- generate some non genesis chainpoints
-  timedUtxoEvent :: Core.TimedEvent Utxo.UtxoEvent <-
+  timedUtxoEvent :: Core.TimedEvent C.ChainPoint Utxo.UtxoEvent <-
     forAll $ genShelleyEraUtxoEventsAtChainPoint cp
   conn <- liftIO $ Utxo.initSQLite ":memory:"
   let (keep, flush) = (1, 1) -- small memory to force SQL flush
@@ -119,13 +111,13 @@ allqueryUtxosShouldBeUnspent = property $ do
   mixedIndexer <-
     Core.indexEither timedUtxoEvent indexer
       >>= Hedgehog.evalEither
-  let unprocessedUtxos :: [Core.TimedEvent Utxo.Utxo]
+  let unprocessedUtxos :: [Core.TimedEvent C.ChainPoint Utxo.Utxo]
       unprocessedUtxos = Utxo.timedUtxosFromTimedUtxoEvent timedUtxoEvent
 
       queryUtxos :: [Utxo.QueryUtxoByAddress]
       queryUtxos = mkQuery unprocessedUtxos cp
 
-  retrievedUtxos :: [Core.TimedEvent Utxo.Utxo] <-
+  retrievedUtxos :: [Core.TimedEvent C.ChainPoint Utxo.Utxo] <-
     liftIO $ concat . filter (not . null) <$> traverse (\q -> Core.query cp q mixedIndexer) queryUtxos
 
   let inputsFromTimedUtxoEvent :: [C.TxIn] -- get all the TxIn from quried UtxoRows
@@ -151,7 +143,7 @@ propTxInWhenPhase2ValidationFails = property $ do
   tx@(C.Tx (C.TxBody C.TxBodyContent{..}) _) <- forAll genTxWithCollateral
   cp <- forAll $ genChainPoint' genBlockNo genSlotNo
   let utxoIndexerConfig = UtxoIndexerConfig{ucTargetAddresses = Nothing, ucEnableUtxoTxOutRef = True} -- \^ index all addresses, and store scriptRef
-      event :: Core.TimedEvent Utxo.UtxoEvent
+      event :: Core.TimedEvent C.ChainPoint Utxo.UtxoEvent
       event = Core.TimedEvent cp $ Utxo.getUtxoEvents utxoIndexerConfig [tx]
       computedTxins :: [C.TxIn]
       computedTxins = Set.toList $ Set.map Utxo.unSpent (event ^. Core.event . Utxo.ueInputs)
@@ -189,7 +181,7 @@ propSaveAndQueryUtxoEvents :: Property
 propSaveAndQueryUtxoEvents = property $ do
   -- we'll do many inserts, but keep the same connection to force DB flush
   cp <- forAll $ genChainPoint' genBlockNo genSlotNo -- generate some non genesis chainpoints
-  timedUtxoEvent :: Core.TimedEvent Utxo.UtxoEvent <-
+  timedUtxoEvent :: Core.TimedEvent C.ChainPoint Utxo.UtxoEvent <-
     forAll $ genShelleyEraUtxoEventsAtChainPoint cp
   conn <- liftIO $ Utxo.initSQLite ":memory:"
   let (keep, flush) = (1, 3) -- small memory to force SQL flush
@@ -206,19 +198,20 @@ propSaveAndQueryUtxoEvents = property $ do
     liftIO
       (SQL.query_ conn "SELECT count(1) from spent" :: IO [Integer])
 
-  let unprocessedUtxos :: [Core.TimedEvent Utxo.Utxo]
+  let unprocessedUtxos :: [Core.TimedEvent C.ChainPoint Utxo.Utxo]
       unprocessedUtxos = Utxo.timedUtxosFromTimedUtxoEvent timedUtxoEvent
 
       queryUtxos :: [Utxo.QueryUtxoByAddress]
       queryUtxos = mkQuery unprocessedUtxos cp
-      inMemoryEvents :: [Core.TimedEvent Utxo.UtxoEvent] = mixedIndexer ^. Core.inMemory . Core.events
+      inMemoryEvents :: [Core.TimedEvent C.ChainPoint Utxo.UtxoEvent] =
+        mixedIndexer ^. Core.inMemory . Core.events
       -- in-memory events are utxoEvents. We need to convert them to Utxos for the purpose of this test
       inMemoryUtxos = length $ concatMap Utxo.timedUtxosFromTimedUtxoEvent inMemoryEvents
 
       inDbSyncPoint :: C.ChainPoint
       inDbSyncPoint = mixedIndexer ^. Core.inDatabase . Core.dbLastSync
 
-  retrievedUtxoMixed :: [Core.TimedEvent Utxo.Utxo] <-
+  retrievedUtxoMixed :: [Core.TimedEvent C.ChainPoint Utxo.Utxo] <-
     liftIO $ concat . filter (not . null) <$> traverse (\q -> Core.query cp q mixedIndexer) queryUtxos
   -- test the mixedIndexer
   Hedgehog.assert $ -- make sure we've saved both Utxo and Spent
@@ -242,7 +235,7 @@ propSaveAndQueryUtxoEvents = property $ do
 propMixedIndexerAndListIndexerProvideTheSameQueryResult :: Property
 propMixedIndexerAndListIndexerProvideTheSameQueryResult = property $ do
   cp <- forAll $ genChainPoint' genBlockNo genSlotNo -- generate some non genesis chainpoints
-  timedUtxoEvent :: Core.TimedEvent Utxo.UtxoEvent <-
+  timedUtxoEvent :: Core.TimedEvent C.ChainPoint Utxo.UtxoEvent <-
     forAll $ genShelleyEraUtxoEventsAtChainPoint cp
   conn <- liftIO $ Utxo.initSQLite ":memory:"
   let (keep, flush) = (0, 0) -- small memory to force SQL flush
@@ -257,7 +250,7 @@ propMixedIndexerAndListIndexerProvideTheSameQueryResult = property $ do
   [utxosSQLCount] <-
     liftIO
       (SQL.query_ conn "SELECT count(1) from unspent_transactions" :: IO [Integer])
-  let unprocessedUtxos :: [Core.TimedEvent Utxo.Utxo]
+  let unprocessedUtxos :: [Core.TimedEvent C.ChainPoint Utxo.Utxo]
       unprocessedUtxos = Utxo.timedUtxosFromTimedUtxoEvent timedUtxoEvent
 
       queryUtxos :: [Utxo.QueryUtxoByAddress]
@@ -298,7 +291,7 @@ propMixedIndexerAndListIndexerProvideTheSameQueryResult = property $ do
 propListIndexerAndMixedIndexerInMemroyIndexerProvideTheSameQueryResult :: Property
 propListIndexerAndMixedIndexerInMemroyIndexerProvideTheSameQueryResult = property $ do
   cp <- forAll $ genChainPoint' genBlockNo genSlotNo -- generate some non genesis chainpoints
-  timedUtxoEvent :: Core.TimedEvent Utxo.UtxoEvent <-
+  timedUtxoEvent :: Core.TimedEvent C.ChainPoint Utxo.UtxoEvent <-
     forAll $ genShelleyEraUtxoEventsAtChainPoint cp
   conn <- liftIO $ Utxo.initSQLite ":memory:"
   let -- we force mixedIndexer to use in-memory indexer only
@@ -316,7 +309,7 @@ propListIndexerAndMixedIndexerInMemroyIndexerProvideTheSameQueryResult = propert
   [utxosSQLCount] <-
     liftIO
       (SQL.query_ conn "SELECT count(1) from unspent_transactions" :: IO [Integer])
-  let unprocessedUtxos :: [Core.TimedEvent Utxo.Utxo]
+  let unprocessedUtxos :: [Core.TimedEvent C.ChainPoint Utxo.Utxo]
       unprocessedUtxos = Utxo.timedUtxosFromTimedUtxoEvent timedUtxoEvent
 
       queryUtxos :: [Utxo.QueryUtxoByAddress]
@@ -346,11 +339,11 @@ TODO change the test name to prop.......
 propListIndexerUpdatesLastSyncPoint :: Property
 propListIndexerUpdatesLastSyncPoint = property $ do
   cp <- forAll $ genChainPoint' genBlockNo genSlotNo -- generate some non genesis chainpoints
-  timedUtxoEvent :: Core.TimedEvent Utxo.UtxoEvent <-
+  timedUtxoEvent :: Core.TimedEvent C.ChainPoint Utxo.UtxoEvent <-
     forAll $ genShelleyEraUtxoEventsAtChainPoint cp
   listIndexer :: Core.ListIndexer Utxo.UtxoEvent <-
     Core.index timedUtxoEvent Core.mkListIndexer -- add events to in-memory listIndexer
-  let unProcessedUtxos :: [Core.TimedEvent Utxo.Utxo] -- These Utxos, are not processed yet and may have spent in them
+  let unProcessedUtxos :: [Core.TimedEvent C.ChainPoint Utxo.Utxo] -- These Utxos, are not processed yet and may have spent in them
       unProcessedUtxos = Utxo.timedUtxosFromTimedUtxoEvent timedUtxoEvent
 
       queryUtxos :: [Utxo.QueryUtxoByAddress]
@@ -384,7 +377,7 @@ propUtxoQueryAtLatestPointShouldBeSameAsQueryingAll :: Property
 propUtxoQueryAtLatestPointShouldBeSameAsQueryingAll = property $ do
   highSlotNo <- forAll $ Gen.integral $ Range.constantFrom 7 5 20
   chainPoints :: [C.ChainPoint] <- forAll $ genChainPoints 2 highSlotNo
-  timedUtxoEvents :: [Core.TimedEvent Utxo.UtxoEvent] <-
+  timedUtxoEvents :: [Core.TimedEvent C.ChainPoint Utxo.UtxoEvent] <-
     forAll $ traverse genShelleyEraUtxoEventsAtChainPoint chainPoints
   conn <- liftIO $ Utxo.initSQLite ":memory:"
   let (keep, flush) = (1, 1) -- small memory to force SQL flush
@@ -411,7 +404,7 @@ propUtxoQueryAtLatestPointShouldBeSameAsQueryingAll = property $ do
 -}
 propUsingAllAddressesOfTxsAsTargetAddressesShouldReturnUtxosAsIfNoFilterWasApplied :: Property
 propUsingAllAddressesOfTxsAsTargetAddressesShouldReturnUtxosAsIfNoFilterWasApplied = property $ do
-  timedUtxoEventsWithTxs :: [(Core.TimedEvent Utxo.UtxoEvent, MockBlock C.BabbageEra)] <-
+  timedUtxoEventsWithTxs :: [(Core.TimedEvent C.ChainPoint Utxo.UtxoEvent, MockBlock C.BabbageEra)] <-
     forAll genUtxoEventsWithTxs
   forM_ timedUtxoEventsWithTxs $ \(expectedTimedUtxoEvent, block) -> do
     let txs = mockBlockTxs block
@@ -421,13 +414,13 @@ propUsingAllAddressesOfTxsAsTargetAddressesShouldReturnUtxosAsIfNoFilterWasAppli
       isJust expectedAddresses
     cover 1 "No target addresses are provided" $
       isNothing expectedAddresses
-    let actualTimedUtxoEvents :: Core.TimedEvent Utxo.UtxoEvent
+    let actualTimedUtxoEvents :: Core.TimedEvent C.ChainPoint Utxo.UtxoEvent
         actualTimedUtxoEvents =
           Core.TimedEvent
             (expectedTimedUtxoEvent ^. Core.point)
             $ Utxo.getUtxoEvents utxoIndexerConfig txs
     let -- (expectedTimedUtxoEvent ^. Core.event . Utxo.ueUtxos)
-        filteredExpectedUtxoEvent :: Core.TimedEvent Utxo.UtxoEvent
+        filteredExpectedUtxoEvent :: Core.TimedEvent C.ChainPoint Utxo.UtxoEvent
         filteredExpectedUtxoEvent =
           expectedTimedUtxoEvent
             & Core.event . Utxo.ueUtxos
@@ -550,7 +543,7 @@ propLastChainPointOnRewindIndexer = property $ do
   fromDbSlotNosAfter === tail fromDbSlotNosBefore -- SQLite should reflect the new rwound chainpoint
 
 -- | make a unique query for every  Utxo
-mkQuery :: [Core.TimedEvent Utxo.Utxo] -> C.ChainPoint -> [Utxo.QueryUtxoByAddress]
+mkQuery :: [Core.TimedEvent C.ChainPoint Utxo.Utxo] -> C.ChainPoint -> [Utxo.QueryUtxoByAddress]
 mkQuery timedUtxos cp =
   let addressesToQuery :: [C.AddressAny]
       addressesToQuery =

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -196,7 +196,6 @@ module Marconi.Core.Experiment (
   TimedEvent (TimedEvent),
   point,
   event,
-  mapTimedEvent,
 
   -- ** Core typeclasses
   HasGenesis (..),
@@ -529,7 +528,7 @@ import Marconi.Core.Experiment.Transformer.WithPruning (
  )
 import Marconi.Core.Experiment.Transformer.WithTracer (HasTracerConfig (tracer), WithTracer, tracer, withTracer)
 import Marconi.Core.Experiment.Transformer.WithTransform (HasTransformConfig (..), WithTransform, withTransform)
-import Marconi.Core.Experiment.Type (IndexerError (..), Point, QueryError (..), Result, TimedEvent (..), event, mapTimedEvent, point)
+import Marconi.Core.Experiment.Type (IndexerError (..), Point, QueryError (..), Result, TimedEvent (..), event, point)
 import Marconi.Core.Experiment.Worker (
   ProcessedInput (..),
   Worker,

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -100,7 +100,7 @@
         It can be a time, a slot number, a block, whatever information that tracks when
         an event happen.
 
-        2. It's already enough to index `TimedEvent` of the events you defined at step one
+        2. It's already enough to index `Timed` of the events you defined at step one
         of your indexer and to proceed to rollback.
         You can already test it, creating an indexer with `listIndexer`.
 
@@ -131,7 +131,7 @@
         And a more complex one, where several inserts are needed.
 
             In the simple case, you can use 'singleInsertSQLiteIndexr' to create your indexer.
-            It requires the definition of a @param@ type, a data representation of the TimedEvent
+            It requires the definition of a @param@ type, a data representation of the Timed
             that SQLite can process (it should have a @ToRow@ instance).
             You also need to declare a 'InsertRecord' type instance that is a list of this @param@.
 
@@ -193,7 +193,7 @@ module Marconi.Core.Experiment (
   --     3. @query@ that defines what can be asked to an @indexer@.
   Point,
   Result,
-  TimedEvent (TimedEvent),
+  Timed (Timed),
   point,
   event,
 
@@ -528,7 +528,7 @@ import Marconi.Core.Experiment.Transformer.WithPruning (
  )
 import Marconi.Core.Experiment.Transformer.WithTracer (HasTracerConfig (tracer), WithTracer, tracer, withTracer)
 import Marconi.Core.Experiment.Transformer.WithTransform (HasTransformConfig (..), WithTransform, withTransform)
-import Marconi.Core.Experiment.Type (IndexerError (..), Point, QueryError (..), Result, TimedEvent (..), event, point)
+import Marconi.Core.Experiment.Type (IndexerError (..), Point, QueryError (..), Result, Timed (..), event, point)
 import Marconi.Core.Experiment.Worker (
   ProcessedInput (..),
   Worker,

--- a/marconi-core/src/Marconi/Core/Experiment/Class.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Class.hs
@@ -23,7 +23,7 @@ module Marconi.Core.Experiment.Class (
 
 import Control.Monad.Except (ExceptT, MonadError, runExceptT)
 import Data.Foldable (foldlM, foldrM)
-import Marconi.Core.Experiment.Type (Point, QueryError, Result, TimedEvent)
+import Marconi.Core.Experiment.Type (Point, QueryError, Result, Timed)
 
 -- IsIndex
 
@@ -38,7 +38,7 @@ class Monad m => IsIndex m event indexer where
   -- | index an event at a given point in time
   index
     :: Eq (Point event)
-    => TimedEvent (Point event) event
+    => Timed (Point event) event
     -> indexer event
     -> m (indexer event)
 
@@ -47,7 +47,7 @@ class Monad m => IsIndex m event indexer where
   -- The events must be sorted in ascending order (the most recent first)
   indexAll
     :: (Ord (Point event), Traversable f)
-    => f (TimedEvent (Point event) event)
+    => f (Timed (Point event) event)
     -> indexer event
     -> m (indexer event)
   indexAll = flip $ foldlM (flip index)
@@ -57,7 +57,7 @@ class Monad m => IsIndex m event indexer where
   -- The events must be sorted in descending order (the most recent first)
   indexAllDescending
     :: (Ord (Point event), Traversable f)
-    => f (TimedEvent (Point event) event)
+    => f (Timed (Point event) event)
     -> indexer event
     -> m (indexer event)
   indexAllDescending = flip $ foldrM index
@@ -73,7 +73,7 @@ indexEither
   :: ( IsIndex (ExceptT err m) event indexer
      , Eq (Point event)
      )
-  => TimedEvent (Point event) event
+  => Timed (Point event) event
   -> indexer event
   -> m (Either err (indexer event))
 indexEither evt = runExceptT . index evt
@@ -84,7 +84,7 @@ indexAllEither
      , Traversable f
      , Ord (Point event)
      )
-  => f (TimedEvent (Point event) event)
+  => f (Timed (Point event) event)
   -> indexer event
   -> m (Either err (indexer event))
 indexAllEither evt = runExceptT . indexAll evt
@@ -95,7 +95,7 @@ indexAllDescendingEither
      , Traversable f
      , Ord (Point event)
      )
-  => f (TimedEvent (Point event) event)
+  => f (Timed (Point event) event)
   -> indexer event
   -> m (Either err (indexer event))
 indexAllDescendingEither evt = runExceptT . indexAllDescending evt

--- a/marconi-core/src/Marconi/Core/Experiment/Class.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Class.hs
@@ -38,7 +38,7 @@ class Monad m => IsIndex m event indexer where
   -- | index an event at a given point in time
   index
     :: Eq (Point event)
-    => TimedEvent event
+    => TimedEvent (Point event) event
     -> indexer event
     -> m (indexer event)
 
@@ -47,7 +47,7 @@ class Monad m => IsIndex m event indexer where
   -- The events must be sorted in ascending order (the most recent first)
   indexAll
     :: (Ord (Point event), Traversable f)
-    => f (TimedEvent event)
+    => f (TimedEvent (Point event) event)
     -> indexer event
     -> m (indexer event)
   indexAll = flip $ foldlM (flip index)
@@ -57,7 +57,7 @@ class Monad m => IsIndex m event indexer where
   -- The events must be sorted in descending order (the most recent first)
   indexAllDescending
     :: (Ord (Point event), Traversable f)
-    => f (TimedEvent event)
+    => f (TimedEvent (Point event) event)
     -> indexer event
     -> m (indexer event)
   indexAllDescending = flip $ foldrM index
@@ -73,7 +73,7 @@ indexEither
   :: ( IsIndex (ExceptT err m) event indexer
      , Eq (Point event)
      )
-  => TimedEvent event
+  => TimedEvent (Point event) event
   -> indexer event
   -> m (Either err (indexer event))
 indexEither evt = runExceptT . index evt
@@ -84,7 +84,7 @@ indexAllEither
      , Traversable f
      , Ord (Point event)
      )
-  => f (TimedEvent event)
+  => f (TimedEvent (Point event) event)
   -> indexer event
   -> m (Either err (indexer event))
 indexAllEither evt = runExceptT . indexAll evt
@@ -95,7 +95,7 @@ indexAllDescendingEither
      , Traversable f
      , Ord (Point event)
      )
-  => f (TimedEvent event)
+  => f (TimedEvent (Point event) event)
   -> indexer event
   -> m (Either err (indexer event))
 indexAllDescendingEither evt = runExceptT . indexAllDescending evt

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/ListIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/ListIndexer.hs
@@ -28,7 +28,7 @@ import Marconi.Core.Experiment.Type (Point, TimedEvent, point)
 
 -- | The constructor is not exposed, use 'listIndexer' instead.
 data ListIndexer event = ListIndexer
-  { _events :: [TimedEvent event]
+  { _events :: [TimedEvent (Point event) event]
   -- ^ Stored @event@s, associated with their history 'Point'
   , _latest :: Point event
   -- ^ Ease access to the latest sync point
@@ -69,7 +69,7 @@ instance Applicative m => Rollbackable m event ListIndexer where
         isIndexBeforeRollback :: ListIndexer event -> Bool
         isIndexBeforeRollback x = x ^. latest < p
 
-        isEventAfterRollback :: TimedEvent event -> Bool
+        isEventAfterRollback :: TimedEvent (Point event) event -> Bool
         isEventAfterRollback x = x ^. point > p
      in pure $
           if isIndexBeforeRollback ix

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/ListIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/ListIndexer.hs
@@ -24,11 +24,11 @@ import Marconi.Core.Experiment.Class (
   Resetable (reset),
   Rollbackable (rollback),
  )
-import Marconi.Core.Experiment.Type (Point, TimedEvent, point)
+import Marconi.Core.Experiment.Type (Point, Timed, point)
 
 -- | The constructor is not exposed, use 'listIndexer' instead.
 data ListIndexer event = ListIndexer
-  { _events :: [TimedEvent (Point event) event]
+  { _events :: [Timed (Point event) event]
   -- ^ Stored @event@s, associated with their history 'Point'
   , _latest :: Point event
   -- ^ Ease access to the latest sync point
@@ -69,7 +69,7 @@ instance Applicative m => Rollbackable m event ListIndexer where
         isIndexBeforeRollback :: ListIndexer event -> Bool
         isIndexBeforeRollback x = x ^. latest < p
 
-        isEventAfterRollback :: TimedEvent (Point event) event -> Bool
+        isEventAfterRollback :: Timed (Point event) event -> Bool
         isEventAfterRollback x = x ^. point > p
      in pure $
           if isIndexBeforeRollback ix

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/MixedIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/MixedIndexer.hs
@@ -57,7 +57,7 @@ class Flushable m indexer where
     :: Word
     -- ^ How many event do we keep
     -> indexer event
-    -> m (Container indexer (TimedEvent event), indexer event)
+    -> m (Container indexer (TimedEvent (Point event) event), indexer event)
 
 instance Applicative m => Flushable m ListIndexer where
   type Container ListIndexer = []

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/MixedIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/MixedIndexer.hs
@@ -42,7 +42,7 @@ import Marconi.Core.Experiment.Transformer.IndexWrapper (
   wrappedIndexer,
   wrapperConfig,
  )
-import Marconi.Core.Experiment.Type (Point, TimedEvent)
+import Marconi.Core.Experiment.Type (Point, Timed)
 
 -- | Define a way to flush old events out of a container
 class Flushable m indexer where
@@ -57,7 +57,7 @@ class Flushable m indexer where
     :: Word
     -- ^ How many event do we keep
     -> indexer event
-    -> m (Container indexer (TimedEvent (Point event) event), indexer event)
+    -> m (Container indexer (Timed (Point event) event), indexer event)
 
 instance Applicative m => Flushable m ListIndexer where
   type Container ListIndexer = []

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
@@ -52,7 +52,7 @@ import Marconi.Core.Experiment.Type (
 data SQLInsertPlan event = forall a.
   SQL.ToRow a =>
   SQLInsertPlan
-  { planExtractor :: TimedEvent event -> [a]
+  { planExtractor :: TimedEvent (Point event) event -> [a]
   -- ^ How to transform the event into a type that can be handle by the database
   , planInsert :: SQL.Query
   -- ^ The insert statement for the extracted data
@@ -116,7 +116,7 @@ mkSingleInsertSqliteIndexer
   => SQL.ToRow param
   => HasGenesis (Point event)
   => SQL.Connection
-  -> (TimedEvent event -> param)
+  -> (TimedEvent (Point event) event -> param)
   -- ^ extract @param@ out of a 'TimedEvent'
   -> SQL.Query
   -- ^ the insert query
@@ -137,7 +137,7 @@ runIndexQueriesStep
   :: MonadIO m
   => MonadError IndexerError m
   => SQL.Connection
-  -> [TimedEvent event]
+  -> [TimedEvent (Point event) event]
   -> [SQLInsertPlan event]
   -> m ()
 runIndexQueriesStep _ _ [] = pure ()
@@ -156,7 +156,7 @@ runIndexQueries
   :: MonadIO m
   => MonadError IndexerError m
   => SQL.Connection
-  -> [TimedEvent event]
+  -> [TimedEvent (Point event) event]
   -> [[SQLInsertPlan event]]
   -> m ()
 runIndexQueries c = traverse_ . runIndexQueriesStep c

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
@@ -44,7 +44,7 @@ import Marconi.Core.Experiment.Type (
   Point,
   QueryError (AheadOfLastSync),
   Result,
-  TimedEvent,
+  Timed,
   point,
  )
 
@@ -52,7 +52,7 @@ import Marconi.Core.Experiment.Type (
 data SQLInsertPlan event = forall a.
   SQL.ToRow a =>
   SQLInsertPlan
-  { planExtractor :: TimedEvent (Point event) event -> [a]
+  { planExtractor :: Timed (Point event) event -> [a]
   -- ^ How to transform the event into a type that can be handle by the database
   , planInsert :: SQL.Query
   -- ^ The insert statement for the extracted data
@@ -83,7 +83,7 @@ mkSqliteIndexer
   => SQL.FromRow (Point event)
   => SQL.Connection
   -> [[SQLInsertPlan event]]
-  -- ^ extract @param@ out of a 'TimedEvent'
+  -- ^ extract @param@ out of a 'Timed'
   -> SQL.Query
   -- ^ the lastSyncQuery
   -> m (SQLiteIndexer event)
@@ -116,8 +116,8 @@ mkSingleInsertSqliteIndexer
   => SQL.ToRow param
   => HasGenesis (Point event)
   => SQL.Connection
-  -> (TimedEvent (Point event) event -> param)
-  -- ^ extract @param@ out of a 'TimedEvent'
+  -> (Timed (Point event) event -> param)
+  -- ^ extract @param@ out of a 'Timed'
   -> SQL.Query
   -- ^ the insert query
   -> SQL.Query
@@ -137,7 +137,7 @@ runIndexQueriesStep
   :: MonadIO m
   => MonadError IndexerError m
   => SQL.Connection
-  -> [TimedEvent (Point event) event]
+  -> [Timed (Point event) event]
   -> [SQLInsertPlan event]
   -> m ()
 runIndexQueriesStep _ _ [] = pure ()
@@ -156,7 +156,7 @@ runIndexQueries
   :: MonadIO m
   => MonadError IndexerError m
   => SQL.Connection
-  -> [TimedEvent (Point event) event]
+  -> [Timed (Point event) event]
   -> [[SQLInsertPlan event]]
   -> m ()
 runIndexQueries c = traverse_ . runIndexQueriesStep c

--- a/marconi-core/src/Marconi/Core/Experiment/Query.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Query.hs
@@ -21,7 +21,7 @@ import Marconi.Core.Experiment.Type (
   Point,
   QueryError (AheadOfLastSync, NotStoredAnymore),
   Result,
-  TimedEvent,
+  Timed,
   event,
   point,
  )
@@ -72,7 +72,7 @@ allEvents :: EventsMatchingQuery event
 allEvents = EventsMatchingQuery (const True)
 
 -- | The result of an @EventMatchingQuery@
-type instance Result (EventsMatchingQuery event) = [TimedEvent (Point event) event]
+type instance Result (EventsMatchingQuery event) = [Timed (Point event) event]
 
 instance
   (MonadError (QueryError (EventsMatchingQuery event)) m)

--- a/marconi-core/src/Marconi/Core/Experiment/Query.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Query.hs
@@ -17,7 +17,14 @@ import Control.Monad (when)
 import Control.Monad.Except (MonadError (catchError, throwError))
 import Marconi.Core.Experiment.Class (AppendResult (appendResult), Queryable (query), isAheadOfSync)
 import Marconi.Core.Experiment.Indexer.ListIndexer (ListIndexer, events)
-import Marconi.Core.Experiment.Type (QueryError (AheadOfLastSync, NotStoredAnymore), Result, TimedEvent, event, point)
+import Marconi.Core.Experiment.Type (
+  Point,
+  QueryError (AheadOfLastSync, NotStoredAnymore),
+  Result,
+  TimedEvent,
+  event,
+  point,
+ )
 
 -- | Get the event stored by the indexer at a given point in time
 data EventAtQuery event = EventAtQuery
@@ -65,7 +72,7 @@ allEvents :: EventsMatchingQuery event
 allEvents = EventsMatchingQuery (const True)
 
 -- | The result of an @EventMatchingQuery@
-type instance Result (EventsMatchingQuery event) = [TimedEvent event]
+type instance Result (EventsMatchingQuery event) = [TimedEvent (Point event) event]
 
 instance
   (MonadError (QueryError (EventsMatchingQuery event)) m)

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/IndexWrapper.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/IndexWrapper.hs
@@ -66,7 +66,7 @@ instance IndexerTrans (IndexWrapper config) where
 indexVia
   :: (IsIndex m event indexer, Eq (Point event))
   => Lens' s (indexer event)
-  -> TimedEvent event
+  -> TimedEvent (Point event) event
   -> s
   -> m s
 indexVia l = l . index
@@ -77,7 +77,7 @@ indexVia l = l . index
 indexAllDescendingVia
   :: (Ord (Point event), IsIndex m event indexer, Traversable f)
   => Lens' s (indexer event)
-  -> f (TimedEvent event)
+  -> f (TimedEvent (Point event) event)
   -> s
   -> m s
 indexAllDescendingVia l = l . indexAllDescending

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/IndexWrapper.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/IndexWrapper.hs
@@ -33,7 +33,7 @@ import Marconi.Core.Experiment.Class (
   Rollbackable (rollback),
   queryLatest,
  )
-import Marconi.Core.Experiment.Type (Point, QueryError, Result, TimedEvent)
+import Marconi.Core.Experiment.Type (Point, QueryError, Result, Timed)
 
 data IndexWrapper config indexer event = IndexWrapper
   { _wrapperConfig :: config event
@@ -66,7 +66,7 @@ instance IndexerTrans (IndexWrapper config) where
 indexVia
   :: (IsIndex m event indexer, Eq (Point event))
   => Lens' s (indexer event)
-  -> TimedEvent (Point event) event
+  -> Timed (Point event) event
   -> s
   -> m s
 indexVia l = l . index
@@ -77,7 +77,7 @@ indexVia l = l . index
 indexAllDescendingVia
   :: (Ord (Point event), IsIndex m event indexer, Traversable f)
   => Lens' s (indexer event)
-  -> f (TimedEvent (Point event) event)
+  -> f (Timed (Point event) event)
   -> s
   -> m s
 indexAllDescendingVia l = l . indexAllDescending

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithAggregate.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithAggregate.hs
@@ -47,7 +47,7 @@ import Marconi.Core.Experiment.Type (
   IndexerError (IndexerInternalError),
   Point,
   QueryError,
-  TimedEvent (TimedEvent),
+  Timed (Timed),
   event,
   point,
  )
@@ -119,7 +119,7 @@ instance
           case lastAggregateOrError of
             Left _ -> throwError $ IndexerInternalError "can't find last aggregate"
             Right agg -> pure $ agg <> asAggregate
-    let asOutput = TimedEvent point' event'
+    let asOutput = Timed point' event'
     indexVia unwrapMap asOutput indexer
 
   indexAllDescending events indexer = case sortOn (^. point) $ toList events of
@@ -136,10 +136,10 @@ instance
             case lastAggregateOrError of
               Left _ -> throwError $ IndexerInternalError "can't find last aggregate"
               Right agg -> pure $ agg <> asAggregate
-      let firstTimedEvent = TimedEvent (x ^. point) firstEvent
-      let toOutput' tacc te = TimedEvent (te ^. point) ((tacc ^. event) <> (event' $ te ^. event))
+      let firstTimed = Timed (x ^. point) firstEvent
+      let toOutput' tacc te = Timed (te ^. point) ((tacc ^. event) <> (event' $ te ^. event))
           asOutputs tacc es = scanl' toOutput' tacc es
-      indexAllDescendingVia unwrapMap (asOutputs firstTimedEvent xs) indexer
+      indexAllDescendingVia unwrapMap (asOutputs firstTimed xs) indexer
 
 instance
   (Point output ~ Point event, IsSync m output indexer)

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithAggregation.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithAggregation.hs
@@ -16,7 +16,7 @@ import Control.Lens (makeLenses)
 import Control.Lens.Operators ((^.))
 import Marconi.Core.Experiment.Class (IsIndex (index))
 import Marconi.Core.Experiment.Transformer.IndexWrapper (indexVia)
-import Marconi.Core.Experiment.Type (Point, TimedEvent (TimedEvent), event, point)
+import Marconi.Core.Experiment.Type (Point, Timed (Timed), event, point)
 
 data AggregationConfig output input = AggregationConfig
   { _transformEvent :: input -> output
@@ -39,7 +39,7 @@ instance
   index timedEvent indexer = do
     let point' = indexer ^. config . transformPoint $ timedEvent ^. point
     let asEvent =
-          TimedEvent
+          Timed
             point'
             (indexer ^. config . transformEvent $ timedEvent ^. event)
     indexVia aggregatedIndexer asEvent indexer

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCache.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCache.hs
@@ -50,12 +50,12 @@ import Marconi.Core.Experiment.Type (
   Point,
   QueryError (AheadOfLastSync),
   Result,
-  TimedEvent,
+  Timed,
  )
 
 data CacheConfig query event = CacheConfig
   { _configCache :: Map query (Result query)
-  , _configOnForward :: TimedEvent (Point event) event -> Result query -> Result query
+  , _configOnForward :: Timed (Point event) event -> Result query -> Result query
   }
 
 configCache :: Lens' (CacheConfig query event) (Map query (Result query))
@@ -69,7 +69,7 @@ configCacheEntries f cfg =
 configOnForward
   :: Getter
       (CacheConfig query event)
-      (TimedEvent (Point event) event -> Result query -> Result query)
+      (Timed (Point event) event -> Result query -> Result query)
 configOnForward = to _configOnForward
 
 {- | Setup a cache for some requests.
@@ -98,7 +98,7 @@ deriving via
 -}
 withCache
   :: Ord query
-  => (TimedEvent (Point event) event -> Result query -> Result query)
+  => (Timed (Point event) event -> Result query -> Result query)
   -> indexer event
   -> WithCache query indexer event
 withCache _configOnForward =
@@ -139,7 +139,7 @@ instance
 onForward
   :: Getter
       (WithCache query indexer event)
-      (TimedEvent (Point event) event -> Result query -> Result query)
+      (Timed (Point event) event -> Result query -> Result query)
 onForward = cacheWrapper . wrapperConfig . configOnForward
 
 {- | Add a cache for a specific query.

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCache.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCache.hs
@@ -55,7 +55,7 @@ import Marconi.Core.Experiment.Type (
 
 data CacheConfig query event = CacheConfig
   { _configCache :: Map query (Result query)
-  , _configOnForward :: TimedEvent event -> Result query -> Result query
+  , _configOnForward :: TimedEvent (Point event) event -> Result query -> Result query
   }
 
 configCache :: Lens' (CacheConfig query event) (Map query (Result query))
@@ -69,7 +69,7 @@ configCacheEntries f cfg =
 configOnForward
   :: Getter
       (CacheConfig query event)
-      (TimedEvent event -> Result query -> Result query)
+      (TimedEvent (Point event) event -> Result query -> Result query)
 configOnForward = to _configOnForward
 
 {- | Setup a cache for some requests.
@@ -98,7 +98,7 @@ deriving via
 -}
 withCache
   :: Ord query
-  => (TimedEvent event -> Result query -> Result query)
+  => (TimedEvent (Point event) event -> Result query -> Result query)
   -> indexer event
   -> WithCache query indexer event
 withCache _configOnForward =
@@ -139,7 +139,7 @@ instance
 onForward
   :: Getter
       (WithCache query indexer event)
-      (TimedEvent event -> Result query -> Result query)
+      (TimedEvent (Point event) event -> Result query -> Result query)
 onForward = cacheWrapper . wrapperConfig . configOnForward
 
 {- | Add a cache for a specific query.

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithDelay.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithDelay.hs
@@ -40,12 +40,12 @@ import Marconi.Core.Experiment.Transformer.IndexWrapper (
   wrappedIndexer,
   wrapperConfig,
  )
-import Marconi.Core.Experiment.Type (Point, TimedEvent, point)
+import Marconi.Core.Experiment.Type (Point, Timed, point)
 
 data DelayConfig event = DelayConfig
   { _configDelayCapacity :: Word
   , _configDelayLength :: Word
-  , _configDelayBuffer :: Seq (TimedEvent (Point event) event)
+  , _configDelayBuffer :: Seq (Timed (Point event) event)
   }
 
 makeLenses 'DelayConfig
@@ -117,7 +117,7 @@ instance
   where
   delayCapacity = unwrapMap . delayCapacity
 
-delayBuffer :: Lens' (WithDelay indexer event) (Seq (TimedEvent (Point event) event))
+delayBuffer :: Lens' (WithDelay indexer event) (Seq (Timed (Point event) event))
 delayBuffer = delayWrapper . wrapperConfig . configDelayBuffer
 
 delayLength :: Lens' (WithDelay indexer event) Word

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithDelay.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithDelay.hs
@@ -40,12 +40,12 @@ import Marconi.Core.Experiment.Transformer.IndexWrapper (
   wrappedIndexer,
   wrapperConfig,
  )
-import Marconi.Core.Experiment.Type (TimedEvent, point)
+import Marconi.Core.Experiment.Type (Point, TimedEvent, point)
 
 data DelayConfig event = DelayConfig
   { _configDelayCapacity :: Word
   , _configDelayLength :: Word
-  , _configDelayBuffer :: Seq (TimedEvent event)
+  , _configDelayBuffer :: Seq (TimedEvent (Point event) event)
   }
 
 makeLenses 'DelayConfig
@@ -117,7 +117,7 @@ instance
   where
   delayCapacity = unwrapMap . delayCapacity
 
-delayBuffer :: Lens' (WithDelay indexer event) (Seq (TimedEvent event))
+delayBuffer :: Lens' (WithDelay indexer event) (Seq (TimedEvent (Point event) event))
 delayBuffer = delayWrapper . wrapperConfig . configDelayBuffer
 
 delayLength :: Lens' (WithDelay indexer event) Word

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithTransform.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithTransform.hs
@@ -35,7 +35,7 @@ import Marconi.Core.Experiment.Transformer.IndexWrapper (
   resetVia,
   rollbackVia,
  )
-import Marconi.Core.Experiment.Type (Point, TimedEvent (TimedEvent), event, point)
+import Marconi.Core.Experiment.Type (Point, Timed (Timed), event, point)
 
 newtype TransformConfig output input = TransformConfig
   { _transformEventConfig :: input -> output
@@ -82,12 +82,12 @@ instance
   index timedEvent indexer = do
     let point' = timedEvent ^. point
         event' = indexer ^. transformEvent $ timedEvent ^. event
-        asOutput = TimedEvent point' event'
+        asOutput = Timed point' event'
     indexVia unwrapMap asOutput indexer
 
   indexAllDescending events indexer = do
     let event' = indexer ^. transformEvent
-        toOutput te = TimedEvent (te ^. point) (event' $ te ^. event)
+        toOutput te = Timed (te ^. point) (event' $ te ^. event)
         asOutputs = toOutput <$> events
     indexAllDescendingVia unwrapMap asOutputs indexer
 

--- a/marconi-core/src/Marconi/Core/Experiment/Type.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Type.hs
@@ -11,7 +11,7 @@ module Marconi.Core.Experiment.Type (
   -- * Types and type families
   Point,
   Result,
-  TimedEvent (TimedEvent),
+  Timed (Timed),
   point,
   event,
 
@@ -42,24 +42,24 @@ type family Point event
 type family Result query
 
 -- | Attach an event to a point in time
-data TimedEvent point event = TimedEvent
+data Timed point event = Timed
   { _point :: point
   , _event :: event
   }
 
-deriving stock instance (Show event, Show point) => Show (TimedEvent point event)
-deriving stock instance (Eq event, Eq point) => Eq (TimedEvent point event)
-deriving stock instance (Ord event, Ord point) => Ord (TimedEvent point event)
-deriving stock instance Functor (TimedEvent point)
-deriving stock instance Foldable (TimedEvent point)
-deriving stock instance Traversable (TimedEvent point)
+deriving stock instance (Show event, Show point) => Show (Timed point event)
+deriving stock instance (Eq event, Eq point) => Eq (Timed point event)
+deriving stock instance (Ord event, Ord point) => Ord (Timed point event)
+deriving stock instance Functor (Timed point)
+deriving stock instance Foldable (Timed point)
+deriving stock instance Traversable (Timed point)
 
 -- | When was this event created
-point :: Lens' (TimedEvent point event) point
+point :: Lens' (Timed point event) point
 point f te = fmap (\_point -> te{_point}) $ f $ _point te
 
 -- | A lens to get the event without its time information
-event :: Lens' (TimedEvent point event) event
+event :: Lens' (Timed point event) event
 event f te = fmap (\_event -> te{_event}) $ f $ _event te
 
 -- | Error that can occur when you index events

--- a/marconi-core/src/Marconi/Core/Experiment/Type.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Type.hs
@@ -43,25 +43,27 @@ type family Point event
 type family Result query
 
 -- | Attach an event to a point in time
-data TimedEvent event = TimedEvent
-  { _point :: Point event
+data TimedEvent point event = TimedEvent
+  { _point :: point
   , _event :: event
   }
 
-deriving stock instance (Show event, Show (Point event)) => Show (TimedEvent event)
+deriving stock instance (Show event, Show point) => Show (TimedEvent point event)
+deriving stock instance (Eq event, Eq point) => Eq (TimedEvent point event)
+deriving stock instance (Ord event, Ord point) => Ord (TimedEvent point event)
 
 {- | A functor like function for TimedEvent, which requires that both @a@ and @b@ have the same
  point instance.
 -}
-mapTimedEvent :: Point a ~ Point b => (a -> b) -> TimedEvent a -> TimedEvent b
+mapTimedEvent :: (a -> b) -> TimedEvent point a -> TimedEvent point b
 mapTimedEvent f (TimedEvent p x) = TimedEvent p $ f x
 
 -- | When was this event created
-point :: Lens' (TimedEvent event) (Point event)
+point :: Lens' (TimedEvent point event) point
 point f te = fmap (\_point -> te{_point}) $ f $ _point te
 
 -- | A lens to get the event without its time information
-event :: Lens' (TimedEvent event) event
+event :: Lens' (TimedEvent point event) event
 event f te = fmap (\_event -> te{_event}) $ f $ _event te
 
 -- | Error that can occur when you index events

--- a/marconi-core/src/Marconi/Core/Experiment/Type.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Type.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -51,6 +51,8 @@ deriving stock instance (Show event, Show point) => Show (TimedEvent point event
 deriving stock instance (Eq event, Eq point) => Eq (TimedEvent point event)
 deriving stock instance (Ord event, Ord point) => Ord (TimedEvent point event)
 deriving stock instance Functor (TimedEvent point)
+deriving stock instance Foldable (TimedEvent point)
+deriving stock instance Traversable (TimedEvent point)
 
 -- | When was this event created
 point :: Lens' (TimedEvent point event) point

--- a/marconi-core/src/Marconi/Core/Experiment/Type.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Type.hs
@@ -14,7 +14,6 @@ module Marconi.Core.Experiment.Type (
   TimedEvent (TimedEvent),
   point,
   event,
-  mapTimedEvent,
 
   -- * Error types
   IndexerError (..),
@@ -51,12 +50,7 @@ data TimedEvent point event = TimedEvent
 deriving stock instance (Show event, Show point) => Show (TimedEvent point event)
 deriving stock instance (Eq event, Eq point) => Eq (TimedEvent point event)
 deriving stock instance (Ord event, Ord point) => Ord (TimedEvent point event)
-
-{- | A functor like function for TimedEvent, which requires that both @a@ and @b@ have the same
- point instance.
--}
-mapTimedEvent :: (a -> b) -> TimedEvent point a -> TimedEvent point b
-mapTimedEvent f (TimedEvent p x) = TimedEvent p $ f x
+deriving stock instance Functor (TimedEvent point)
 
 -- | When was this event created
 point :: Lens' (TimedEvent point event) point

--- a/marconi-core/src/Marconi/Core/Experiment/Worker.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Worker.hs
@@ -67,7 +67,7 @@ data ProcessedInput event
   = -- | A rollback happen and indexers need to go back to the given point in time
     Rollback (Point event)
   | -- | A new event has to be indexed
-    Index (TimedEvent event)
+    Index (TimedEvent (Point event) event)
 
 -- Create workers
 
@@ -123,7 +123,7 @@ startWorker chan tokens (Worker ix transformInput hoistError errorBox) =
       unlockCoordinator = do
         Con.signalQSemN tokens 1
 
-      fresherThan :: Ord (Point event) => TimedEvent event -> Point event -> Bool
+      fresherThan :: Ord (Point event) => TimedEvent (Point event) event -> Point event -> Bool
       fresherThan evt p = evt ^. point > p
 
       indexEvent timedEvent = Con.modifyMVar_ ix $ \indexer -> do

--- a/marconi-core/src/Marconi/Core/Experiment/Worker.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Worker.hs
@@ -34,7 +34,7 @@ import Marconi.Core.Experiment.Class (
   IsSync (lastSyncPoint),
   Rollbackable (rollback),
  )
-import Marconi.Core.Experiment.Type (IndexerError, Point, TimedEvent (TimedEvent), event, point)
+import Marconi.Core.Experiment.Type (IndexerError, Point, Timed (Timed), event, point)
 
 -- Type alias for the type classes that are required to build a worker for an indexer
 type WorkerIndexer n event indexer =
@@ -67,7 +67,7 @@ data ProcessedInput event
   = -- | A rollback happen and indexers need to go back to the given point in time
     Rollback (Point event)
   | -- | A new event has to be indexed
-    Index (TimedEvent (Point event) event)
+    Index (Timed (Point event) event)
 
 -- Create workers
 
@@ -106,7 +106,7 @@ mapIndex
   -> ProcessedInput event
   -> f (ProcessedInput event')
 mapIndex _ (Rollback p) = pure $ Rollback p
-mapIndex f (Index timedEvent) = Index . TimedEvent (timedEvent ^. point) <$> f (timedEvent ^. event)
+mapIndex f (Index timedEvent) = Index . Timed (timedEvent ^. point) <$> f (timedEvent ^. event)
 
 {- | The worker notify its coordinator that it's ready
  and starts waiting for new events and process them as they come
@@ -123,7 +123,7 @@ startWorker chan tokens (Worker ix transformInput hoistError errorBox) =
       unlockCoordinator = do
         Con.signalQSemN tokens 1
 
-      fresherThan :: Ord (Point event) => TimedEvent (Point event) event -> Point event -> Bool
+      fresherThan :: Ord (Point event) => Timed (Point event) event -> Point event -> Bool
       fresherThan evt p = evt ^. point > p
 
       indexEvent timedEvent = Con.modifyMVar_ ix $ \indexer -> do

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -238,7 +238,7 @@ process
   -> indexer event
   -> m (indexer event)
 process = \case
-  Insert ix evt -> Core.index (Core.TimedEvent ix evt)
+  Insert ix evt -> Core.index (Core.Timed ix evt)
   Rollback n -> Core.rollback n
 
 genChain
@@ -500,7 +500,7 @@ instance
   where
   query =
     let rowToResult (Core.EventsMatchingQuery predicate) =
-          fmap (uncurry Core.TimedEvent)
+          fmap (uncurry Core.Timed)
             . filter (predicate . snd)
      in Core.querySQLiteIndexerWith
           (\p _ -> [":point" SQL.:= p])
@@ -721,7 +721,7 @@ buildCacheFor
   => Ord query
   => Ord (Core.Point event)
   => query
-  -> (Core.TimedEvent (Core.Point event) event -> Core.Result query -> Core.Result query)
+  -> (Core.Timed (Core.Point event) event -> Core.Result query -> Core.Result query)
   -> indexer event
   -> m (Core.WithCache query indexer event)
 buildCacheFor q onForward indexer = do
@@ -736,7 +736,7 @@ withCacheRunner
   => Ord query
   => Ord (Core.Point event)
   => query
-  -> (Core.TimedEvent (Core.Point event) event -> Core.Result query -> Core.Result query)
+  -> (Core.Timed (Core.Point event) event -> Core.Result query -> Core.Result query)
   -> IndexerTestRunner m event wrapped
   -> IndexerTestRunner m event (Core.WithCache query wrapped)
 withCacheRunner q onForward wRunner =

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -721,7 +721,7 @@ buildCacheFor
   => Ord query
   => Ord (Core.Point event)
   => query
-  -> (Core.TimedEvent event -> Core.Result query -> Core.Result query)
+  -> (Core.TimedEvent (Core.Point event) event -> Core.Result query -> Core.Result query)
   -> indexer event
   -> m (Core.WithCache query indexer event)
 buildCacheFor q onForward indexer = do
@@ -736,7 +736,7 @@ withCacheRunner
   => Ord query
   => Ord (Core.Point event)
   => query
-  -> (Core.TimedEvent event -> Core.Result query -> Core.Result query)
+  -> (Core.TimedEvent (Core.Point event) event -> Core.Result query -> Core.Result query)
   -> IndexerTestRunner m event wrapped
   -> IndexerTestRunner m event (Core.WithCache query wrapped)
 withCacheRunner q onForward wRunner =


### PR DESCRIPTION
`TimedEvent` is great to attach a chainPoint to a datatype, it was hard to manipulate though, because each type should have a `Point` type instance to use it, and we couldn't map on it because of the type family.

- Change `TimedEvent event` to `TimedEvent point event`.
- Add `Functor`, `Foldable` and `Traverse` to the experimental indexer.
- Refactor code to take advantage of it

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
