### PR TITLE
Add a catch-up mechanism at an indexer transformer

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -37,7 +37,7 @@ import Data.Either (fromRight)
 import Data.Foldable (fold, foldl')
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Ord ()
+import Data.Ord (comparing)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text qualified as Text
@@ -76,7 +76,7 @@ data Utxo = Utxo
 $(makeLenses ''Utxo)
 
 instance Ord Utxo where
-  compare u1 u2 = compare (u1 ^. utxoTxIn) (u2 ^. utxoTxIn)
+  compare = comparing (view utxoTxIn)
 
 newtype Spent = Spent {unSpent :: C.TxIn}
   deriving (Show, Eq, Ord)

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -68,6 +68,7 @@ library
     Marconi.Core.Experiment.Transformer.IndexWrapper
     Marconi.Core.Experiment.Transformer.WithAggregate
     Marconi.Core.Experiment.Transformer.WithCache
+    Marconi.Core.Experiment.Transformer.WithCatchup
     Marconi.Core.Experiment.Transformer.WithDelay
     Marconi.Core.Experiment.Transformer.WithPruning
     Marconi.Core.Experiment.Transformer.WithTracer

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -370,10 +370,14 @@ module Marconi.Core.Experiment (
   withTracer,
   HasTracerConfig (tracer),
 
+  -- ** WithCatchup
+  WithCatchup,
+  withCatchup,
+  HasCatchupConfig (catchupBypassDistance, catchupBatchSize),
+
   -- ** Delay
   WithDelay,
   withDelay,
-  delayBuffer,
   -- | A type class that give access to the configuration of 'WithDelay'
   HasDelayConfig (delayCapacity),
 
@@ -521,10 +525,14 @@ import Marconi.Core.Experiment.Transformer.WithCache (
   addCacheFor,
   withCache,
  )
+import Marconi.Core.Experiment.Transformer.WithCatchup (
+  HasCatchupConfig (catchupBatchSize, catchupBypassDistance),
+  WithCatchup,
+  withCatchup,
+ )
 import Marconi.Core.Experiment.Transformer.WithDelay (
   HasDelayConfig (delayCapacity),
   WithDelay,
-  delayBuffer,
   withDelay,
  )
 import Marconi.Core.Experiment.Transformer.WithPruning (

--- a/marconi-core/src/Marconi/Core/Experiment/Class.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Class.hs
@@ -49,7 +49,7 @@ class (Monad m) => IsIndex m event indexer where
   --
   -- The events must be sorted in ascending order (the most recent first)
   indexAll
-    :: (Ord (Point event), Traversable f)
+    :: (Eq (Point event), Traversable f)
     => f (Timed (Point event) (Maybe event))
     -> indexer event
     -> m (indexer event)
@@ -59,7 +59,7 @@ class (Monad m) => IsIndex m event indexer where
   --
   -- The events must be sorted in descending order (the most recent first)
   indexAllDescending
-    :: (Ord (Point event), Traversable f)
+    :: (Eq (Point event), Traversable f)
     => f (Timed (Point event) (Maybe event))
     -> indexer event
     -> m (indexer event)

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/LastPointIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/LastPointIndexer.hs
@@ -11,10 +11,10 @@ module Marconi.Core.Experiment.Indexer.LastPointIndexer (
   lastPointIndexer,
 ) where
 
-import Control.Lens (folded, makeLenses, maximumOf, view)
+import Control.Lens (makeLenses, view)
 import Control.Lens.Operators ((^.))
-import Data.Maybe (fromMaybe)
 
+import Data.Foldable (Foldable (toList))
 import Marconi.Core.Experiment.Class (
   HasGenesis (genesis),
   IsIndex (index, indexAllDescending),
@@ -44,7 +44,9 @@ instance
   where
   index timedEvent _ = pure $ LastPointIndexer $ timedEvent ^. point
 
-  indexAllDescending evts _ = pure $ LastPointIndexer $ fromMaybe genesis $ maximumOf (folded . point) evts
+  indexAllDescending evts _ = case toList evts of
+    [] -> pure $ LastPointIndexer genesis
+    (evt : _) -> pure $ LastPointIndexer $ evt ^. point
 
 instance (Applicative m) => IsSync m event LastPointIndexer where
   lastSyncPoint = pure . view lastPoint

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/IndexWrapper.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/IndexWrapper.hs
@@ -77,7 +77,7 @@ indexVia l = l . index
  If you don't want to perform any other side logic, use @deriving via@ instead.
 -}
 indexAllDescendingVia
-  :: (Ord (Point event), IsIndex m event indexer, Traversable f)
+  :: (Eq (Point event), IsIndex m event indexer, Traversable f)
   => Lens' s (indexer event)
   -> f (Timed (Point event) (Maybe event))
   -> s
@@ -88,7 +88,7 @@ indexAllDescendingVia l = l . indexAllDescending
  If you don't want to perform any other side logic, use @deriving via@ instead.
 -}
 indexAllVia
-  :: (Ord (Point event), IsIndex m event indexer, Traversable f)
+  :: (Eq (Point event), IsIndex m event indexer, Traversable f)
   => Lens' s (indexer event)
   -> f (Timed (Point event) (Maybe event))
   -> s

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCatchup.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCatchup.hs
@@ -1,0 +1,177 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DerivingVia #-}
+
+{- | The catch-up mechanism buffered events to pass them in batch to an indexer, to reduce the time
+ needed for an indexer to catch-up with the tip.
+
+ Once we are close enough to the tip of the chain, `WithCatchup` deactivate itself and pass directly
+ the blocks to the indexer.
+-}
+module Marconi.Core.Experiment.Transformer.WithCatchup (
+  WithCatchup,
+  withCatchup,
+  HasCatchupConfig (..),
+) where
+
+import Control.Lens qualified as Lens
+import Control.Lens.Operators ((%~), (+~), (.~), (^.))
+import Data.Function ((&))
+import Marconi.Core.Experiment.Class (
+  Closeable,
+  IsIndex (index),
+  IsSync,
+  Queryable,
+  Resetable (reset),
+  Rollbackable (rollback),
+ )
+import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (unwrapMap))
+import Marconi.Core.Experiment.Transformer.IndexWrapper (
+  IndexWrapper (IndexWrapper),
+  IndexerTrans (Config, unwrap, wrap),
+  indexAllDescendingVia,
+  indexVia,
+  resetVia,
+  rollbackVia,
+  wrappedIndexer,
+  wrapperConfig,
+ )
+import Marconi.Core.Experiment.Type (Point, Timed (Timed), point)
+
+data CatchupConfig event = CatchupConfig
+  { _configDistanceComputation :: Point event -> event -> Word
+  -- ^ How we compute distance to tip
+  , _configCatchupBypassDistance :: Word
+  -- ^ How far from the block should we be to bypass the catchup mechanism (in number of blocks)
+  , _configCatchupBatchSize :: Word
+  -- ^ Maximal number of events in one batch
+  , _configCatchupBufferLength :: Word
+  -- ^ How many event do we have in the batch
+  , _configCatchupBuffer :: [Timed (Point event) (Maybe event)]
+  -- ^ Where we store the event that must be batched
+  }
+
+Lens.makeLenses 'CatchupConfig
+
+newtype WithCatchup indexer event = WithCatchup {_catchupWrapper :: IndexWrapper CatchupConfig indexer event}
+
+Lens.makeLenses 'WithCatchup
+
+-- | A smart constructor for 'WithCatchup'
+withCatchup
+  :: (Point event -> event -> Word)
+  -- ^ The distance function
+  -> Word
+  -- ^ Minimal distance to tip to deactivate the catchup mechanism
+  -> Word
+  -- ^ Maximal number of elements to send to the indexer in one batch
+  -> indexer event
+  -- ^ the underlying indexer
+  -> WithCatchup indexer event
+withCatchup computeDistance bypassDistance batchSize =
+  WithCatchup . IndexWrapper (CatchupConfig computeDistance bypassDistance batchSize 0 [])
+
+deriving via
+  (IndexWrapper CatchupConfig indexer)
+  instance
+    (IsSync m event indexer) => IsSync m event (WithCatchup indexer)
+
+deriving via
+  (IndexWrapper CatchupConfig indexer)
+  instance
+    (Closeable m indexer) => Closeable m (WithCatchup indexer)
+
+deriving via
+  (IndexWrapper CatchupConfig indexer)
+  instance
+    (Queryable m event query indexer) => Queryable m event query (WithCatchup indexer)
+
+caughtUpIndexer :: Lens.Lens' (WithCatchup indexer event) (indexer event)
+caughtUpIndexer = catchupWrapper . wrappedIndexer
+
+instance IndexerTrans WithCatchup where
+  type Config WithCatchup = CatchupConfig
+
+  wrap cfg = WithCatchup . IndexWrapper cfg
+
+  unwrap = caughtUpIndexer
+
+{- | A typeclass that allows an indexer with a @WitchCatchup@ transformer to configure
+ the behaviour of this transformer
+-}
+class HasCatchupConfig indexer where
+  catchupBypassDistance :: Lens.Lens' (indexer event) Word
+  catchupBatchSize :: Lens.Lens' (indexer event) Word
+
+instance {-# OVERLAPPING #-} HasCatchupConfig (WithCatchup indexer) where
+  catchupBypassDistance = catchupWrapper . wrapperConfig . configCatchupBypassDistance
+  catchupBatchSize = catchupWrapper . wrapperConfig . configCatchupBatchSize
+
+instance
+  {-# OVERLAPPABLE #-}
+  (IndexerTrans t, HasCatchupConfig indexer)
+  => HasCatchupConfig (t indexer)
+  where
+  catchupBypassDistance = unwrap . catchupBypassDistance
+  catchupBatchSize = unwrap . catchupBatchSize
+
+instance
+  {-# OVERLAPPABLE #-}
+  (IndexerMapTrans t, HasCatchupConfig indexer)
+  => HasCatchupConfig (t indexer output)
+  where
+  catchupBypassDistance = unwrapMap . catchupBypassDistance
+  catchupBatchSize = unwrapMap . catchupBatchSize
+
+catchupDistance :: Lens.Lens' (WithCatchup indexer event) (Point event -> event -> Word)
+catchupDistance = catchupWrapper . wrapperConfig . configDistanceComputation
+
+catchupBuffer :: Lens.Lens' (WithCatchup indexer event) [Timed (Point event) (Maybe event)]
+catchupBuffer = catchupWrapper . wrapperConfig . configCatchupBuffer
+
+catchupBufferLength :: Lens.Lens' (WithCatchup indexer event) Word
+catchupBufferLength = catchupWrapper . wrapperConfig . configCatchupBufferLength
+
+resetBuffer :: WithCatchup indexer event -> WithCatchup indexer event
+resetBuffer = (catchupBufferLength .~ 0) . (catchupBuffer .~ [])
+
+instance (IsIndex m event indexer) => IsIndex m event (WithCatchup indexer) where
+  index timedEvent indexer =
+    let bufferIsFull ix = (ix ^. catchupBufferLength) >= (ix ^. catchupBatchSize)
+        pushEvent ix =
+          ix
+            & catchupBuffer %~ (timedEvent :)
+            & catchupBufferLength +~ 1
+        hasCaughtUp (Timed p e) =
+          maybe False ((< indexer ^. catchupBypassDistance) . (indexer ^. catchupDistance) p) e
+        sendBatch ix = do
+          ix' <- indexAllDescendingVia caughtUpIndexer (ix ^. catchupBuffer) ix
+          pure $ resetBuffer ix'
+     in if hasCaughtUp timedEvent
+          then do
+            indexer' <-
+              if null (indexer ^. catchupBuffer)
+                then pure indexer
+                else sendBatch indexer
+            indexVia caughtUpIndexer timedEvent indexer'
+          else do
+            let indexer' = pushEvent indexer
+            if bufferIsFull indexer'
+              then sendBatch indexer'
+              else pure indexer'
+
+instance (Monad m, Rollbackable m event indexer) => Rollbackable m event (WithCatchup indexer) where
+  rollback p indexer =
+    let updateBuffer ix = ix & catchupBuffer %~ dropWhile ((> p) . Lens.view point)
+        setBufferSize ix = ix & catchupBufferLength .~ (fromIntegral $ length $ ix ^. catchupBuffer)
+        indexer' = setBufferSize $ updateBuffer indexer
+     in if indexer' ^. catchupBufferLength == 0
+          then rollbackVia caughtUpIndexer p indexer'
+          else pure indexer'
+
+instance
+  (Applicative m, Resetable m event indexer)
+  => Resetable m event (WithCatchup indexer)
+  where
+  reset indexer = do
+    indexer' <- resetVia caughtUpIndexer indexer
+    pure $ resetBuffer indexer'

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithDelay.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithDelay.hs
@@ -13,7 +13,6 @@
 module Marconi.Core.Experiment.Transformer.WithDelay (
   WithDelay,
   withDelay,
-  delayBuffer,
   HasDelayConfig (delayCapacity),
 ) where
 

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -36,6 +36,9 @@ module Marconi.Core.Spec.Experiment (
   cacheHitProperty,
   cacheMissProperty,
 
+  -- ** Catchup test suite
+  catchupTestGroup,
+
   -- ** Delay test suite
   delayTestGroup,
 
@@ -943,6 +946,102 @@ delayTestGroup title runner =
         , Tasty.testProperty "in a chain with rollbacks" $
             Test.withMaxSuccess 10000 $
               delayProperty 10 (view defaultChain <$> Test.arbitrary) runner
+        ]
+    ]
+
+-- | A runner for a the 'WithTracer' tranformer
+withCatchupRunner
+  :: Monad m
+  => (Core.Point event ~ TestPoint)
+  => Word
+  -> Word
+  -> IndexerTestRunner m event wrapped
+  -> IndexerTestRunner m event (Core.WithCatchup wrapped)
+withCatchupRunner batchSize bypassDistance wRunner =
+  let computeDistance (TestPoint d) _ = fromIntegral $ 100 - d
+   in IndexerTestRunner
+        (wRunner ^. indexerRunner)
+        (Core.withCatchup computeDistance batchSize bypassDistance <$> wRunner ^. indexerGenerator)
+
+catchupProperty
+  :: Core.IsIndex m TestEvent indexer
+  => Core.IsSync m TestEvent indexer
+  => Core.Rollbackable m TestEvent indexer
+  => Core.Queryable
+      (ExceptT (Core.QueryError (Core.EventsMatchingQuery TestEvent)) m)
+      TestEvent
+      (Core.EventsMatchingQuery TestEvent)
+      indexer
+  => Core.IsSync m TestEvent indexer
+  => Word
+  -> Word
+  -> Gen [Item TestEvent]
+  -> IndexerTestRunner m TestEvent indexer
+  -> Property
+catchupProperty batchSize bypassDistance gen runner =
+  let indexerEvents indexer' =
+        fmap (view Core.event)
+          . fromRight []
+          <$> Core.queryLatest' Core.allEvents indexer'
+
+      modelEvents lastSync =
+        views model (mapMaybe snd . filter ((lastSync >=) . fst))
+
+      dRunner = withCatchupRunner batchSize bypassDistance runner
+
+      r = dRunner ^. indexerRunner
+      genIndexer = dRunner ^. indexerGenerator
+   in Test.forAll gen $ \chain -> r $ do
+        initialIndexer <- GenM.run genIndexer
+        indexer <- GenM.run $ foldM (flip process) initialIndexer chain
+        iResult <- GenM.run $ indexerEvents indexer
+        lastSyncPoint <- GenM.run $ Core.lastSyncPoint indexer
+        let model' = runModel chain
+            mResult = modelEvents lastSyncPoint model'
+        GenM.stop $ mResult === iResult
+
+-- | A test tree for the core functionalities of a delayed indexer
+catchupTestGroup
+  :: Core.Rollbackable m TestEvent indexer
+  => Core.IsIndex m TestEvent indexer
+  => Core.IsSync m TestEvent indexer
+  => Core.Queryable
+      (ExceptT (Core.QueryError (Core.EventsMatchingQuery TestEvent)) m)
+      TestEvent
+      (Core.EventsMatchingQuery TestEvent)
+      indexer
+  => String
+  -> IndexerTestRunner m TestEvent indexer
+  -> Tasty.TestTree
+catchupTestGroup title runner =
+  Tasty.testGroup
+    (title <> "WithCatchup behaviour with WithCatchup")
+    [ Tasty.testGroup
+        "0 bufferSize, stop on tip (100 events)"
+        [ Tasty.testProperty "indexes events without rollback" $
+            Test.withMaxSuccess 5000 $
+              catchupProperty 0 0 (view forwardChain <$> Test.arbitrary) runner
+        , Tasty.testProperty "indexes events with rollbacks" $
+            Test.withMaxSuccess 10000 $
+              catchupProperty 0 0 (view defaultChain <$> Test.arbitrary) runner
+        ]
+    , Tasty.testGroup
+        "100 bufferSize, stop on tip (100 events)"
+        [ Tasty.testProperty "indexes events without rollback" $
+            Test.withMaxSuccess 5000 $
+              catchupProperty 100 0 (view forwardChain <$> Test.arbitrary) runner
+        , Tasty.testProperty "indexes events with rollbacks" $
+            Test.withMaxSuccess 10000 $
+              catchupProperty 100 0 (view defaultChain <$> Test.arbitrary) runner
+        ]
+    , Tasty.testGroup
+        "1000 bufferSize, stop on tip (100 events)"
+        [ Tasty.testProperty "indexes events without rollback" $
+            Test.withMaxSuccess 5000 $
+              catchupProperty 1000 0 (view forwardChain <$> Test.arbitrary) runner
+        , Tasty.testProperty "indexes events with rollbacks" $
+            Test.withMaxSuccess 10000 $
+              catchupProperty 1000 0 (view defaultChain <$> Test.arbitrary) runner
         ]
     ]
 

--- a/marconi-core/test/Spec.hs
+++ b/marconi-core/test/Spec.hs
@@ -36,6 +36,11 @@ experimentTests =
         , E.delayTestGroup "SQLiteIndexer" E.mkSqliteIndexerRunner
         ]
     , testGroup
+        "WithCatchup"
+        [ E.catchupTestGroup "ListIndexer" E.listIndexerRunner
+        , E.catchupTestGroup "SQLiteIndexer" E.mkSqliteIndexerRunner
+        ]
+    , testGroup
         "WithTransform"
         [ E.withTransformTest
         ]


### PR DESCRIPTION
As we want to move towards full in-database indexers, we discussed the need to have a way to batch events to the database until we catchup with the tip.

This PR proposes a indexer transformer that does exactly this: when an block comes in, we compute the distance to the tip and we decide either:

- that we are too far from the tip and thus we put the block in a batch and if the batch is full, we send it to the database
- that we are close enough to the tip, we just skip the batch mechanism and add directly the block to the indexer.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
