### PR TITLE
PLT-6881 Utxo indexer returns all spent transaction outputs when not specifying `unspentBeforeSlotNo` field

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -959,7 +959,7 @@ instance Queryable UtxoHandle where
         Nothing -> mempty
         Just lowerBound' -> (["u.slotNo >= :lowerBound"], [":lowerBound" := lowerBound'])
       upperBoundFilter = case intervalUpperBound slotInterval of
-        Nothing -> mempty
+        Nothing -> (["s.slotNo IS NULL"], [])
         Just upperBound' ->
           (
             [ -- created before the upperBound


### PR DESCRIPTION
Fix UTXO bug and modify the existing tests to catch regression

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
