### PR TITLE
PLT-6440 Deserialisation of txInputs doesn't fail when no inputs were found

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -623,10 +623,11 @@ instance FromRow UtxoResult where
           concatenatedTxIds <- field
           case concatenatedTxIds of
             Nothing -> pure []
+            Just xs | xs == "" -> pure []
             Just xs ->
               case traverse decodeTxId $ Text.splitOn "," xs of
                 Nothing -> fieldWith $ \field' ->
-                  returnError SQL.ConversionFailed field' "Can't decode the spent txIds sequence"
+                  returnError SQL.ConversionFailed field' ("Can't decode the spent txIds sequence: " <> show xs)
                 Just xs' -> pure xs'
         decodeTxIx = fmap C.TxIx . readMaybe . Text.unpack
         txIxesFromField = do

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -76,15 +76,13 @@ import Data.Aeson (
   (.=),
  )
 import Data.Either (fromRight, rights)
-import Data.Foldable (foldl', toList)
+import Data.Foldable (toList)
 import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes, listToMaybe, mapMaybe)
 import Data.Ord (Down (Down))
-import Data.Set (Set)
-import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Word (Word64)
@@ -448,27 +446,12 @@ data instance StorableResult UtxoHandle
   deriving (Eq, Show, Ord)
 
 data instance StorableEvent UtxoHandle = UtxoEvent
-  { ueUtxos :: !(Set Utxo)
+  { ueUtxos :: ![Utxo]
   , ueInputs :: !(Map C.TxIn C.TxId)
   , ueBlockInfo :: !BlockInfo
   , ueDatum :: !(Map (C.Hash C.ScriptData) C.ScriptData)
   }
   deriving (Eq, Ord, Show, Generic)
-
--- | mappend, combine and balance Utxos
-instance Semigroup (StorableEvent UtxoHandle) where
-  (UtxoEvent us is bi ad) <> (UtxoEvent us' is' bi' ad') =
-    let txins = Map.union is is'
-        insertUnspent :: Set Utxo -> Utxo -> Set Utxo
-        insertUnspent acc u =
-          if (u ^. txIn) `Map.notMember` txins
-            then Set.insert u acc
-            else acc
-
-        utxos =
-          foldl' insertUnspent Set.empty $
-            Set.union us us'
-     in UtxoEvent utxos txins (max bi bi') (ad <> ad')
 
 -- | The effect of a transaction (or a number of them) on the tx output map.
 data TxOutBalance = TxOutBalance
@@ -483,21 +466,10 @@ makeLenses ''TxOutBalance
 
 instance Semigroup TxOutBalance where
   bUtxoL <> bUtxoR =
-    let bUnspentKeys :: Set C.TxIn
-        bUnspentKeys =
-          Map.keysSet $
-            (bUtxoR ^. tbUnspent)
-              <> ((bUtxoL ^. tbUnspent) `Map.difference` (bUtxoR ^. tbSpent))
-        utxoMap :: Map C.TxIn Utxo
-        utxoMap = _tbUnspent bUtxoL `Map.union` _tbUnspent bUtxoR
-        bSpent =
-          bUtxoL
-            ^. tbSpent
-            <> ((bUtxoR ^. tbSpent) `Map.difference` (bUtxoL ^. tbUnspent))
-     in TxOutBalance
-          { _tbUnspent = Map.restrictKeys utxoMap bUnspentKeys
-          , _tbSpent = bSpent
-          }
+    TxOutBalance
+      { _tbUnspent = bUtxoL ^. tbUnspent <> bUtxoR ^. tbUnspent
+      , _tbSpent = bUtxoL ^. tbSpent <> bUtxoR ^. tbSpent
+      }
 
 instance Monoid TxOutBalance where
   mappend = (<>)
@@ -895,7 +867,7 @@ eventToRows (UtxoEvent utxos _ bi _) =
           , _urBlockInfo = bi
           , _urSpentInfo = Nothing
           }
