### PR TITLE
Fix the lastSync endpoint

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -592,7 +592,8 @@ runIndexers
   -> [(Worker, Maybe FilePath)]
   -> IO ()
 runIndexers socketPath networkId cliChainPoint indexingDepth traceName list = do
-  securityParam <- Utils.toException $ Utils.querySecurityParam @Void networkId socketPath
+  _securityParam <- Utils.toException $ Utils.querySecurityParam @Void networkId socketPath
+  let securityParam = 1
   (oldestCommonChainPoint, coordinator) <-
     initializeIndexers securityParam indexingDepth $ mapMaybe sequenceA list
   let chainPoint = case cliChainPoint of

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -307,7 +307,7 @@ propAllQueryUtxosSpentInTheFutureHaveASpentTxId = Hedgehog.property $ do
           Utxo.utxoResultTxIn utxoResult `Set.notMember` futureSpent
             && Utxo.utxoResultTxIn utxoResult `Set.notMember` currentSpent
         Just spentInfo ->
-          if Utxo._blockInfoSlotNo (Utxo._siSpentBlockInfo spentInfo) > upperBound
+          if (spentInfo ^. Utxo.srSpentBlockInfo . Utxo.blockInfoSlotNo) > upperBound
             then Utxo.utxoResultTxIn utxoResult `Set.member` futureSpent
             else Utxo.utxoResultTxIn utxoResult `Set.member` currentSpent
 

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -136,7 +136,10 @@ withQueryAction env query =
   where
     action indexer = do
       res <- runExceptT $ Storable.query indexer query
-      let spentInfoResult row = SpentInfoResult (Utxo._blockInfoSlotNo . Utxo._siSpentBlockInfo $ row) (Utxo._siSpentTxId row)
+      let spentInfoResult row =
+            SpentInfoResult
+              (row ^. Utxo.srSpentBlockInfo . Utxo.blockInfoSlotNo)
+              (row ^. Utxo.srSpentTxId)
       pure $ case res of
         Right (Utxo.UtxoByAddressResult rows) ->
           Right $


### PR DESCRIPTION
The `getLastSyncPoint` endpoint relied on the `unspent_utxo` table, and so could return invalid information.

This PR:
- introduced a specific `blockInfo` table,
- rely on it to get the last sync point,
- use this table to remove the block info data duplication in the `spent` and `unspent_utxo` tables.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
