### PR TITLE
PLT-6892 Add node tip info to the getLastSyncedBlock query

### DIFF
--- a/marconi-chain-index/json-rpc/src/Network/JsonRpc/Server/Types.hs
+++ b/marconi-chain-index/json-rpc/src/Network/JsonRpc/Server/Types.hs
@@ -76,7 +76,7 @@ instance
       pxa = Proxy @api
       pxh = Proxy @Handler
 
-  hoistServerWithContext _ _ f x = hoistRpcRouter (Proxy @api) f x
+  hoistServerWithContext _ _ = hoistRpcRouter (Proxy @api)
 
 -- | This internal class is how we accumulate a map of handlers for dispatch
 class RouteJsonRpc a where

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -241,7 +241,10 @@ utxoWorker_ callback depth utxoIndexerConfig Coordinator{_barrier, _errorVar} ch
           let utxoEvents = Utxo.getUtxoEventsFromBlock utxoIndexerConfig block epochNo posixTime ct
            in void $ updateWith mIndexer _errorVar $ ignoreQueryError . Storable.insert utxoEvents
         RollBackward cp _ct ->
-          void $ updateWith mIndexer _errorVar $ ignoreQueryError . Storable.rewind cp
+          void $
+            updateWith mIndexer _errorVar $
+              ignoreQueryError . Storable.rewind cp
+
       raiseError =
         tryPutMVar _errorVar $ CantInsertEvent "Utxo raised an uncaught exception"
       loop :: IO ()

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -237,8 +237,8 @@ utxoWorker_ callback depth utxoIndexerConfig Coordinator{_barrier, _errorVar} ch
   -- TODO consider adding a CLI param to allow user to perfomr Vaccum or not.
   mIndexer <- newMVar ix
   let process = \case
-        RollForward (BlockInMode block _, epochNo, posixTime) _ct ->
-          let utxoEvents = Utxo.getUtxoEventsFromBlock utxoIndexerConfig block epochNo posixTime
+        RollForward (BlockInMode block _, epochNo, posixTime) ct ->
+          let utxoEvents = Utxo.getUtxoEventsFromBlock utxoIndexerConfig block epochNo posixTime ct
            in void $ updateWith mIndexer _errorVar $ ignoreQueryError . Storable.insert utxoEvents
         RollBackward cp _ct ->
           void $ updateWith mIndexer _errorVar $ ignoreQueryError . Storable.rewind cp

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -757,7 +757,7 @@ instance Buffered UtxoHandle where
           `concurrently_` do
             SQL.execute
               c
