### PR TITLE
Fix new rollback

### DIFF
--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
@@ -38,7 +38,6 @@ import Database.SQLite.Simple qualified as SQL
 
 import Data.Foldable (Foldable (toList), traverse_)
 import Data.Maybe (catMaybes)
-import Database.SQLite.Simple.QQ (sql)
 import Database.SQLite.Simple.ToField qualified as SQL
 import Marconi.Core.Experiment.Class (
   Closeable (close),
@@ -224,13 +223,10 @@ instance
 
   rollback p indexer = do
     let c = indexer ^. handle
-        deleteAll tName =
-          SQL.executeNamed
-            c
-            [sql|DELETE FROM tableName"|]
-            [":tableName" SQL.:= tName]
+        deleteAllQuery tName = "DELETE FROM " <> tName
+        deleteAll = SQL.execute_ c . deleteAllQuery . SQL.Query . Text.pack
         deleteUntilQuery tName pName =
-          "DELETE FROM " <> tName <> " WHERE " <> pName <> " > :point"
+          deleteAllQuery tName <> " WHERE " <> pName <> " > :point"
         deleteUntil :: (SQL.ToField a) => String -> String -> a -> IO ()
         deleteUntil tName pName pt =
           SQL.executeNamed

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -133,7 +133,7 @@ import Data.Function ((&))
 
 import GHC.Generics (Generic)
 
-import Test.QuickCheck (Arbitrary, Gen, Property, choose, (===), (==>))
+import Test.QuickCheck (Arbitrary, Gen, Property, chooseInt, (===), (==>))
 import Test.QuickCheck qualified as Test
 import Test.QuickCheck.Monadic (PropertyM)
 import Test.QuickCheck.Monadic qualified as GenM
@@ -266,7 +266,7 @@ genChain cfg = flip evalStateT cfg $ do
   replicateM size genItem
 
 uniformRollBack :: TestPoint -> Gen TestPoint
-uniformRollBack = fmap TestPoint . choose . (,) 0 . unwrapTestPoint
+uniformRollBack = fmap TestPoint . chooseInt . (,) 0 . unwrapTestPoint
 
 genLargeChain
   :: (Arbitrary event)
@@ -274,7 +274,7 @@ genLargeChain
   -- ^ Rollback percentage
   -> Gen [Item event]
 genLargeChain p = do
-  let n = Test.choose (1000000, 1200000)
+  let n = Test.chooseInt (1000000, 1200000)
   genChain $ GenChainConfig n 5 p uniformRollBack 0
 
 -- | Chain events with 10% of rollback

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -505,12 +505,14 @@ initSQLite = do
 
 sqliteModelIndexer :: SQL.Connection -> ExceptT Core.IndexerError IO (Core.SQLiteIndexer TestEvent)
 sqliteModelIndexer con =
-  Core.mkSingleInsertSqliteIndexer
-    con
-    (\t -> (t ^. Core.point, t ^. Core.event))
-    "INSERT INTO index_model VALUES (?, ?)"
-    (Core.SQLRollbackPlan "index_model" "point" Just)
-    "SELECT point FROM index_model ORDER BY point DESC LIMIT 1"
+  let extractor 0 = Nothing
+      extractor n = Just n
+   in Core.mkSingleInsertSqliteIndexer
+        con
+        (\t -> (t ^. Core.point, t ^. Core.event))
+        "INSERT INTO index_model VALUES (?, ?)"
+        (Core.SQLRollbackPlan "index_model" "point" extractor)
+        "SELECT point FROM index_model ORDER BY point DESC LIMIT 1"
 
 instance
   ( MonadIO m

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -282,7 +282,7 @@ newtype DefaultChain event = DefaultChain {_defaultChain :: [Item event]}
 
 makeLenses 'DefaultChain
 
--- | Chain events with 10% of rollback (rollbackDepth is)
+-- | Chain events with 10% of rollback
 instance (Arbitrary event) => Arbitrary (DefaultChain event) where
   arbitrary = Test.sized $ \n ->
     DefaultChain <$> genChain (GenChainConfig (pure n) 5 10 uniformRollBack 0)


### PR DESCRIPTION
The from genesis query was wrong. It's fixed, the indexer that tests the rollback is fixed as well, to cover the case.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
