### PR TITLE
Fix syncLastPointQuery

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/SyncHelper.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/SyncHelper.hs
@@ -65,11 +65,13 @@ syncLastPointQuery = syncHistoryQuery 1
 {- | Query the last sync point up to the first immutable event
 
 Used to find resuming points on restart.
+
+Note that if you want to get one stable point, you need to pass @securityParam + 1@
 -}
 syncHistoryQuery :: SecurityParam -> SQL.Query
 syncHistoryQuery securityParam =
   [sql|SELECT * FROM sync ORDER BY slotNo DESC LIMIT |]
-    <> SQL.Query (Text.pack $ show $ securityParam + 1)
+    <> SQL.Query (Text.pack $ show securityParam)
 
 -- | Standard rollback plan for the sync table
 syncRollbackPlan :: Core.SQLRollbackPlan C.ChainPoint

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
@@ -105,10 +105,11 @@ makeLenses 'SQLiteIndexer
  that we set 'dbLastSync' thanks to the provided query
 -}
 mkSqliteIndexer
-  :: (MonadIO m)
-  => (MonadError IndexerError m)
-  => (HasGenesis (Point event))
-  => (SQL.FromRow (Point event))
+  :: ( MonadIO m
+     , MonadError IndexerError m
+     , HasGenesis (Point event)
+     , SQL.FromRow (Point event)
+     )
   => FilePath
   -> [SQL.Query]
   -- ^ cration statement


### PR DESCRIPTION
There was an off by 1 error that ends in retrieving 2 points instead of 1 in the getLastSync query, stopping the application on resuming.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
