### PR TITLE
Bugfix CLI parsing

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/CLI.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/CLI.hs
@@ -167,16 +167,16 @@ optionsParser =
     <*> commonMinIndexingDepth
     <*> commonDbDir
     <*> Opt.switch
+      ( Opt.long "enable-txoutref"
+          <> Opt.help "enable txout ref storage."
+      )
+    <*> Opt.switch
       ( Opt.long "disable-utxo"
           <> Opt.help "disable utxo indexers."
       )
     <*> Opt.switch
       ( Opt.long "disable-address-datum"
           <> Opt.help "disable address->datum indexers."
-      )
-    <*> Opt.switch
-      ( Opt.long "disable-datum"
-          <> Opt.help "disable datum indexers."
       )
     <*> Opt.switch
       ( Opt.long "disable-script-tx"

--- a/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___disable_address_data.help
+++ b/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___disable_address_data.help
@@ -8,8 +8,8 @@ Usage: marconi-chain-index [--version] (-s|--socket-path FILE-PATH)
                            [(-n|--slot-no SLOT-NO)
                              (-b|--block-header-hash BLOCK-HEADER-HASH)] 
                            [--max-indexing-depth | --min-indexing-depth NATURAL]
-                           (-d|--db-dir DIR) [--disable-utxo] 
-                           [--disable-address-datum] [--disable-datum] 
+                           (-d|--db-dir DIR) [--enable-txoutref] 
+                           [--disable-utxo] [--disable-address-datum] 
                            [--disable-script-tx] 
                            [--disable-epoch-stakepool-size] [--disable-mintburn]
                            [(-a|--addresses-to-index BECH32-ADDRESS)] 

--- a/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___help.help
+++ b/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___help.help
@@ -6,8 +6,8 @@ Usage: marconi-chain-index [--version] (-s|--socket-path FILE-PATH)
                            [(-n|--slot-no SLOT-NO)
                              (-b|--block-header-hash BLOCK-HEADER-HASH)] 
                            [--max-indexing-depth | --min-indexing-depth NATURAL]
-                           (-d|--db-dir DIR) [--disable-utxo] 
-                           [--disable-address-datum] [--disable-datum] 
+                           (-d|--db-dir DIR) [--enable-txoutref] 
+                           [--disable-utxo] [--disable-address-datum] 
                            [--disable-script-tx] 
                            [--disable-epoch-stakepool-size] [--disable-mintburn]
                            [(-a|--addresses-to-index BECH32-ADDRESS)] 
@@ -28,9 +28,9 @@ Available options:
                            Depth of an event before it is indexed
   -d,--db-dir DIR          Directory path where all SQLite databases are
                            located.
+  --enable-txoutref        enable txout ref storage.
   --disable-utxo           disable utxo indexers.
   --disable-address-datum  disable address->datum indexers.
-  --disable-datum          disable datum indexers.
   --disable-script-tx      disable script-tx indexers.
   --disable-epoch-stakepool-size
                            disable epoch stakepool size indexers.


### PR DESCRIPTION
The optional storage of utxo introduced a flag and disabled another one, but didn't modify the CLI parsing accordingly.
As a consequence, we were assigning the wrong options during the parsing.

It's fixed.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
