### PR TITLE
Significant speed increase on the MintBurn indexer (plus some small refactoring)

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -505,7 +505,7 @@ mintBurnWorker_ securityParam callback mAssets c ch dbPath = do
             let event' = MintBurn.toUpdate mAssets blockInMode
             void $
               updateWith indexerMVar (c ^. errorVar) $
-                ignoreQueryError . Storable.insert (MintBurn.MintBurnEvent event')
+                ignoreQueryError . Storable.insert event'
           RollBackward cp' _ct ->
             void $ updateWith indexerMVar (c ^. errorVar) $ ignoreQueryError . Storable.rewind cp'
         signalQSemN (c ^. barrier) 1


### PR DESCRIPTION
* Added BEGIN and COMMIT SQL statements when doing bulk inserts in MintBurn. Went from ~200blocks/s to ~3000blocks/s in the first few epochs.
* Removed unused functions in MintBurn indexer
* MintBurn.toUpdate now returns StorableEvent instead of TxMints

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
