### PR TITLE
Add a missing index to speed up the utxo query

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -710,6 +710,11 @@ open dbPath (Depth k) isToVacuume = do
   lift $
     SQL.execute_
       c
+      [sql|CREATE INDEX IF NOT EXISTS spent_tx_inputs ON spent (spentTxId)|]
+
+  lift $
+    SQL.execute_
+      c
       [sql|CREATE INDEX IF NOT EXISTS unspent_transaction_address ON unspent_transactions (address)|]
 
   emptyState k (UtxoHandle c k isToVacuume)


### PR DESCRIPTION
This PR address an performance issue raised by @james-iohk on the query to the utxo indexer:
since we add the inputs to the result of the query, we need to join on the `spentTxId` field of the `spent` table. The table is huge and without an index, it was way too slow. 
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