-              [sql|INSERT OR UPDATE INTO nodeTip
+              [sql|INSERT OR REPLACE INTO nodeTip
                    ( isUnique
                    , slotNo
                    , blockHeaderHash

--- a/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
@@ -12,7 +12,7 @@ import Cardano.Binary qualified as CBOR
 import Cardano.Ledger.Shelley.API qualified as Ledger
 import Codec.CBOR.Read qualified as CBOR
 import Codec.Serialise (Serialise (decode, encode))
-import Data.Aeson (FromJSON, ToJSON, (.:))
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy (toStrict)
 import Data.Coerce (coerce)

--- a/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
@@ -39,6 +39,18 @@ instance Pretty C.ChainTip where
   pretty C.ChainTipAtGenesis = "ChainTipAtGenesis"
   pretty (C.ChainTip sn ha bn) = "ChainTip(" <> pretty sn <> "," <+> pretty ha <> "," <+> pretty bn <> ")"
 
+instance SQL.FromRow C.ChainTip where
+  fromRow = C.ChainTip <$> SQL.field <*> SQL.field <*> SQL.field
+
+instance ToRow C.ChainTip where
+  toRow C.ChainTipAtGenesis = [SQL.SQLNull]
+  toRow (C.ChainTip sn bh bno) = [toField sn, toField bh, toField bno]
+
+instance Ord C.ChainTip where
+  compare C.ChainTipAtGenesis _ = LT
+  compare _ C.ChainTipAtGenesis = GT
+  compare (C.ChainTip snX haX _bnX) (C.ChainTip snY haY _bnY) = compare (snX, haX) (snY, haY)
+
 instance Pretty C.ChainPoint where
   pretty C.ChainPointAtGenesis = "ChainPointAtGenesis"
   pretty (C.ChainPoint sn ha) = "ChainPoint(" <> pretty sn <> "," <+> pretty ha <> ")"

--- a/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
@@ -12,7 +12,7 @@ import Cardano.Binary qualified as CBOR
 import Cardano.Ledger.Shelley.API qualified as Ledger
 import Codec.CBOR.Read qualified as CBOR
 import Codec.Serialise (Serialise (decode, encode))
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON, ToJSON, (.:))
 import Data.Aeson qualified as Aeson
 import Data.ByteString.Lazy (toStrict)
 import Data.Coerce (coerce)

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -75,9 +75,10 @@ genUtxoEventsWithTxs' genTxBodyContent = do
           plutusDatums = Datum.getPlutusDatumsFromTxs txs
           filteredTxOutDatums :: Map (C.Hash C.ScriptData) C.ScriptData
           filteredTxOutDatums = Datum.getFilteredTxOutDatumsFromTxs Nothing txs
-       in -- We don't care about the timestamp or the epochNo, so we put default values.
-          UtxoEvent resolvedUtxos spentTxOuts (BlockInfo slotNo blockHeaderHash blockNo 0 1) $
-            Map.union plutusDatums filteredTxOutDatums
+          -- We don't care about the timestamp or the epochNo, so we put default values.
+          blockInfo = BlockInfo slotNo blockHeaderHash blockNo 0 1
+          tip = C.ChainTip slotNo blockHeaderHash blockNo
+       in UtxoEvent resolvedUtxos spentTxOuts blockInfo (Map.union plutusDatums filteredTxOutDatums) tip
 
     getUtxosFromTx :: (C.Tx C.BabbageEra, TxIndexInBlock) -> Map C.TxIn Utxo
     getUtxosFromTx (C.Tx txBody@(C.TxBody txBodyContent) _, txIndexInBlock) =

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -182,15 +182,15 @@ propAllQueryUtxosShouldBeUnspent = Hedgehog.property $ do
           $ events
   results <- liftIO . raiseException . traverse (Storable.query indexer) $ addressQueries
   let getResult = \case
-        Utxo.UtxoByAddressResult rs -> rs
-        Utxo.LastSyncedBlockInfoResult _ -> []
+        Utxo.UtxoByAddressResult rs -> fst rs
+        Utxo.LastSyncedBlockInfoResult _ -> error "Invalid result type"
       retrievedUtxoResults :: [Utxo.UtxoResult] = concatMap getResult results
       -- Get all the TxIn from quried UtxoRows
       txInsFromRetrievedUtxoRows :: [C.TxIn] =
         fmap Utxo.utxoResultTxIn retrievedUtxoResults
       -- Get all the TxIn from quried UtxoRows
       txInsFromGeneratedEvents :: [C.TxIn] =
-        concatMap (\(Utxo.UtxoEvent _ ins _ _) -> Map.keys ins) events
+        concatMap (\(Utxo.UtxoEvent _ ins _ _ _) -> Map.keys ins) events
 
   -- A property of the generator is that there is at least one unspent transaction
   -- this property also ensures that the next test will not succeed for the trivila case
@@ -227,7 +227,7 @@ propReturnedInputsArePartOfTheOfTheGeneratedSpentOutputs = property $ do
           foldMap (fmap (view Utxo.address) . Utxo.ueUtxos) events
   results <- liftIO . raiseException . traverse (Storable.query indexer) $ addressQueries
   let getResult = \case
-        Utxo.UtxoByAddressResult rs -> rs >>= Utxo.utxoResultTxIns
+        Utxo.UtxoByAddressResult rs -> fst rs >>= Utxo.utxoResultTxIns
         Utxo.LastSyncedBlockInfoResult _ -> error "Can't happen"
       retrievedTxIns = foldMap getResult results
       txInsFromGeneratedEvents :: [C.TxIn] =
@@ -264,15 +264,15 @@ propAllQueryUtxosSpentInTheFutureHaveASpentTxId = Hedgehog.property $ do
         Utxo.open ":memory:" (Utxo.Depth depth) False >>= Storable.insertMany events
   results <- liftIO . raiseException . traverse (Storable.query indexer) $ addressQueries upperBound
   let getResult = \case
-        Utxo.UtxoByAddressResult rs -> rs
-        Utxo.LastSyncedBlockInfoResult _ -> []
+        Utxo.UtxoByAddressResult rs -> fst rs
+        Utxo.LastSyncedBlockInfoResult _ -> error "Invalid result type"
       utxoResults :: [Utxo.UtxoResult] = concatMap getResult results
       -- Get all the TxIn from quried UtxoRows
       txInsFromRetrievedUtxoRows :: [C.TxIn] =
         fmap Utxo.utxoResultTxIn utxoResults
 
       getAlreadySpent :: StorableEvent Utxo.UtxoHandle -> [C.TxIn]
-      getAlreadySpent (Utxo.UtxoEvent _ ins bi _) =
+      getAlreadySpent (Utxo.UtxoEvent _ ins bi _ _) =
         if upperBound >= Utxo._blockInfoSlotNo bi
           then Map.keys ins
           else []
@@ -281,7 +281,7 @@ propAllQueryUtxosSpentInTheFutureHaveASpentTxId = Hedgehog.property $ do
       txInsFromGeneratedEvents :: [C.TxIn]
       txInsFromGeneratedEvents =
         foldMap getAlreadySpent $
-          filter (\(Utxo.UtxoEvent _ _ bi _) -> upperBound < Utxo._blockInfoSlotNo bi) events
+          filter (\(Utxo.UtxoEvent _ _ bi _ _) -> upperBound < Utxo._blockInfoSlotNo bi) events
 
   -- A property of the generator is that there is at least one unspent transaction
   -- this property also ensures that the next test will not succeed for the trivila case
@@ -293,7 +293,7 @@ propAllQueryUtxosSpentInTheFutureHaveASpentTxId = Hedgehog.property $ do
   -- No retrieved utxo should be spent by upperBound if it's spent after that
   traverse_ (Hedgehog.assert . flip notElem txInsFromGeneratedEvents) txInsFromRetrievedUtxoRows
 
-  let allSpent = flip map events $ \(Utxo.UtxoEvent _ ins bi _) ->
+  let allSpent = flip map events $ \(Utxo.UtxoEvent _ ins bi _ _) ->
         if Utxo._blockInfoSlotNo bi > upperBound
           then Left $ Map.keysSet ins
           else Right $ Map.keysSet ins
@@ -331,6 +331,7 @@ propUtxoQueryShouldRespondWithResolvedDatums = Hedgehog.property $ do
   bhh <- forAll Gen.genHashBlockHeader
   let blockInfo = BlockInfo slotNo bhh (C.BlockNo sn) 0 1
       blockInfo2 = BlockInfo slotNo bhh (C.BlockNo (sn + 1)) 0 1
+      tip = C.ChainTip slotNo bhh (C.BlockNo (sn + 2))
       utxoIndexerConfig = UtxoIndexerConfig{ucTargetAddresses = Nothing, ucEnableUtxoTxOutRef = True}
 
   -- Generated UtxoEvents that contain only resolved datums
@@ -342,7 +343,7 @@ propUtxoQueryShouldRespondWithResolvedDatums = Hedgehog.property $ do
           , fmap (\d -> Gen.TxOutDatumInlineLocation (C.hashScriptDataBytes d) d) CGen.genHashableScriptData
           ]
   txs1 <- forAll $ Gen.genTxsWithAddresses addrsWithResolvedDatum
-  let utxoEventsResolvedDatums = Utxo.getUtxoEvents utxoIndexerConfig txs1 blockInfo
+  let utxoEventsResolvedDatums = Utxo.getUtxoEvents utxoIndexerConfig txs1 blockInfo tip
 
   -- Generated UtxoEvents that contain only unresolved datums
   addrsWithUnresolvedDatum <-
@@ -352,7 +353,7 @@ propUtxoQueryShouldRespondWithResolvedDatums = Hedgehog.property $ do
           [ fmap (\d -> Gen.TxOutDatumHashLocation (C.hashScriptDataBytes d) d) CGen.genHashableScriptData
           ]
   txs2 <- forAll $ Gen.genTxsWithAddresses addrsWithUnresolvedDatum
-  let utxoEventsUnresolvedDatums = Utxo.getUtxoEvents utxoIndexerConfig txs2 blockInfo2
+  let utxoEventsUnresolvedDatums = Utxo.getUtxoEvents utxoIndexerConfig txs2 blockInfo2 tip
 
   let utxoEvents = [utxoEventsResolvedDatums, utxoEventsUnresolvedDatums]
   Hedgehog.annotateShow utxoEvents
@@ -373,8 +374,8 @@ propUtxoQueryShouldRespondWithResolvedDatums = Hedgehog.property $ do
       raiseException $
         traverse (Storable.query indexer) qs
   let getResult = \case
-        Utxo.UtxoByAddressResult rs -> rs
-        Utxo.LastSyncedBlockInfoResult _ -> []
+        Utxo.UtxoByAddressResult rs -> fst rs
+        Utxo.LastSyncedBlockInfoResult _ -> error "Invalid result type"
       actualUtxoResults = concatMap getResult results
       actualDatumHashes = Set.fromList $ mapMaybe Utxo.utxoResultDatumHash actualUtxoResults
       actualDatums = Set.fromList $ mapMaybe Utxo.utxoResultDatum actualUtxoResults
@@ -418,8 +419,9 @@ propTxInWhenPhase2ValidationFails = Hedgehog.property $ do
   slotNo@(C.SlotNo sn) <- forAll Gen.genSlotNo
   bhh <- forAll Gen.genHashBlockHeader
   let blockInfo = BlockInfo slotNo bhh (C.BlockNo sn) 0 1
+      tip = C.ChainTip slotNo bhh (C.BlockNo sn)
       utxoIndexerConfig = UtxoIndexerConfig{ucTargetAddresses = Nothing, ucEnableUtxoTxOutRef = True}
-      event :: StorableEvent Utxo.UtxoHandle = Utxo.getUtxoEvents utxoIndexerConfig [tx] blockInfo
+      event = Utxo.getUtxoEvents utxoIndexerConfig [tx] blockInfo tip
       computedTxIns :: [C.TxIn] = fmap (view Utxo.sTxIn) $ Utxo.getSpentFrom event
       expectedTxIns :: [C.TxIn] = fmap fst txIns
 
@@ -504,12 +506,12 @@ propSaveAndRetrieveUtxoEvents = Hedgehog.property $ do
       . traverse (Storable.query indexer)
       $ qs
   let getResult = \case
-        Utxo.UtxoByAddressResult rs -> rs
-        Utxo.LastSyncedBlockInfoResult _ -> []
+        Utxo.UtxoByAddressResult rs -> fst rs
+        Utxo.LastSyncedBlockInfoResult _ -> error "Invalid response type"
       resultsFromStorage :: [Utxo.UtxoResult] = concatMap getResult results
       fromStorageTxIns :: Set.Set C.TxIn =
         Set.fromList $ map Utxo.utxoResultTxIn resultsFromStorage
-      maybeSpentThusFar (Utxo.UtxoEvent _ ins bi _) =
+      maybeSpentThusFar (Utxo.UtxoEvent _ ins bi _ _) =
         if Utxo._blockInfoSlotNo bi <= upperBound
           then Just $ Map.keysSet ins
           else Nothing
@@ -626,8 +628,8 @@ propUtxoQueryByAddressAndSlotInterval = property $ do
 
             filterResult :: StorableResult Utxo.UtxoHandle -> [Utxo.UtxoResult]
             filterResult = \case
-              Utxo.UtxoByAddressResult rs -> rs
-              _other -> []
+              Utxo.UtxoByAddressResult rs -> fst rs
+              _other -> error "invalid result type"
 
         maxIntervalResult <-
           liftIO $ raiseException $ traverse (Storable.query indexer) maxIntervalQuery
@@ -697,12 +699,14 @@ propSupressSavingInlineScriptAndInlineScriptHash = property $ do
               saveRefUtxoIndexerConfig
               txs
               (Utxo.ueBlockInfo expectedUtxoEvent)
+              (Utxo.ueTip expectedUtxoEvent)
         withNoSaveScriptRef =
           Utxo.ueUtxos $
             Utxo.getUtxoEvents
               noSaveRefUtxoIndexerConfig
               txs
               (Utxo.ueBlockInfo expectedUtxoEvent)
+              (Utxo.ueTip expectedUtxoEvent)
 
     -- There should be some inlineScripts
     Hedgehog.annotateShow withSaveScriptRef
@@ -739,6 +743,7 @@ propUsingAllAddressesOfTxsAsTargetAddressesShouldReturnUtxosAsIfNoFilterWasAppli
             utxoIndexerConfig
             txs
             (Utxo.ueBlockInfo expectedUtxoEvent)
+            (Utxo.ueTip expectedUtxoEvent)
         filteredExpectedUtxoEvent =
           expectedUtxoEvent
             { Utxo.ueUtxos =
@@ -809,8 +814,9 @@ propGetUtxoEventFromBlock = Hedgehog.property $ do
     let (C.BlockHeader sno bhh bn) = mockBlockChainPoint block
         txs = mockBlockTxs block
         bi = BlockInfo sno bhh bn 0 1
+        tip = C.ChainTip sno bhh bn
         utxoIndexerConfig = UtxoIndexerConfig{ucTargetAddresses = Nothing, ucEnableUtxoTxOutRef = True}
-        computedEvent = Utxo.getUtxoEvents utxoIndexerConfig txs bi
+        computedEvent = Utxo.getUtxoEvents utxoIndexerConfig txs bi tip
     length (Utxo.ueUtxos computedEvent) === length (Utxo.ueUtxos expectedUtxoEvent)
     length (Utxo.ueInputs computedEvent) === length (Utxo.ueInputs expectedUtxoEvent)
     computedEvent === expectedUtxoEvent
@@ -868,6 +874,6 @@ mkUtxoQueries events slotInterval =
       qAddresses =
         Set.toList
           . Set.fromList
-          . concatMap (\(Utxo.UtxoEvent utxoSet _ _ _) -> map Utxo._address utxoSet)
+          . concatMap (\(Utxo.UtxoEvent utxoSet _ _ _ _) -> map Utxo._address utxoSet)
           $ events
    in fmap (Utxo.QueryUtxoByAddressWrapper . flip Utxo.QueryUtxoByAddress slotInterval) qAddresses

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/HttpServer.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/HttpServer.hs
@@ -27,6 +27,7 @@ import Marconi.Sidechain.Api.Routes (
   API,
   GetBurnTokenEventsParams (afterTx, assetName, beforeSlotNo, policyId),
   GetBurnTokenEventsResult (GetBurnTokenEventsResult),
+  GetCurrentSyncedBlockParams,
   GetCurrentSyncedBlockResult,
   GetEpochActiveStakePoolDelegationResult,
   GetEpochNonceResult,
@@ -133,7 +134,7 @@ getTargetAddressesQueryHandler env _ =
 getCurrentSyncedBlockHandler
   :: SidechainEnv
   -- ^ Utxo Environment to access Utxo Storage running on the marconi thread
-  -> String
+  -> GetCurrentSyncedBlockParams
   -- ^ Will always be an empty string as we are ignoring this param, and returning everything
   -> Handler (Either (JsonRpcErr String) GetCurrentSyncedBlockResult)
 getCurrentSyncedBlockHandler env _ =

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -28,6 +28,7 @@ import Marconi.Sidechain.Api.Routes (
   AddressUtxoResult (AddressUtxoResult),
   GetCurrentSyncedBlockResult (GetCurrentSyncedBlockResult),
   GetUtxosFromAddressResult (GetUtxosFromAddressResult),
+  SidechainTip (SidechainTip),
   SpentInfoResult (SpentInfoResult),
   UtxoTxInput (UtxoTxInput),
  )
@@ -72,8 +73,8 @@ currentSyncedBlock env = do
   indexer <- atomically (readTMVar $ env ^. addressUtxoIndexerEnvIndexer)
   res <- runExceptT $ Storable.query indexer Utxo.LastSyncedBlockInfoQuery
   pure $ case res of
-    Right (Utxo.LastSyncedBlockInfoResult blockInfoM) ->
-      Right $ GetCurrentSyncedBlockResult blockInfoM
+    Right (Utxo.LastSyncedBlockInfoResult blockInfoM tip) ->
+      Right $ GetCurrentSyncedBlockResult blockInfoM (SidechainTip tip)
     Left (InvalidIndexer err) -> Left $ IndexerInternalError err
     _other -> Left $ UnexpectedQueryResult Utxo.LastSyncedBlockInfoQuery
 

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -130,16 +130,20 @@ data GetCurrentSyncedBlockResult
 
 instance ToJSON GetCurrentSyncedBlockResult where
   toJSON (GetCurrentSyncedBlockResult blockInfoM tip) =
-    let chainPointObj = case blockInfoM of
-          (At (BlockInfo sn bhh bn bt en)) ->
-            [ "blockNo" .= bn
-            , "blockTimestamp" .= bt
-            , "blockHeaderHash" .= bhh
-            , "slotNo" .= sn
-            , "epochNo" .= en
-            , "nodeTip" .= toJSON tip
-            ]
-          Origin -> ["nodeTip" .= toJSON tip]
+    let nodeTip = case tip of
+          SidechainTip C.ChainTipAtGenesis -> []
+          tip' -> ["nodeTip" .= toJSON tip']
+        chainPointObj =
+          case blockInfoM of
+            (At (BlockInfo sn bhh bn bt en)) ->
+              [ "blockNo" .= bn
+              , "blockTimestamp" .= bt
+              , "blockHeaderHash" .= bhh
+              , "slotNo" .= sn
+              , "epochNo" .= en
+              ]
+                <> nodeTip
+            Origin -> nodeTip
      in Aeson.object chainPointObj
 
 instance FromJSON GetCurrentSyncedBlockResult where

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -132,6 +132,9 @@ instance FromJSON GetCurrentSyncedBlockParams where
   parseJSON (Aeson.Object o) | null o = pure GetCurrentSyncedBlockParams
   parseJSON _ = fail "The param value must be empty (use '{}', 'null', empty string"
 
+instance ToJSON GetCurrentSyncedBlockParams where
+  toJSON = const Aeson.Null
+
 data GetCurrentSyncedBlockResult
   = GetCurrentSyncedBlockResult (WithOrigin BlockInfo) SidechainTip
   deriving (Eq, Ord, Generic, Show)

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -66,7 +66,7 @@ type RpcTargetAddressesMethod = JsonRpc "getTargetAddresses" String String [Text
 type RpcCurrentSyncedBlockMethod =
   JsonRpc
     "getCurrentSyncedBlock"
-    String
+    GetCurrentSyncedBlockParams
     String
     GetCurrentSyncedBlockResult
 
@@ -123,6 +123,14 @@ instance FromJSON SidechainTip where
           bn <- v .: "blockNo"
           pure $ SidechainTip $ C.ChainTip slotNo bhh bn
      in Aeson.withObject "ChainTip" parseTip obj
+
+data GetCurrentSyncedBlockParams = GetCurrentSyncedBlockParams
+
+instance FromJSON GetCurrentSyncedBlockParams where
+  parseJSON (Aeson.String "") = pure GetCurrentSyncedBlockParams
+  parseJSON Aeson.Null = pure GetCurrentSyncedBlockParams
+  parseJSON (Aeson.Object o) | null o = pure GetCurrentSyncedBlockParams
+  parseJSON _ = fail "The param value must be empty (use '{}', 'null', empty string"
 
 data GetCurrentSyncedBlockResult
   = GetCurrentSyncedBlockResult (WithOrigin BlockInfo) SidechainTip

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -25,7 +25,7 @@ import Data.Function (on)
 import Data.List qualified as List
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
@@ -102,12 +102,34 @@ type RpcEpochNonceMethod =
 -- Query and Result types
 --------------------------
 
-newtype GetCurrentSyncedBlockResult
-  = GetCurrentSyncedBlockResult (WithOrigin BlockInfo)
+newtype SidechainTip = SidechainTip {getTip :: C.ChainTip}
+  deriving (Eq, Ord, Generic, Show)
+
+instance ToJSON SidechainTip where
+  toJSON (SidechainTip C.ChainTipAtGenesis) = Aeson.Null
+  toJSON (SidechainTip (C.ChainTip sn bhh bn)) =
+    Aeson.object
+      [ "blockNo" .= bn
+      , "blockHeaderHash" .= bhh
+      , "slotNo" .= sn
+      ]
+
+instance FromJSON SidechainTip where
+  parseJSON Aeson.Null = pure $ SidechainTip C.ChainTipAtGenesis
+  parseJSON obj =
+    let parseTip v = do
+          slotNo <- v .: "slotNo"
+          bhh <- v .: "blockHeaderHash"
+          bn <- v .: "blockNo"
+          pure $ SidechainTip $ C.ChainTip slotNo bhh bn
+     in Aeson.withObject "ChainTip" parseTip obj
+
+data GetCurrentSyncedBlockResult
+  = GetCurrentSyncedBlockResult (WithOrigin BlockInfo) SidechainTip
   deriving (Eq, Ord, Generic, Show)
 
 instance ToJSON GetCurrentSyncedBlockResult where
-  toJSON (GetCurrentSyncedBlockResult blockInfoM) =
+  toJSON (GetCurrentSyncedBlockResult blockInfoM tip) =
     let chainPointObj = case blockInfoM of
           (At (BlockInfo sn bhh bn bt en)) ->
             [ "blockNo" .= bn
@@ -115,8 +137,9 @@ instance ToJSON GetCurrentSyncedBlockResult where
             , "blockHeaderHash" .= bhh
             , "slotNo" .= sn
             , "epochNo" .= en
+            , "nodeTip" .= toJSON tip
             ]
-          Origin -> []
+          Origin -> ["nodeTip" .= toJSON tip]
      in Aeson.object chainPointObj
 
 instance FromJSON GetCurrentSyncedBlockResult where
@@ -127,8 +150,9 @@ instance FromJSON GetCurrentSyncedBlockResult where
           bnM <- v .:? "blockNo"
           blockTimestampM <- v .:? "blockTimestamp"
           epochNoM <- v .:? "epochNo"
+          tip <- v .:? "nodeTip"
           let blockInfoM = withOriginFromMaybe $ BlockInfo <$> slotNoM <*> bhhM <*> bnM <*> blockTimestampM <*> epochNoM
-          pure $ GetCurrentSyncedBlockResult blockInfoM
+          pure $ GetCurrentSyncedBlockResult blockInfoM (fromMaybe (SidechainTip C.ChainTipAtGenesis) tip)
      in Aeson.withObject "BlockResult" parseBlock
 
 data GetUtxosFromAddressParams = GetUtxosFromAddressParams

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Query/Indexers/Utxo.hs
@@ -162,7 +162,7 @@ propUtxoEventInsertionAndJsonRpcCurrentSlotQuery action = property $ do
   -- Now, we are storing the events in the index
   liftIO $ insertUtxoEventsAction action events
 
-  Result _ (GetCurrentSyncedBlockResult resp) <- liftIO $ querySyncedBlockAction action
+  Result _ (GetCurrentSyncedBlockResult resp _tip) <- liftIO $ querySyncedBlockAction action
   Hedgehog.cover 40 "Should have some significant non genesis chainpoints results" $
     resp /= Origin && fmap _blockInfoSlotNo resp > At (C.SlotNo 0)
   assert $ getBlockInfoChainPoint resp `elem` chainPoints

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Routes/Golden/current-synced-point-response-1.json
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Routes/Golden/current-synced-point-response-1.json
@@ -1,3 +1,1 @@
-{
-    "nodeTip": null
-}
+{}

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Routes/Golden/current-synced-point-response-1.json
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Routes/Golden/current-synced-point-response-1.json
@@ -1,1 +1,3 @@
-{}
+{
+    "nodeTip": null
+}

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Routes/Golden/current-synced-point-response-2.json
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/Api/Routes/Golden/current-synced-point-response-2.json
@@ -3,5 +3,10 @@
     "blockNo": 64903,
     "blockTimestamp": 0,
     "epochNo": 6,
+    "nodeTip": {
+        "blockHeaderHash": "6161616161616161616161616161616161616161616161616161616161616161",
+        "blockNo": 64903,
+        "slotNo": 1
+    },
     "slotNo": 1
 }

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/RpcClientAction.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/RpcClientAction.hs
@@ -14,6 +14,7 @@ import Marconi.Sidechain.Api.Query.Indexers.Utxo qualified as UIQ
 import Marconi.Sidechain.Api.Routes (
   GetBurnTokenEventsParams (GetBurnTokenEventsParams),
   GetBurnTokenEventsResult,
+  GetCurrentSyncedBlockParams (GetCurrentSyncedBlockParams),
   GetCurrentSyncedBlockResult,
   GetUtxosFromAddressParams (GetUtxosFromAddressParams),
   GetUtxosFromAddressResult,
@@ -65,7 +66,7 @@ mkRpcClientAction env port = do
       (mkInsertUtxoEventsCallback env)
       (mkInsertMintBurnEventsCallback env)
       (\a -> rpcUtxos $ GetUtxosFromAddressParams a (Utxo.lessThanOrEqual maxBound))
-      (rpcSyncPoint "")
+      (rpcSyncPoint GetCurrentSyncedBlockParams)
       (\(p, a) -> rpcMinting $ GetBurnTokenEventsParams p a Nothing Nothing)
 
 baseUrl :: Warp.Port -> BaseUrl


### PR DESCRIPTION
Added the chain tip to the event and propagated it down to the side chain query.

The only issue (that would be complex to overcome) is that we ignore chainTip on rollback.
Handling it means either adding an indexing call on rollback and changing the event type to allow it, or adding a specific backdoor function to change the content of the tip. 

These solutions look ugly so I didn't integrate it. May be there is a cleaner one but I hadn't find it.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
