### PR TITLE
Fix nested transaction issue

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/EpochState.hs
@@ -403,7 +403,6 @@ instance Buffered EpochStateHandle where
     liftSQLError CantInsertEvent $ do
       let eventsList = toList events
 
-      SQL.execute_ c "BEGIN"
       SQL.withTransaction c $ do
         forM_ (concatMap eventToEpochSDDRows $ filter epochStateEventIsFirstEventOfEpoch eventsList) $ \row ->
           SQL.execute


### PR DESCRIPTION
The epochState indexer has a nested transactions issue after the performance PR. Remove the extra BEGIN statement.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
