### PR TITLE
Clean exit and better resume points

### DIFF
--- a/marconi-chain-index/bench/BenchQueries.hs
+++ b/marconi-chain-index/bench/BenchQueries.hs
@@ -42,6 +42,7 @@ import Data.Word (Word64)
 import Database.SQLite.Simple (FromRow (fromRow), field, toRow)
 import Database.SQLite.Simple qualified as SQL
 import Database.SQLite.Simple.FromField (FromField)
+import Database.SQLite.Simple.QQ (sql)
 import Database.SQLite.Simple.ToField (ToField)
 import Database.SQLite.Simple.ToRow (ToRow)
 import GHC.Generics (Generic)
@@ -60,7 +61,6 @@ import Marconi.Core.Storable qualified as Storable
 import System.Environment (getEnv)
 import System.FilePath ((</>))
 import Test.Tasty.Bench (bench, bgroup, defaultMain, nfIO)
-import Text.RawString.QQ (r)
 
 data FrequencyRow a = FrequencyRow
   { _frequencyRowValue :: !a
@@ -133,7 +133,7 @@ tests databaseDir indexerTVar = do
   (addressesWithMostUtxos :: [FrequencyRow C.AddressAny]) <-
     SQL.query
       c
-      [r|SELECT address, COUNT(address) as frequency
+      [sql|SELECT address, COUNT(address) as frequency
            FROM unspent_transactions u
            LEFT JOIN spent s
            ON u.txId = s.txInTxId
@@ -208,7 +208,7 @@ waitUntilSynced databaseDir nodeSocketPath = do
       sns <-
         SQL.query
           c
-          [r|SELECT slotNo
+          [sql|SELECT slotNo
                    FROM unspent_transactions
                    ORDER BY slotNo DESC
                    LIMIT 1|]

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -62,6 +62,7 @@ library
     Marconi.ChainIndex.Indexers
     Marconi.ChainIndex.Indexers.AddressDatum
     Marconi.ChainIndex.Indexers.EpochState
+    Marconi.ChainIndex.Indexers.LastSync
     Marconi.ChainIndex.Indexers.MintBurn
     Marconi.ChainIndex.Indexers.ScriptTx
     Marconi.ChainIndex.Indexers.Utxo
@@ -123,7 +124,6 @@ library
     , mwc-random
     , optparse-applicative
     , prettyprinter
-    , raw-strings-qq
     , serialise
     , sqlite-simple
     , stm
@@ -285,7 +285,6 @@ benchmark marconi-chain-index-bench
     , base
     , bytestring
     , filepath
-    , raw-strings-qq
     , sqlite-simple
     , stm
     , tasty-bench

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -43,10 +43,10 @@ import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Database.SQLite.Simple (NamedParam ((:=)))
 import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.QQ (sql)
 import Database.SQLite.Simple.FromRow (FromRow (fromRow), field)
 import Database.SQLite.Simple.ToField (ToField (toField))
 import Database.SQLite.Simple.ToRow (ToRow (toRow))
-import Text.RawString.QQ (r)
 
 import Cardano.Api qualified as C
 import Cardano.Api qualified as Core
@@ -185,7 +185,7 @@ mkSqliteIndexer
 mkSqliteIndexer conn =
   let utxoInsertQuery :: SQL.Query -- Utxo table SQL statement
       utxoInsertQuery =
-        [r|INSERT
+        [sql|INSERT
                INTO unspent_transactions (
                  address,
                  txId,
@@ -202,7 +202,7 @@ mkSqliteIndexer conn =
 
       spentInsertQuery :: SQL.Query -- Spent table SQL statements
       spentInsertQuery =
-        [r|INSERT
+        [sql|INSERT
               INTO spent (
                 txId,
                 txIx,
@@ -278,7 +278,7 @@ initSQLite dbPath = do
 
   SQL.execute_
     c
-    [r|CREATE TABLE IF NOT EXISTS unspent_transactions
+    [sql|CREATE TABLE IF NOT EXISTS unspent_transactions
                       ( address BLOB NOT NULL
                       , txId TEXT NOT NULL
                       , txIx INT NOT NULL
@@ -292,7 +292,7 @@ initSQLite dbPath = do
 
   SQL.execute_
     c
-    [r|CREATE TABLE IF NOT EXISTS spent
+    [sql|CREATE TABLE IF NOT EXISTS spent
                       ( txId TEXT NOT NULL
                       , txIx INT NOT NULL
                       , slotNo INT
@@ -431,7 +431,7 @@ mkUtxoAddressQueryAction (C.ChainPoint futureSpentSlotNo _) (QueryUtxoByAddress 
         -> (SQL.Connection -> m (Core.Result QueryUtxoByAddress))
       mkUtxoAddressQueryAction' filters params =
         let builtQuery =
-              [r|SELECT
+              [sql|SELECT
                       u.address,
                       u.txId,
                       u.txIx,
@@ -451,7 +451,7 @@ mkUtxoAddressQueryAction (C.ChainPoint futureSpentSlotNo _) (QueryUtxoByAddress 
                       AND s.txIx IS NULL
                   AND |]
                 <> SQL.Query (Text.intercalate " AND " $ SQL.fromQuery <$> filters)
-                <> [r| ORDER BY
+                <> [sql| ORDER BY
                     u.slotNo ASC |]
          in \conn -> liftIO $ SQL.queryNamed conn builtQuery params
    in uncurry mkUtxoAddressQueryAction' filterPairs

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -43,8 +43,8 @@ import Data.Set qualified as Set
 import Data.Text qualified as Text
 import Database.SQLite.Simple (NamedParam ((:=)))
 import Database.SQLite.Simple qualified as SQL
-import Database.SQLite.Simple.QQ (sql)
 import Database.SQLite.Simple.FromRow (FromRow (fromRow), field)
+import Database.SQLite.Simple.QQ (sql)
 import Database.SQLite.Simple.ToField (ToField (toField))
 import Database.SQLite.Simple.ToRow (ToRow (toRow))
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -500,7 +500,7 @@ cleanExit c = do
   putStrLn "Marconi is shutting down."
   putStrLn "Waiting for indexers to finish their work..."
 
-  void $ timeout 10_000_000 $ waitQSemN (c ^. barrier) (c ^. indexerCount)
+  void $ timeout 180_000_000 $ waitQSemN (c ^. barrier) (c ^. indexerCount)
   putStrLn "Done."
 
 mkIndexerStream'

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochState.hs
@@ -84,11 +84,13 @@ import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Protocol.TPraos.API qualified as Shelley
 import Cardano.Protocol.TPraos.Rules.Tickn qualified as Shelley
 import Cardano.Slotting.Slot (EpochNo)
+
 import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Control.Monad (filterM, forM_, when)
 import Control.Monad.Except (ExceptT)
 import Control.Monad.Trans (MonadTrans (lift))
+
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (Object), object, (.:), (.=))
 import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Lazy qualified as BS
@@ -107,7 +109,10 @@ import Data.Text.Encoding qualified as Text
 import Data.Tuple (swap)
 import Data.VMap qualified as VMap
 import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.QQ (sql)
+
 import GHC.Generics (Generic)
+
 import Marconi.ChainIndex.Error (
   IndexerError (CantInsertEvent, CantQueryIndexer, CantRollback, CantStartIndexer),
   liftSQLError,
@@ -140,7 +145,6 @@ import Ouroboros.Consensus.Shelley.Ledger qualified as O
 import Ouroboros.Consensus.Storage.Serialisation qualified as O
 import System.Directory (listDirectory, removeFile)
 import System.FilePath (dropExtension, (</>))
-import Text.RawString.QQ (r)
 import Text.Read (readMaybe)
 
 data EpochStateHandle = EpochStateHandle
@@ -403,7 +407,7 @@ instance Buffered EpochStateHandle where
       forM_ (concatMap eventToEpochSDDRows $ filter epochStateEventIsFirstEventOfEpoch eventsList) $ \row ->
         SQL.execute
           c
-          [r|INSERT INTO epoch_sdd
+          [sql|INSERT INTO epoch_sdd
                   ( epochNo
                   , poolId
                   , lovelace
@@ -418,7 +422,7 @@ instance Buffered EpochStateHandle where
       forM_ (mapMaybe eventToEpochNonceRow $ filter epochStateEventIsFirstEventOfEpoch eventsList) $ \row ->
         SQL.execute
           c
-          [r|INSERT INTO epoch_nonce
+          [sql|INSERT INTO epoch_nonce
                   ( epochNo
                   , nonce
                   , slotNo
@@ -590,7 +594,7 @@ instance Queryable EpochStateHandle where
           res :: [EpochSDDRow] <-
             SQL.query
               c
-              [r|SELECT epochNo, poolId, lovelace, slotNo, blockHeaderHash, blockNo
+              [sql|SELECT epochNo, poolId, lovelace, slotNo, blockHeaderHash, blockNo
                      FROM epoch_sdd
                      WHERE epochNo = ?
                   |]
@@ -605,7 +609,7 @@ instance Queryable EpochStateHandle where
           res :: [EpochNonceRow] <-
             SQL.query
               c
-              [r|SELECT epochNo, nonce, slotNo, blockHeaderHash, blockNo
+              [sql|SELECT epochNo, nonce, slotNo, blockHeaderHash, blockNo
                      FROM epoch_nonce
                      WHERE epochNo = ?
                   |]
@@ -695,7 +699,7 @@ instance Resumable EpochStateHandle where
         result :: [[C.SlotNo]] <-
           SQL.query
             c
-            [r|SELECT slotNo
+            [sql|SELECT slotNo
                        FROM epoch_sdd
                        WHERE slotNo = ? LIMIT 1 |]
             (SQL.Only slotNo)
@@ -706,7 +710,7 @@ instance Resumable EpochStateHandle where
         result :: [[C.SlotNo]] <-
           SQL.query
             c
-            [r|SELECT slotNo
+            [sql|SELECT slotNo
                        FROM epoch_nonce
                        WHERE slotNo = ? LIMIT 1 |]
             (SQL.Only slotNo)
@@ -753,7 +757,7 @@ open topLevelConfig dbPath ledgerStateDirPath securityParam = do
   lift $
     SQL.execute_
       c
-      [r|CREATE TABLE IF NOT EXISTS epoch_sdd
+      [sql|CREATE TABLE IF NOT EXISTS epoch_sdd
             ( epochNo INT NOT NULL
             , poolId BLOB NOT NULL
             , lovelace INT NOT NULL
@@ -764,13 +768,14 @@ open topLevelConfig dbPath ledgerStateDirPath securityParam = do
   lift $
     SQL.execute_
       c
-      [r|CREATE TABLE IF NOT EXISTS epoch_nonce
+      [sql|CREATE TABLE IF NOT EXISTS epoch_nonce
             ( epochNo INT NOT NULL
             , nonce BLOB NOT NULL
             , slotNo INT NOT NULL
             , blockHeaderHash BLOB NOT NULL
             , blockNo INT NOT NULL
             )|]
+
   emptyState 1 (EpochStateHandle topLevelConfig c ledgerStateDirPath securityParam)
 
 readLedgerStateFromDisk

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/LastSync.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/LastSync.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+-- | SQlite helpers to manage the last sync table
+module Marconi.ChainIndex.Indexers.LastSync (
+  createLastSyncTable,
+  updateLastSyncTable,
+  queryLastSyncPoint,
+) where
+
+import Cardano.Api qualified as C
+import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.QQ (sql)
+import Marconi.ChainIndex.Orphans ()
+import Marconi.ChainIndex.Utils (
+  chainPointOrGenesis,
+ )
+
+-- |  create a table with a single row, to store the last sync point of the indexer
+createLastSyncTable :: SQL.Connection -> IO ()
+createLastSyncTable c =
+  SQL.execute_
+    c
+    [sql|CREATE TABLE IF NOT EXISTS lastSync
+    ( id INT PRIMARY KEY CHECK (id = 1)
+    , blockHeaderHash BLOB NOT NULL
+    , slotNo INT NOT NULL
+    )|]
+
+-- | update the last sync point of the indexer
+updateLastSyncTable :: SQL.Connection -> C.ChainPoint -> IO ()
+updateLastSyncTable c (C.ChainPoint slotNo blockHeader) =
+  SQL.execute
+    c
+    [sql|REPLACE INTO lastSync VALUES (1, ?, ?)|]
+    (blockHeader, slotNo)
+updateLastSyncTable c C.ChainPointAtGenesis =
+  SQL.execute_
+    c
+    [sql|DELETE FROM lastSync|]
+
+-- | get the last sync point of the indexer
+queryLastSyncPoint :: SQL.Connection -> IO C.ChainPoint
+queryLastSyncPoint c =
+  chainPointOrGenesis <$> SQL.query_ c "SELECT slotNo, blockHeaderHash FROM lastSync"


### PR DESCRIPTION
This PR has introduce two new features:

- We now wait for each indexer to process their block before exiting Marconi. The wait has a 3 minutes timeout.
- We keep track of all the chainpoints when we flush on disk. I wanted to keep only one event first, but as we flush the whole memory at the moment and as we want to be able to resume from at least 1 non volatile point, I had to do so.

This PR doesn't revert the intersection computation. It should be done if we want to continue with this indexer design.
It isn't a problem for side chain as the epoch state indexer will lag behind anyhow and will be the one that will be used when resuming.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