-   in fmap eventToRow $ Set.toList utxos
+   in fmap eventToRow utxos
 
 {- | Used internally to gather the information required
  to update the in-database result
@@ -945,8 +917,8 @@ eventsAtAddress addr snoInterval = foldMap go
     afterUpperBound :: StorableEvent UtxoHandle -> Bool
     afterUpperBound = afterBoundCheck . _blockInfoSlotNo . ueBlockInfo
 
-    utxosAtAddress :: StorableEvent UtxoHandle -> Set Utxo
-    utxosAtAddress = Set.filter ((addr ==) . _address) . ueUtxos
+    utxosAtAddress :: StorableEvent UtxoHandle -> [Utxo]
+    utxosAtAddress = filter ((addr ==) . _address) . ueUtxos
 
     splitEventAtAddress :: StorableEvent UtxoHandle -> [StorableEvent UtxoHandle]
     splitEventAtAddress event =
@@ -1025,8 +997,8 @@ instance Queryable UtxoHandle where
       filters = addressFilter <> lowerBoundFilter <> upperBoundFilter
 
       bufferEventUtxoResult :: StorableEvent UtxoHandle -> IO [UtxoResult]
-      bufferEventUtxoResult (UtxoEvent utxoSet spents bi datumMap) =
-        catMaybes <$> traverse updateSpent (Set.toList utxoSet)
+      bufferEventUtxoResult (UtxoEvent utxos spents bi datumMap) =
+        catMaybes <$> traverse updateSpent utxos
         where
           updateSpent :: Utxo -> IO (Maybe UtxoResult)
           updateSpent u =
@@ -1042,7 +1014,7 @@ instance Queryable UtxoHandle where
              in Map.keys . Map.filter (txid ==)
 
           txIns :: [C.TxIn]
-          txIns = case toList utxoSet of
+          txIns = case utxos of
             [] -> []
             u : _ -> resolveTxIns u spents
 
@@ -1181,8 +1153,8 @@ getUtxoEvents
 getUtxoEvents utxoIndexerConfig@(UtxoIndexerConfig maybeTargetAddresses _) txs bi =
   let (TxOutBalance utxos spentTxOuts) =
         foldMap (balanceUtxoFromTx utxoIndexerConfig) $ zip txs [0 ..]
-      resolvedUtxos :: Set Utxo
-      resolvedUtxos = Set.fromList $ Map.elems utxos
+      resolvedUtxos :: [Utxo]
+      resolvedUtxos = Map.elems utxos
       plutusDatums :: Map (C.Hash C.ScriptData) C.ScriptData
       plutusDatums = Datum.getPlutusDatumsFromTxs txs
       filteredTxOutDatums :: Map (C.Hash C.ScriptData) C.ScriptData

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -62,10 +62,7 @@ genUtxoEventsWithTxs' genTxBodyContent = do
     getStorableEventFromBlock (MockBlock (BlockHeader slotNo blockHeaderHash blockNo) txs) =
       let (TxOutBalance utxos spentTxOuts) = foldMap txOutBalanceFromTx txs
           utxoMap = foldMap getUtxosFromTx $ zip txs [0 ..]
-          resolvedUtxos =
-            Set.fromList $
-              mapMaybe (`Map.lookup` utxoMap) $
-                Set.toList utxos
+          resolvedUtxos = mapMaybe (`Map.lookup` utxoMap) $ Set.toList utxos
 
           plutusDatums :: Map (C.Hash C.ScriptData) C.ScriptData
           plutusDatums = Datum.getPlutusDatumsFromTxs txs
@@ -148,7 +145,7 @@ genShelleyEraUtxoEvents :: Gen [StorableEvent Utxo.UtxoHandle]
 genShelleyEraUtxoEvents = do
   events <- genUtxoEvents
   forM events $ \event -> do
-    us <- forM (Set.toList $ Utxo.ueUtxos event) $ \utxo -> do
+    us <- forM (Utxo.ueUtxos event) $ \utxo -> do
       a <- CGen.genAddressShelley
       pure $ utxo{_address = C.toAddressAny a}
-    pure event{Utxo.ueUtxos = Set.fromList us}
+    pure event{Utxo.ueUtxos = us}

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -85,7 +85,7 @@ queryTargetAddressTest = property $ do
       . Set.toList
       . Set.fromList -- remove the potential duplicate addresses
       . fmap Utxo._address
-      . concatMap (Set.toList . Utxo.ueUtxos)
+      . concatMap Utxo.ueUtxos
       $ events
 
   let numOfFetched = length fetchedRows
@@ -119,7 +119,7 @@ propUtxoEventInsertionAndJsonRpcQueryRoundTrip action = property $ do
           . Set.fromList
           . fmap (unpack . C.serialiseAddress)
           . mapMaybe (addressAnyToShelley . Utxo._address)
-          . foldMap (Set.toList . Utxo.ueUtxos)
+          . foldMap Utxo.ueUtxos
           $ events
   rpcResponses <- liftIO $ for qAddresses (queryAddressUtxosAction action)
   let fetchedUtxoRows = foldMap fromQueryResult rpcResponses


### PR DESCRIPTION
The logic that allows the deserialisation of a list of TxIn when we're retrieving utxos at a given address didn't cover the case of txout without any inputs, leading to a deserialisation error. It's now fixed.

It led us to another bug, as Utxo should have an input. The reason is that we were filtering out an utxo and its corresponding spent if they occurred in the same block. It was a bad behaviour as we lost track of inputs.

As a consequence:
- we remove when we compose `TxOutBalance`.
- There is no longer any reason to store utxo as a Set, as no set operations were required anymore, we move back to a list.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
