### PR TITLE
Always track point

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/BlockInfo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/BlockInfo.hs
@@ -104,9 +104,10 @@ mkBlockInfoIndexer path = do
       blockInfoInsertQuery =
         [sql|INSERT INTO blockInfo (slotNo, blockHeaderHash, blockNo, blockTimestamp, epochNo)
              VALUES (?, ?, ?, ?, ?)|]
-      lastPointQuery :: SQL.Query
+      lastPointQuery :: Core.GetLastSyncQuery
       lastPointQuery =
-        [sql|SELECT slotNo, blockHeaderHash FROM blockInfo ORDER BY slotNo DESC LIMIT 1|]
+        Core.GetLastSyncQuery
+          [sql|SELECT slotNo, blockHeaderHash FROM blockInfo ORDER BY slotNo DESC LIMIT 1|]
   Core.mkSingleInsertSqliteIndexer
     path
     id

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Datum.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Datum.hs
@@ -107,15 +107,14 @@ mkDatumIndexer path = do
         [sql|CREATE TABLE IF NOT EXISTS datum (datumHash BLOB PRIMARY KEY, datum BLOB, slotNo Int)|]
       datumInsertQuery :: SQL.Query
       datumInsertQuery =
-        [sql|INSERT OR IGNORE INTO datum (datumHash, datum, slotNo) VALUES (?, ?, ?)|]
+        [sql|INSERT OR IGNORE INTO datum (datumHash, datum, slotNo)
+          VALUES (?, ?, ?)|]
+      datumCreation = [createDatum, Sync.syncTableCreation]
   Core.mkSqliteIndexer
     path
-    [createDatum, Sync.syncTableCreation]
-    [
-      [ Core.SQLInsertPlan (traverse NonEmpty.toList) datumInsertQuery
-      , Sync.syncInsertPlan
-      ]
-    ]
+    datumCreation
+    [[Core.SQLInsertPlan (traverse NonEmpty.toList) datumInsertQuery]]
+    (Just Sync.syncInsertPlan)
     [ Core.SQLRollbackPlan "datum" "slotNo" C.chainPointToSlotNo
     , Sync.syncRollbackPlan
     ]

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Datum.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Datum.hs
@@ -103,16 +103,16 @@ mkDatumIndexer
   => FilePath
   -> m (Core.SQLiteIndexer DatumEvent)
 mkDatumIndexer path = do
-  let createDatum =
+  let createDatumQuery =
         [sql|CREATE TABLE IF NOT EXISTS datum (datumHash BLOB PRIMARY KEY, datum BLOB, slotNo Int)|]
       datumInsertQuery :: SQL.Query
       datumInsertQuery =
         [sql|INSERT OR IGNORE INTO datum (datumHash, datum, slotNo)
           VALUES (?, ?, ?)|]
-      datumCreation = [createDatum, Sync.syncTableCreation]
+      createDatumTables = [createDatumQuery, Sync.syncTableCreation]
   Core.mkSqliteIndexer
     path
-    datumCreation
+    createDatumTables
     [[Core.SQLInsertPlan (traverse NonEmpty.toList) datumInsertQuery]]
     (Just Sync.syncInsertPlan)
     [ Core.SQLRollbackPlan "datum" "slotNo" C.chainPointToSlotNo

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -259,15 +259,14 @@ mkMintTokenIndexer dbPath = do
                  redeemerData
               ) VALUES
               (?, ?, ?, ?, ?, ?, ?, ?)|]
+      mintCreation = [createMintPolicyEvent, createMintPolicyIdIndex, Sync.syncTableCreation]
+      mintInsert = [Core.SQLInsertPlan timedMintEventsToTimedMintEventList mintEventInsertQuery]
 
   Core.mkSqliteIndexer
     dbPath
-    [createMintPolicyEvent, createMintPolicyIdIndex, Sync.syncTableCreation]
-    [
-      [ Core.SQLInsertPlan timedMintEventsToTimedMintEventList mintEventInsertQuery
-      , Sync.syncInsertPlan
-      ]
-    ]
+    mintCreation
+    [mintInsert]
+    (Just Sync.syncInsertPlan)
     [ Core.SQLRollbackPlan "minting_policy_events" "slotNo" C.chainPointToSlotNo
     , Sync.syncRollbackPlan
     ]

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Spent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Spent.hs
@@ -119,14 +119,15 @@ mkSpentIndexer path = do
                , slotNo
                )
                VALUES (?, ?, ?, ?)|]
+      spentCreation =
+        [createSpent, createSlotNoIndex, createTxInIndex, createSpentAtIndex, Sync.syncTableCreation]
+      spentInsert =
+        [Core.SQLInsertPlan (traverse NonEmpty.toList) spentInsertQuery]
   Core.mkSqliteIndexer
     path
