### PR TITLE
PLT-969 Resolve bug in Cardano streaming, blocking on new era

### DIFF
--- a/cardano-streaming/src/Cardano/Streaming.hs
+++ b/cardano-streaming/src/Cardano/Streaming.hs
@@ -32,7 +32,7 @@ import Cardano.Slotting.Slot (WithOrigin (At, Origin))
 import Cardano.Slotting.Time qualified as C
 import Cardano.Streaming.Callbacks qualified as CS
 import Cardano.Streaming.Helpers qualified as CS
-import Control.Concurrent (readMVar)
+import Control.Concurrent (modifyMVar)
 import Control.Concurrent qualified as IO
 import Control.Concurrent.Async (ExceptionInLinkedThread (ExceptionInLinkedThread), link, withAsync)
 import Control.Concurrent.MVar (MVar, newEmptyMVar, putMVar, takeMVar)
@@ -44,6 +44,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (runExceptT)
 import Data.Foldable (forM_)
 import Data.Function ((&))
+import Data.Functor ((<&>))
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import Data.Time.Clock.POSIX (POSIXTime)
@@ -147,32 +148,37 @@ withChainSyncEventEpochNoStream socketPath networkId points consumer =
     let queryHistoryInMode :: C.QueryInMode C.CardanoMode (C.EraHistory C.CardanoMode)
         queryHistoryInMode = C.QueryEraHistory C.CardanoModeIsMultiEra
 
-        askHistory :: IO ()
+        askHistory :: IO (C.EraHistory C.CardanoMode)
         askHistory = do
           res <- C.queryNodeLocalState localNodeConnectInfo Nothing queryHistoryInMode
           case res of
             Left err -> fail $ show err
-            Right h -> putMVar eraHistoryVar h
-
-        getHistory = readMVar eraHistoryVar
+            Right h -> pure h
 
         attachEpochAndTime
           :: CS.ChainSyncEvent (C.BlockInMode C.CardanoMode)
           -> IO (CS.ChainSyncEvent (C.BlockInMode C.CardanoMode, C.EpochNo, POSIXTime))
         attachEpochAndTime (CS.RollBackward cp ct) = pure $ CS.RollBackward cp ct
         attachEpochAndTime evt@(CS.RollForward (C.BlockInMode (C.Block (C.BlockHeader sn _ _) _) _) _) = do
-          history <- getHistory
-          let epochAndTime = do
-                (epoch, _, _) <- C.slotToEpoch sn history
-                (relativeTime, _) <- C.getProgress sn history
-                pure (epoch, Time.utcTimeToPOSIXSeconds $ C.fromRelativeTime systemStart relativeTime)
-          case epochAndTime of
-            Left _ -> askHistory *> attachEpochAndTime evt
-            Right (epoch, time) -> pure $ (,epoch,time) <$> evt
+          modifyMVar eraHistoryVar $ \history ->
+            let epochAndTime h = do
+                  (epoch, _, _) <- C.slotToEpoch sn h
+                  (relativeTime, _) <- C.getProgress sn h
+                  pure (epoch, Time.utcTimeToPOSIXSeconds $ C.fromRelativeTime systemStart relativeTime)
+                buildEpochAndTime
+                  :: C.EraHistory C.CardanoMode
+                  -> IO
+                      ( C.EraHistory C.CardanoMode
+                      , CS.ChainSyncEvent (C.BlockInMode C.CardanoMode, C.EpochNo, POSIXTime)
+                      )
+                buildEpochAndTime h = case epochAndTime h of
+                  Left _ -> askHistory >>= buildEpochAndTime
+                  Right (epoch, time) -> pure (h, evt <&> (,epoch,time))
+             in buildEpochAndTime history
 
         client = chainSyncStreamingClient points nextChainSyncEventVar
 
-    askHistory
+    putMVar eraHistoryVar =<< askHistory
 
     withAsync (connectToLocalNodeWithChainSyncClient localNodeConnectInfo client) $ \a -> do
       -- Make sure all exceptions in the client thread are passed to the consumer thread
@@ -181,7 +187,9 @@ withChainSyncEventEpochNoStream socketPath networkId points consumer =
       consumer $ S.repeatM $ takeMVar nextChainSyncEventVar >>= attachEpochAndTime
     -- Let's rethrow exceptions from the client thread unwrapped, so that the
     -- consumer does not have to know anything about async
-    `catch` \(ExceptionInLinkedThread _ (SomeException e)) -> throw e
+    `catch` \(ExceptionInLinkedThread _ (SomeException e)) -> do
+      putStrLn "error in chainSync"
+      throw e
 
 connectToLocalNodeWithChainSyncClient
   :: C.LocalNodeConnectInfo C.CardanoMode

--- a/marconi-sidechain/app/Main.hs
+++ b/marconi-sidechain/app/Main.hs
@@ -17,6 +17,7 @@ import Marconi.Sidechain.CLI (parseCli)
 -}
 main :: IO ()
 main = do
+  putStrLn "DEBUG: 20230802-16:32-UTC"
   cli@CliArgs{httpPort, targetAddresses, targetAssets} <- parseCli
   rpcEnv <- initializeSidechainEnv httpPort targetAddresses targetAssets
 

--- a/marconi-sidechain/app/Main.hs
+++ b/marconi-sidechain/app/Main.hs
@@ -17,7 +17,6 @@ import Marconi.Sidechain.CLI (parseCli)
 -}
 main :: IO ()
 main = do
-  putStrLn "DEBUG: 20230802-16:32-UTC"
   cli@CliArgs{httpPort, targetAddresses, targetAssets} <- parseCli
   rpcEnv <- initializeSidechainEnv httpPort targetAddresses targetAssets
 


### PR DESCRIPTION
When the eraHistory used to compute the epochNo was outdated, the stream was blocking when it was trying to update it because it was updating a full `MVar`.

The refactoring remove the need of the `MVar`.

It also improves the robustness of the concurrent code of the indexers and some extra logging, integrated during the bug investigation.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
