### PR TITLE
Clearer JSON-RPC error message for the GetUtxo endpoint

### DIFF
--- a/marconi-sidechain/doc/API.adoc
+++ b/marconi-sidechain/doc/API.adoc
@@ -228,8 +228,6 @@ Retrieves UTXOs of a given address until a given slot, and optionally after a gi
 
 * The `unspentBeforeSlotNo` param value should be larger than the `createdAfterSlotNo`.
 
-* The `createdAfterSlotNo` param value must be lower or equal to the current indexed `SlotNo` (returned by the `getCurrentSyncedBlock` endpoint).
-
 ==== Post-conditions
 
 * The `datumHash` result value should always be available if the `datum` result value is available.
@@ -409,9 +407,6 @@ TBD
     {
       "const": "The 'unspentBeforeSlotNo' param value must be larger than 'createAfterSlotNo'."
     },
-    {
-      "const": "The 'createAfterSlotNo' param value must be lower than the latest indexed SlotNo."
-    }
   ]
 }
 ```

--- a/marconi-sidechain/examples/json-rpc-client/src/Main.hs
+++ b/marconi-sidechain/examples/json-rpc-client/src/Main.hs
@@ -3,10 +3,12 @@
 -- | A sample servant json-rpc client for marconi-sidechain
 module Main where
 
+import Data.Either (fromRight)
 import Data.Proxy (Proxy (Proxy))
 import Marconi.Sidechain.Api.Routes (
   GetUtxosFromAddressParams (GetUtxosFromAddressParams),
   JsonRpcAPI,
+  interval,
  )
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.JsonRpc.Client.Types ()
@@ -41,11 +43,12 @@ main = do
   manager' <- newManager defaultManagerSettings
   let env = mkClientEnv manager' url
   let (rpcEcho :<|> rpcTargets :<|> _ :<|> rpcUtxos :<|> _ :<|> _ :<|> _) = getClients env
+  let boundaries = fromRight (error "the provided interval is correct") (interval Nothing maxBound)
   -- RPC calls
   msg <- rpcEcho "marconi client calling ???" --  return the echo message
   addresses <- rpcTargets "" --  get the targetAddresss
   --  get utxos for this address
-  utxos <- rpcUtxos $ GetUtxosFromAddressParams bech32Address Nothing maxBound
+  utxos <- rpcUtxos $ GetUtxosFromAddressParams bech32Address boundaries
   printResults msg
   printResults addresses
   printResults utxos

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/HttpServer.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/HttpServer.hs
@@ -29,7 +29,7 @@ import Marconi.Sidechain.Api.Routes (
   GetCurrentSyncedBlockResult,
   GetEpochActiveStakePoolDelegationResult,
   GetEpochNonceResult,
-  GetUtxosFromAddressParams (queryAddress, queryCreatedAfterSlotNo, queryUnspentBeforeSlotNo),
+  GetUtxosFromAddressParams (queryAddress, querySearchInterval),
   GetUtxosFromAddressResult,
   JsonRpcAPI,
   RestAPI,
@@ -154,8 +154,7 @@ getAddressUtxoHandler env query =
       Q.Utxo.findByBech32AddressAtSlot
         (env ^. sidechainEnvIndexers . sidechainAddressUtxoIndexer)
         (pack $ queryAddress query)
-        (queryUnspentBeforeSlotNo query)
-        (queryCreatedAfterSlotNo query)
+        (querySearchInterval query)
 
 -- | Handler for retrieving Txs by Minting Policy Hash.
 getMintingPolicyHashTxHandler

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -4,7 +4,10 @@
 {-# LANGUAGE TypeOperators #-}
 
 -- | Defines REST and JSON-RPC routes
-module Marconi.Sidechain.Api.Routes where
+module Marconi.Sidechain.Api.Routes (
+  module Marconi.Sidechain.Api.Routes,
+  Utxo.interval,
+) where
 
 import Cardano.Api qualified as C
 import Cardano.Api.Shelley qualified as C

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -29,6 +29,7 @@ import Data.Text.Encoding qualified as Text
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Marconi.ChainIndex.Indexers.Utxo (BlockInfo (BlockInfo))
+import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Orphans ()
 import Marconi.ChainIndex.Types (TxIndexInBlock)
 import Network.JsonRpc.Types (JsonRpc, RawJsonRpc)
@@ -130,20 +131,27 @@ instance FromJSON GetCurrentSyncedBlockResult where
 data GetUtxosFromAddressParams = GetUtxosFromAddressParams
   { queryAddress :: !String
   -- ^ address to query for
-  , queryCreatedAfterSlotNo :: !(Maybe Word64)
-  -- ^ query upper bound slotNo interval, unspent before or at this slot
-  , queryUnspentBeforeSlotNo :: !Word64
-  -- ^ query lower bound slotNo interval, filter out UTxO that were created during or before that slo
+  , querySearchInterval :: !(Utxo.Interval Ledger.SlotNo)
+  -- ^ query interval
   }
   deriving (Show, Eq)
 
 instance FromJSON GetUtxosFromAddressParams where
   parseJSON =
-    let parseParams v =
-          GetUtxosFromAddressParams
-            <$> (v .: "address")
-            <*> (v .:? "createdAfterSlotNo")
-            <*> (v .: "unspentBeforeSlotNo")
+    let buildInterval v = do
+          lo <-
+            v .:? "createdAfterSlotNo"
+              <|> fail "The 'createAfterSlotNo' param value must be a natural number"
+          hi <-
+            v .: "unspentBeforeSlotNo"
+              <|> fail "The 'unspentBeforeSlotNo' param value must be a natural number"
+          case Utxo.interval lo hi of
+            Left _ -> fail "The 'unspentBeforeSlotNo' param value must be larger than 'createAfterSlotNo'."
+            Right i -> pure i
+        parseParams v = do
+          address <- v .: "address" <|> fail "The 'address' param value must be in the Bech32 format"
+          interval <- buildInterval v
+          pure $ GetUtxosFromAddressParams address interval
      in Aeson.withObject "GetUtxosFromAddressParams" parseParams
 
 instance ToJSON GetUtxosFromAddressParams where
@@ -151,8 +159,8 @@ instance ToJSON GetUtxosFromAddressParams where
     Aeson.object $
       catMaybes
         [ Just ("address" .= queryAddress q)
-        , ("createdAfterSlotNo" .=) <$> queryCreatedAfterSlotNo q
-        , Just $ "unspentBeforeSlotNo" .= queryUnspentBeforeSlotNo q
+        , ("createdAfterSlotNo" .=) <$> Utxo.lowerBound (querySearchInterval q)
+        , ("unspentBeforeSlotNo" .=) <$> Utxo.upperBound (querySearchInterval q)
         ]
 
 newtype GetUtxosFromAddressResult = GetUtxosFromAddressResult

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Routes.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Routes.hs
@@ -25,6 +25,7 @@ import Hedgehog (
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 import Marconi.ChainIndex.Indexers.Utxo (BlockInfo (BlockInfo))
+import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Types (TxIndexInBlock (TxIndexInBlock))
 import Marconi.Sidechain.Api.Routes (
   ActiveSDDResult (ActiveSDDResult),
@@ -140,12 +141,16 @@ propJSONRountripCurrentSyncedBlockResult = property $ do
 
 propJSONRountripGetUtxosFromAddressParams :: Property
 propJSONRountripGetUtxosFromAddressParams = property $ do
+  Right interval <-
+    forAll $
+      Utxo.interval
+        <$> Gen.maybe (C.SlotNo <$> Gen.word64 (Range.linear 1 100))
+        <*> (C.SlotNo <$> Gen.word64 (Range.linear 101 200))
   r <-
     forAll $
       GetUtxosFromAddressParams
         <$> Gen.string (Range.linear 1 10) Gen.alphaNum
-        <*> Gen.maybe (Gen.word64 (Range.linear 1 100))
-        <*> Gen.word64 (Range.linear 101 200)
+        <*> pure interval
   tripping r Aeson.encode Aeson.decode
 
 propJSONRountripGetUtxosFromAddressResult :: Property

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/RpcClientAction.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/RpcClientAction.hs
@@ -64,7 +64,7 @@ mkRpcClientAction env port = do
     RpcClientAction
       (mkInsertUtxoEventsCallback env)
       (mkInsertMintBurnEventsCallback env)
-      (\a -> rpcUtxos $ GetUtxosFromAddressParams a Nothing maxBound)
+      (\a -> rpcUtxos $ GetUtxosFromAddressParams a (Utxo.LessThanOrEqual maxBound))
       (rpcSyncPoint "")
       (\(p, a) -> rpcMinting $ GetBurnTokenEventsParams p a Nothing Nothing)
 


### PR DESCRIPTION
Add better error messages to the GetUtxoByAddress endpoint, as defined in the API specification document.
I decided to drop the error message for a `createBeforeSlotNo` that is after the `getCurrentSyncPoint` slot, to avoid an extra query to resolve the query.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