-    [createSpent, createSlotNoIndex, createTxInIndex, createSpentAtIndex, Sync.syncTableCreation]
-    [
-      [ Core.SQLInsertPlan (traverse NonEmpty.toList) spentInsertQuery
-      , Sync.syncInsertPlan
-      ]
-    ]
+    spentCreation
+    [spentInsert]
+    (Just Sync.syncInsertPlan)
     [ Core.SQLRollbackPlan "spent" "slotNo" C.chainPointToSlotNo
     , Sync.syncRollbackPlan
     ]

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Spent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Spent.hs
@@ -119,13 +119,13 @@ mkSpentIndexer path = do
                , slotNo
                )
                VALUES (?, ?, ?, ?)|]
-      spentCreation =
+      createSpentTables =
         [createSpent, createSlotNoIndex, createTxInIndex, createSpentAtIndex, Sync.syncTableCreation]
       spentInsert =
         [Core.SQLInsertPlan (traverse NonEmpty.toList) spentInsertQuery]
   Core.mkSqliteIndexer
     path
-    spentCreation
+    createSpentTables
     [spentInsert]
     (Just Sync.syncInsertPlan)
     [ Core.SQLRollbackPlan "spent" "slotNo" C.chainPointToSlotNo

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -148,7 +148,7 @@ mkUtxoIndexer path = do
                  slotNo
               ) VALUES
               (?, ?, ?, ?, ?, ?, ?, ?, ?)|]
-      creationPhase =
+      createUtxoTables =
         [ Sync.syncTableCreation
         , createUtxo
         , createAddressIndex
@@ -157,7 +157,7 @@ mkUtxoIndexer path = do
       insertEvent = [Core.SQLInsertPlan (traverse NonEmpty.toList) utxoInsertQuery]
   Core.mkSqliteIndexer
     path
-    creationPhase
+    createUtxoTables
     [insertEvent]
     (Just Sync.syncInsertPlan)
     [ Core.SQLRollbackPlan "utxo" "slotNo" C.chainPointToSlotNo

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -255,6 +255,8 @@ module Marconi.Core.Experiment (
   -- (and the corresponding 'Queryable' interface)
   -- should be enough to have an operational indexer.
   SQLiteIndexer (SQLiteIndexer),
+  GetLastSyncQuery (GetLastSyncQuery),
+  InsertPointQuery (InsertPointQuery),
   -- | Start a new indexer or resume an existing SQLite indexer
   --
   -- The main difference with 'SQLiteIndexer' is
@@ -498,6 +500,8 @@ import Marconi.Core.Experiment.Indexer.SQLiteAggregateQuery (
   mkSQLiteAggregateQuery,
  )
 import Marconi.Core.Experiment.Indexer.SQLiteIndexer (
+  GetLastSyncQuery (GetLastSyncQuery),
+  InsertPointQuery (InsertPointQuery),
   SQLInsertPlan (..),
   SQLRollbackPlan (..),
   SQLiteIndexer (..),

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
@@ -244,10 +244,10 @@ runIndexQueries c events' plan insertPoint' =
         (Just rPlan, Just rPoint) -> Just $ Async.concurrently_ rPlan rPoint
    in case allIndex of
         Nothing -> pure ()
-        Just indexers ->
+        Just runIndexers ->
           let
            in either throwError pure <=< liftIO $
-                handleSQLErrors (SQL.withTransaction c indexers)
+                handleSQLErrors (SQL.withTransaction c runIndexers)
 
 indexEvents
   :: (MonadIO m, MonadError IndexerError m, SQL.ToRow (Point event))

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -490,7 +490,7 @@ sqliteModelIndexerWithFile f = do
     \   )"
     "INSERT INTO index_model VALUES (?, ?)"
     (Core.SQLRollbackPlan "index_model" "point" extractor)
-    "SELECT point FROM index_model ORDER BY point DESC LIMIT 1"
+    (Core.GetLastSyncQuery "SELECT point FROM index_model ORDER BY point DESC LIMIT 1")
 
 sqliteModelIndexer :: ExceptT Core.IndexerError IO (Core.SQLiteIndexer TestEvent)
 sqliteModelIndexer = sqliteModelIndexerWithFile ":memory:"


### PR DESCRIPTION
The experimental indexer design originally expect the SQL database to track only stable blocks. As a consequence, it didn't store anything if there was no event in the block.

As we now want to store unstable events as well, we need to keep track of how far we indexed, and thus to store the sync point, even if no relevant event were introduced. This PR modify the `SQLiteIndexer` to allow this.
It introduces an extra query in the indexer to store the `Point` of the `TimedEvent`, that is triggered independently of the event content. The query is optional though, as some indexers may already have the corresponding information in their event (as for the `BlockInfo` indexer).

All the indexers are modified accordingly.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
