### PR TITLE
Change lastSyncPoint in coordinator

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Coordinator.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Coordinator.hs
@@ -15,7 +15,7 @@ import Marconi.ChainIndex.Experimental.Indexers.Orphans qualified ()
 import Marconi.Core.Experiment qualified as Core
 
 coordinatorWorker
-  :: (MonadIO m, Ord (Core.Point b), Core.HasGenesis (Core.Point b))
+  :: (MonadIO m, Ord (Core.Point b))
   => Text
   -> (WithDistance a -> IO (Maybe b))
   -> [Core.Worker b (Core.Point b)]

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -1,13 +1,13 @@
 module Spec.Marconi.ChainIndex.Experimental.Indexers (tests) where
 
 import Test.Tasty (TestTree, localOption, testGroup)
-import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit))
 
 import Spec.Marconi.ChainIndex.Experimental.Indexers.BlockInfo qualified as BlockInfo
 import Spec.Marconi.ChainIndex.Experimental.Indexers.Datum qualified as Datum
 import Spec.Marconi.ChainIndex.Experimental.Indexers.Spent qualified as Spent
 import Spec.Marconi.ChainIndex.Experimental.Indexers.Utxo qualified as Utxo
 import Spec.Marconi.ChainIndex.Experimental.Indexers.UtxoQuery qualified as UtxoQuery
+import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit))
 
 tests :: TestTree
 tests =

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -345,7 +345,6 @@ module Marconi.Core.Experiment (
 
   -- ** Coordinator
   Coordinator,
-  lastSync,
   workers,
   threadIds,
   tokens,
@@ -468,7 +467,6 @@ import Marconi.Core.Experiment.Class (
 import Marconi.Core.Experiment.Coordinator (
   Coordinator,
   channel,
-  lastSync,
   mkCoordinator,
   nbWorkers,
   step,

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -624,7 +624,10 @@ instance
   indexAllDescending = Core.indexAllDescendingVia underCoordinator
   rollback = Core.rollbackVia $ underCoordinator . wrappedIndexer
 
-instance (MonadIO m) => Core.IsSync m event (UnderCoordinator indexer) where
+instance
+  (MonadIO m, MonadError Core.IndexerError m, Ord (Core.Point event))
+  => Core.IsSync m event (UnderCoordinator indexer)
+  where
   lastSyncPoint = Core.lastSyncPointVia underCoordinator
 
 instance


### PR DESCRIPTION
The coordinator compute its `lastSyncPoint` through the workers instead of maintaining it in its own variable.
It should improve the accuracy of the last sync point when some transformer changes the behaviour of the indexing.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
