### PR TITLE
Create alias for marconi-sidechain-exe

### DIFF
--- a/nix/per-system-outputs.nix
+++ b/nix/per-system-outputs.nix
@@ -1,0 +1,10 @@
+# This file is part of the IOGX template and is documented at the link below:
+# https://www.github.com/input-output-hk/iogx#35-nixper-system-outputsnix
+
+{ inputs, inputs', pkgs, projects }:
+
+{
+
+  packages.marconi-sidechain = inputs.self.packages.marconi-sidechain-exe-marconi-sidechain-ghc927;
+
+}


### PR DESCRIPTION
create an alias for the `marconi-sidechain` excutalbe.
The test:
```
nix build .#marconi-sidechain
cd result/bin
./marconi-sidechain --help
```
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
