### PR TITLE
PLT-6751 Added CLI options to fail if one indexer is forced to resync from genesis

### DIFF
--- a/marconi-chain-index/app/Main.hs
+++ b/marconi-chain-index/app/Main.hs
@@ -36,5 +36,6 @@ main = do
     (Cli.optionsNetworkId $ Cli.commonOptions o)
     (Cli.optionsChainPoint $ Cli.commonOptions o)
     (Cli.optionsMinIndexingDepth $ Cli.commonOptions o)
+    (Cli.optionsFailsIfResync o)
     "marconi-chain-index"
     indexers

--- a/marconi-chain-index/bench/BenchQueries.hs
+++ b/marconi-chain-index/bench/BenchQueries.hs
@@ -66,6 +66,7 @@ import Marconi.ChainIndex.Indexers.Utxo (
  )
 import Marconi.ChainIndex.Types (
   IndexingDepth (MinIndexingDepth),
+  ShouldFailIfResync (ShouldFailIfResync),
   UtxoIndexerConfig (UtxoIndexerConfig),
   ucEnableUtxoTxOutRef,
   ucTargetAddresses,
@@ -130,6 +131,7 @@ runIndexerSyncing databaseDir nodeSocketPath indexerTVar = do
     (C.Testnet $ C.NetworkMagic 1) -- TODO Needs to be passed a CLI param
     C.ChainPointAtGenesis
     (MinIndexingDepth 0)
+    (ShouldFailIfResync True)
     "marconi"
     indexers
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/CLI.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/CLI.hs
@@ -22,6 +22,7 @@ import Cardano.Api qualified as C
 import Data.List.NonEmpty qualified as NonEmpty
 import Marconi.ChainIndex.Types (
   IndexingDepth (MaxIndexingDepth, MinIndexingDepth),
+  ShouldFailIfResync (ShouldFailIfResync),
   TargetAddresses,
   UtxoIndexerConfig (UtxoIndexerConfig),
   addressDatumDbName,
@@ -139,6 +140,9 @@ data Options = Options
   , optionsTargetAssets :: !(Maybe (NonEmpty (C.PolicyId, Maybe C.AssetName)))
   , optionsNodeConfigPath :: !(Maybe FilePath)
   -- ^ Path to the node config
+  , optionsFailsIfResync :: !ShouldFailIfResync
+  -- ^ Fails resuming if at least one indexer will resync from genesis instead of one of its lastest
+  -- synced point.
   }
   deriving (Show)
 
@@ -194,6 +198,13 @@ optionsParser =
             Opt.strOption $
               Opt.long "node-config-path"
                 <> Opt.help "Path to node configuration which you are connecting to."
+        )
+    <*> ( ShouldFailIfResync
+            <$> Opt.switch
+              ( Opt.long "fail-if-resyncing-from-genesis"
+                  <> Opt.help
+                    "Fails resuming if one indexer must resync from genesis when it can resume from a later point."
+              )
         )
 
 -- * Database paths

--- a/marconi-chain-index/src/Marconi/ChainIndex/Logging.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Logging.hs
@@ -132,10 +132,13 @@ chainSyncEventStreamLogging tracer s = effect $ do
     minSecondsBetweenMsg = 10
 
     update
-      :: IORef LastSyncStats -> ChainSyncEvent (C.BlockInMode C.CardanoMode, C.EpochNo, POSIXTime) -> IO ()
+      :: IORef LastSyncStats
+      -> ChainSyncEvent (C.BlockInMode C.CardanoMode, C.EpochNo, POSIXTime)
+      -> IO ()
     update statsRef (RollForward (bim, _epochNo, _posixTime) ct) = do
       let cp = case bim of
-            (C.BlockInMode (C.Block (C.BlockHeader slotNo hash _blockNo) _txs) _eim) -> C.ChainPoint slotNo hash
+            (C.BlockInMode (C.Block (C.BlockHeader slotNo hash _blockNo) _txs) _eim) ->
+              C.ChainPoint slotNo hash
       modifyIORef' statsRef $ \stats ->
         stats
           { syncStatsNumBlocks = syncStatsNumBlocks stats + 1

--- a/marconi-chain-index/src/Marconi/ChainIndex/Types.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Types.hs
@@ -30,6 +30,7 @@ module Marconi.ChainIndex.Types (
   SecurityParam (SecurityParam),
   IndexingDepth (MinIndexingDepth, MaxIndexingDepth),
   TxIndexInBlock (TxIndexInBlock),
+  ShouldFailIfResync (ShouldFailIfResync),
 ) where
 
 import Cardano.Api qualified as C
@@ -69,6 +70,13 @@ type TxOutRef = C.TxIn
 
 txOutRef :: C.TxId -> C.TxIx -> C.TxIn
 txOutRef = C.TxIn
+
+newtype ShouldFailIfResync = ShouldFailIfResync Bool
+  deriving newtype
+    ( Eq
+    , Ord
+    , Show
+    )
 
 data IndexingDepth = MinIndexingDepth !Word64 | MaxIndexingDepth
   deriving (Show, Eq)

--- a/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___disable_address_data.help
+++ b/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___disable_address_data.help
@@ -14,6 +14,7 @@ Usage: marconi-chain-index [--version] (-s|--socket-path FILE-PATH)
                            [--disable-epoch-stakepool-size] [--disable-mintburn]
                            [(-a|--addresses-to-index BECH32-ADDRESS)] 
                            [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
-                           [--node-config-path ARG]
+                           [--node-config-path ARG] 
+                           [--fail-if-resyncing-from-genesis]
 
   marconi

--- a/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___help.help
+++ b/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___help.help
@@ -12,7 +12,8 @@ Usage: marconi-chain-index [--version] (-s|--socket-path FILE-PATH)
                            [--disable-epoch-stakepool-size] [--disable-mintburn]
                            [(-a|--addresses-to-index BECH32-ADDRESS)] 
                            [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
-                           [--node-config-path ARG]
+                           [--node-config-path ARG] 
+                           [--fail-if-resyncing-from-genesis]
 
   marconi
 
@@ -49,3 +50,6 @@ Available options:
                            policy-id-2" ..."
   --node-config-path ARG   Path to node configuration which you are connecting
                            to.
+  --fail-if-resyncing-from-genesis
+                           Fails resuming if one indexer must resync from
+                           genesis when it can resume from a later point.

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Types.hs
@@ -27,7 +27,7 @@ import Network.Wai.Handler.Warp (Settings)
 import Marconi.ChainIndex.Indexers.EpochState (EpochStateHandle)
 import Marconi.ChainIndex.Indexers.MintBurn (MintBurnHandle)
 import Marconi.ChainIndex.Indexers.Utxo (UtxoHandle)
-import Marconi.ChainIndex.Types as Export (IndexingDepth, TargetAddresses)
+import Marconi.ChainIndex.Types as Export (IndexingDepth, ShouldFailIfResync, TargetAddresses)
 import Marconi.Core.Storable (State, StorableQuery)
 
 -- | Type represents http port for JSON-RPC
@@ -48,6 +48,9 @@ data CliArgs = CliArgs
   -- ^ white-space sepparated list of Bech32 Cardano Shelley addresses
   , targetAssets :: !(Maybe (NonEmpty (C.PolicyId, Maybe C.AssetName)))
   -- ^ a list of asset to track
+  , optionsFailsIfResync :: !ShouldFailIfResync
+  -- ^ Fails resuming if at least one indexer will resync from genesis instead of one of its lastest
+  -- synced point.
   }
   deriving (Show)
 

--- a/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
@@ -96,5 +96,6 @@ bootstrapIndexers args env = do
     (CLI.networkId args)
     C.ChainPointAtGenesis
     (CLI.minIndexingDepth args)
+    (CLI.optionsFailsIfResync args)
     "marconi-sidechain"
     indexers

--- a/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
@@ -1,6 +1,7 @@
 module Marconi.Sidechain.CLI where
 
 import Marconi.ChainIndex.CLI qualified as Cli
+import Marconi.ChainIndex.Types (ShouldFailIfResync (ShouldFailIfResync))
 import Marconi.Sidechain.Api.Types (CliArgs (CliArgs))
 import Options.Applicative qualified as Opt
 
@@ -27,3 +28,10 @@ parserCliArgs =
     <*> Cli.commonMinIndexingDepthParser
     <*> Cli.commonMaybeTargetAddressParser
     <*> Cli.commonMaybeTargetAssetParser
+    <*> ( ShouldFailIfResync
+            <$> Opt.switch
+              ( Opt.long "fail-if-resyncing-from-genesis"
+                  <> Opt.help
+                    "Fails resuming if one indexer must resync from genesis when it can resume from a later point."
+              )
+        )

--- a/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___help.help
+++ b/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___help.help
@@ -7,7 +7,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          (--mainnet | --testnet-magic NATURAL) 
                          [--max-indexing-depth | --min-indexing-depth NATURAL] 
                          [(-a|--addresses-to-index BECH32-ADDRESS)] 
-                         [(--match-asset-id POLICY_ID[.ASSET_NAME])]
+                         [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
+                         [--fail-if-resyncing-from-genesis]
 
   marconi-sidechain
 
@@ -38,3 +39,6 @@ Available options:
                            assetname-1.policy-id-1 --match-asset-id policy-id-2
                            ..." or "--match-asset-id "assetname-1.policy-id-1
                            policy-id-2" ..."
+  --fail-if-resyncing-from-genesis
+                           Fails resuming if one indexer must resync from
+                           genesis when it can resume from a later point.

--- a/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___socket.help
+++ b/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___socket.help
@@ -6,6 +6,7 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          (--mainnet | --testnet-magic NATURAL) 
                          [--max-indexing-depth | --min-indexing-depth NATURAL] 
                          [(-a|--addresses-to-index BECH32-ADDRESS)] 
-                         [(--match-asset-id POLICY_ID[.ASSET_NAME])]
+                         [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
+                         [--fail-if-resyncing-from-genesis]
 
   marconi-sidechain


### PR DESCRIPTION
Added CLI options to fail if one indexer is forced to resync from genesis and log resumable points of each indexer

Here are some examples on marconi-sidechain.

__When resuming from non-genesis resumable points__

```
[marconi-sidechain:Info:9] [2023-07-25 17:11:30.26 UTC] Resumable points for each indexer:
    [ ChainPoint(Slot 32262079, BlockHash 5bc7a83aa740515a7cf1fcf510e6d8778d23fd62e999b31b380f9cc7548db79b)
    , ChainPoint(Slot 32054455, BlockHash 8b70cd587d802a596a8dd2c58543f37510ddcf2b14fb7869550561ea91c12b0f)
    , ChainPoint(Slot 32262079, BlockHash 5bc7a83aa740515a7cf1fcf510e6d8778d23fd62e999b31b380f9cc7548db79b) ]
[marconi-sidechain:Info:9] [2023-07-25 17:11:30.27 UTC] Starting from ChainPoint(Slot 32054455, BlockHash 8b70cd587d802a596a8dd2c58543f37510ddcf2b14fb7869550561ea91c12b0f).
[marconi-sidechain:Info:9] [2023-07-25 17:11:57.99 UTC] Synchronising (92.66%). Current synced point is ChainPoint(Slot 32054455, BlockHash 8b70cd587d802a596a8dd2c58543f37510ddcf2b14fb7869550561ea91c12b0f) and current node tip is ChainTip(Slot 34593203, BlockHash ac06a6c96c8576d5b257ce5e3404c144e193632480f2ee63
ec8740b726c14faf, BlockNo 1200024). Processed 0 blocks and 1 rollbacks in the last 27s (0 blocks/s).
```

__When resuming from genesis for one indexer and from non-genesis for another indexer__

```
[marconi-sidechain:Info:13] [2023-07-25 17:17:31.99 UTC] Resumable points for each indexer:
    [ ChainPoint(Slot 128660, BlockHash 1ff8d3c126a8bcaf410414d849e717f8e4a431933d8970cea07ac1214cef8851)
    , ChainPointAtGenesis
    , ChainPoint(Slot 109300, BlockHash 4f9ab08125daf13829e78fb585667e8b4d5c546f454c5cde1ea73a4e3e41fb7c) ]
[marconi-sidechain:Info:13] [2023-07-25 17:17:32.00 UTC] Starting from ChainPointAtGenesis. 
[marconi-sidechain:Info:13] [2023-07-25 17:17:42.00 UTC] Synchronising (0.57%). Current synced point is ChainPoint(Slot 198000, BlockHash 541c87923f490d5d24741089f05a0760e2e318360d8f6c2008c363fec9909d88) and current node tip is ChainTip(Slot 34539696, BlockHash c72d6d62e7dd19bf6da254f7de833cdf4da057ab0eac3a9196db4c596654dc74, BlockNo 1197620). Processed 5627 blocks and 1 rollbacks in the last 10s (563 blocks/s).
```

__When resuming from genesis for one indexer and from non-genesis for another indexer with --fail-if-resyncing-from-genesis option__

```
[marconi-sidechain:Info:13] [2023-07-25 17:18:35.57 UTC] Resumable points for each indexer:
    [ ChainPoint(Slot 344660, BlockHash 9aa0c204ef301a0b7b5a73d914e677c214144691e400aa7539870503e894e5d6)
    , ChainPointAtGenesis
    , ChainPoint(Slot 344660, BlockHash 9aa0c204ef301a0b7b5a73d914e677c214144691e400aa7539870503e894e5d6) ]
[marconi-sidechain:Error:13] [2023-07-25 17:18:35.57 UTC] At least one indexer has a non-genesis resumable point, while the oldest common resumable point between indexers is genesis.
    Are you sure you want to restart syncing that indexer from genesis?
    If so, remove the '--fail-if-resyncing-from-genesis' flag.
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
