### PR TITLE
PLT-6832 Allow params to be empty for some JSON-RPC methods

### DIFF
--- a/marconi-chain-index/json-rpc/src/Network/JsonRpc/Types.hs
+++ b/marconi-chain-index/json-rpc/src/Network/JsonRpc/Types.hs
@@ -24,6 +24,7 @@ module Network.JsonRpc.Types (
   Request (..),
   JsonRpcErr (..),
   JsonRpcResponse (..),
+  UnusedRequestParams (..),
 
   -- ** Smart constructors for standard JSON-RPC errors
   mkJsonRpcParseErr,
@@ -40,7 +41,7 @@ import Control.Applicative (liftA3, (<|>))
 import Data.Aeson (
   FromJSON (parseJSON),
   ToJSON (toJSON),
-  Value (Null),
+  Value (Null, Object, String),
   object,
   withObject,
   (.:),
@@ -176,6 +177,17 @@ instance (ToJSON e, ToJSON r) => ToJSON (JsonRpcResponse e r) where
           , "message" .= msg
           , "data" .= err
           ]
+
+data UnusedRequestParams = UnusedRequestParams
+
+instance FromJSON UnusedRequestParams where
+  parseJSON Null = pure UnusedRequestParams
+  parseJSON (String "") = pure UnusedRequestParams
+  parseJSON (Object o) | null o = pure UnusedRequestParams
+  parseJSON _ = fail "The param value must be empty (use '{}', 'null' or empty string)"
+
+instance ToJSON UnusedRequestParams where
+  toJSON = const Null
 
 -- | A JSON RPC server handles any number of methods.
 data RawJsonRpc api

--- a/marconi-sidechain/doc/API.adoc
+++ b/marconi-sidechain/doc/API.adoc
@@ -10,9 +10,9 @@ In this application, the following HTTP endpoints/routes are available:
 
 [%header%autowidth,format=csv]
 |===
-Route,Methods,ContentType
+Route,Methods,Content Type
 `/json-rpc`,`POST`,JSON
-`/addresses`,`GET`,Text
+`/addresses`,`GET`,JSON
 `/metrics`,`GET`,Text
 `/params`,`GET`,JSON
 `/time`,`GET`,Text
@@ -144,7 +144,7 @@ Echoes a message back as a JSON-RPC response.
 
 ==== Pre-conditions
 
-None. Any string may be given as input.
+Any string may be given as input.
 
 ==== Post-conditions
 
@@ -189,7 +189,7 @@ Returns the list of target addresses represented as Bech32 text, as an array of 
 
 ==== Pre-conditions
 
-None as the input parameter is unused.
+Although the input parameter is unused, it's required to be an "empty value": an empty object, an empty string, or `null`.
 
 ==== Post-conditions
 
@@ -206,8 +206,12 @@ Used for checking the server configuration.
 ====
 ```JSON
 {
-  "type": "string",
   "description": "Unused",
+  "oneOf": [
+    { "const": {} },
+    { "const": "" },
+    { "const": null },
+  ]
 }
 ```
 ====
@@ -224,9 +228,18 @@ Used for checking the server configuration.
 ```
 ====
 
-[NOTE]
+.JSON-RPC error data object
+[%collapsible]
 ====
-This method does not return errors.
+```JSON
+{
+  "oneOf": [
+    {
+      "const": "The param value must be empty (use '{}', 'null' or empty string)"
+    }
+  ]
+}
+```
 ====
 
 === getCurrentSyncedBlock
@@ -245,7 +258,7 @@ Taking the chainpoint before ensure that we have consistent infomation across al
 
 ==== Pre-conditions
 
-None as there are no required inputs.
+Although the input parameter is unused, it's required to be an "empty value": an empty object, an empty string, or `null`.
 
 ==== Post-conditions
 
@@ -263,18 +276,14 @@ It’s triggered when a user calls the Sidechain API to get info about the state
 ====
 ```JSON
 {
+  "description": "Unused",
   "oneOf": [
     { "const": {} },
     { "const": "" },
     { "const": null },
-    { "const": undefined },
+  ]
 }
 ```
-====
-
-[NOTE]
-====
-The param object can be fully omitted for this method.
 ====
 
 .JSON-RPC result object
@@ -340,7 +349,7 @@ The param object can be fully omitted for this method.
 {
   "oneOf": [
     {
-      "const": "The param value must be empty (use '{}', 'null', empty string or omit the param object entirely)."
+      "const": "The param value must be empty (use '{}', 'null' or empty string)"
     }
   ]
 }

--- a/marconi-sidechain/examples/json-rpc-client/src/Main.hs
+++ b/marconi-sidechain/examples/json-rpc-client/src/Main.hs
@@ -12,7 +12,10 @@ import Marconi.Sidechain.Api.Routes (
  )
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.JsonRpc.Client.Types ()
-import Network.JsonRpc.Types (JsonRpcResponse (Ack, Errors, Result))
+import Network.JsonRpc.Types (
+  JsonRpcResponse (Ack, Errors, Result),
+  UnusedRequestParams (UnusedRequestParams),
+ )
 import Servant.API ((:<|>) ((:<|>)))
 import Servant.Client (
   BaseUrl (BaseUrl),
@@ -46,7 +49,7 @@ main = do
   let boundaries = fromRight (error "the provided interval is correct") (interval Nothing (Just maxBound))
   -- RPC calls
   msg <- rpcEcho "marconi client calling ???" --  return the echo message
-  addresses <- rpcTargets "" --  get the targetAddresss
+  addresses <- rpcTargets UnusedRequestParams --  get the targetAddresss
   --  get utxos for this address
   utxos <- rpcUtxos $ GetUtxosFromAddressParams bech32Address boundaries
   printResults msg

--- a/marconi-sidechain/examples/run-pre-prod-queries
+++ b/marconi-sidechain/examples/run-pre-prod-queries
@@ -7,8 +7,8 @@ echo "== unknownMethod"
 echo "============================================="
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "unknownMethod" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "unknownMethod" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "unknownMethod" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "unknownMethod" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 
 
 echo "============================================="
@@ -16,8 +16,8 @@ echo "== getTargetAddresses"
 echo "============================================="
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "getTargetAddresses" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "getTargetAddresses" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "getTargetAddresses" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "getTargetAddresses" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 
 
 echo "============================================="
@@ -25,8 +25,8 @@ echo "== getCurrentSyncedBlock"
 echo "============================================="
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "getCurrentSyncedBlock" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "getCurrentSyncedBlock" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "getCurrentSyncedBlock" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "getCurrentSyncedBlock" , "params": "", "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
 
@@ -39,12 +39,12 @@ echo ""
 # The cardano-db-sync query to get addresses with the most utxos:
 # select address, count(*) as c from tx_out, tx, block where tx_out.tx_id = tx.id and tx.block_id = block.id group by address order by c desc limit 1;
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "address": "addr_test1vz09v9yfxguvlp0zsnrpa3tdtm7el8xufp3m5lsm7qxzclgmzkket" }, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "address": "addr_test1vz09v9yfxguvlp0zsnrpa3tdtm7el8xufp3m5lsm7qxzclgmzkket", "unspentBeforeSlotNo": 30000000 }, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "address": "addr_test1vz09v9yfxguvlp0zsnrpa3tdtm7el8xufp3m5lsm7qxzclgmzkket" }, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "address": "addr_test1vz09v9yfxguvlp0zsnrpa3tdtm7el8xufp3m5lsm7qxzclgmzkket", "unspentBeforeSlotNo": 30000000 }, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "address": "addr_test1vz09v9yfxguvlp0zsnrpa3tdtm7el8xufp3m5lsm7qxzclgmzkket", "createdAtOrAfterSlotNo": 16052985, "unspentBeforeSlotNo": 18364224}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "address": "addr_test1vz09v9yfxguvlp0zsnrpa3tdtm7el8xufp3m5lsm7qxzclgmzkket", "createdAtOrAfterSlotNo": 16052985, "unspentBeforeSlotNo": 18364224}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "address": "addr_test1vz09v9yfxguvlp0zsnrpa3tdtm7el8xufp3m5lsm7qxzclgmzkket", "createdAtOrAfterSlotNo": 16052985, "unspentBeforeSlotNo": 18364224}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "getUtxosFromAddress" , "params": { "address": "addr_test1vz09v9yfxguvlp0zsnrpa3tdtm7el8xufp3m5lsm7qxzclgmzkket", "createdAtOrAfterSlotNo": 16052985, "unspentBeforeSlotNo": 18364224}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
 
@@ -56,20 +56,20 @@ echo ""
 # The cardano-db-sync query to get burn events:
 # select multi_asset.policy, multi_asset.name, block.slot_no, tx.hash from tx, ma_tx_mint, multi_asset, redeemer, block where tx.id = ma_tx_mint.tx_id and multi_asset.id = ma_tx_mint.ident and redeemer.tx_id = tx.id and tx.block_id = block.id limit 1;
 
-echo "curl --silent -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e2bab64ca481afc5a695b7db22fd0a7df4bf930158dfa652fb337999", "assetName": "53554d4d495441574152445344656669", "createdBeforeSlotNo": 11639233}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e2bab64ca481afc5a695b7db22fd0a7df4bf930158dfa652fb337999", "assetName": "53554d4d495441574152445344656669", "createdBeforeSlotNo": 11639233}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e2bab64ca481afc5a695b7db22fd0a7df4bf930158dfa652fb337999", "assetName": "53554d4d495441574152445344656669", "createdBeforeSlotNo": 11639233}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e2bab64ca481afc5a695b7db22fd0a7df4bf930158dfa652fb337999", "assetName": "53554d4d495441574152445344656669", "createdBeforeSlotNo": 11639233}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40", "createdBeforeSlotNo": 10944386}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40", "createdBeforeSlotNo": 10944386}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40", "createdBeforeSlotNo": 10944386}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40", "createdBeforeSlotNo": 10944386}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40", "afterTx": "0a872c4fcf87f041caab5d5ecaeae19fd0e26de14241167c8dee7d1b26b5b4f7"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40", "afterTx": "0a872c4fcf87f041caab5d5ecaeae19fd0e26de14241167c8dee7d1b26b5b4f7"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40", "afterTx": "0a872c4fcf87f041caab5d5ecaeae19fd0e26de14241167c8dee7d1b26b5b4f7"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0", "method": "getBurnTokenEvents", "params": {"policyId": "e222ae950cef1915dcb9db8840dc9c3df3785f9a10eca30dfb84ad40", "afterTx": "0a872c4fcf87f041caab5d5ecaeae19fd0e26de14241167c8dee7d1b26b5b4f7"}, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
 
@@ -78,12 +78,12 @@ echo "== getNonceByEpoch"
 echo "============================================="
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 3, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 3, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 3, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 3, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 4, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 4, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 4, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "getNonceByEpoch" , "params": 4, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
 
@@ -92,10 +92,10 @@ echo "== getActiveStakePoolDelegationByEpoch"
 echo "============================================="
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "getActiveStakePoolDelegationByEpoch" , "params": 7, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "getActiveStakePoolDelegationByEpoch" , "params": 7, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "getActiveStakePoolDelegationByEpoch" , "params": 7, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "getActiveStakePoolDelegationByEpoch" , "params": 7, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""
 
-echo "curl --silent -d '{"jsonrpc": "2.0" , "method": "getActiveStakePoolDelegationByEpoch" , "params": 31, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
-curl --silent -d '{"jsonrpc": "2.0" , "method": "getActiveStakePoolDelegationByEpoch" , "params": 31, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
+echo "curl -sS -d '{"jsonrpc": "2.0" , "method": "getActiveStakePoolDelegationByEpoch" , "params": 31, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq"
+curl -sS -d '{"jsonrpc": "2.0" , "method": "getActiveStakePoolDelegationByEpoch" , "params": 31, "id": 1}' -H 'Content-Type: application/json' -X POST http://localhost:$PORT/json-rpc | jq
 echo ""

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/HttpServer.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/HttpServer.hs
@@ -27,7 +27,6 @@ import Marconi.Sidechain.Api.Routes (
   API,
   GetBurnTokenEventsParams (afterTx, assetName, beforeSlotNo, policyId),
   GetBurnTokenEventsResult (GetBurnTokenEventsResult),
-  GetCurrentSyncedBlockParams,
   GetCurrentSyncedBlockResult,
   GetEpochActiveStakePoolDelegationResult,
   GetEpochNonceResult,
@@ -52,6 +51,7 @@ import Marconi.Sidechain.Error (
 import Network.JsonRpc.Server.Types ()
 import Network.JsonRpc.Types (
   JsonRpcErr (JsonRpcErr),
+  UnusedRequestParams,
   mkJsonRpcParseErr,
  )
 import Network.Wai.Handler.Warp (runSettings)
@@ -128,8 +128,8 @@ getMetricsHandler = liftIO $ Text.decodeUtf8 . BS.toStrict <$> P.exportMetricsAs
 
 -- | Prints TargetAddresses Bech32 representation as thru JsonRpc
 getTargetAddressesQueryHandler
-  :: String
-  -- ^ Will always be an empty string as we are ignoring this param, and returning everything
+  :: UnusedRequestParams
+  -- ^ Will be an empty string, empty object, or null, as we are ignoring this param, and returning everything
   -> ReaderHandler SidechainEnv (Either (JsonRpcErr String) [Text])
 getTargetAddressesQueryHandler _ = do
   indexer <- view $ sidechainIndexersEnv . sidechainAddressUtxoIndexer
@@ -137,8 +137,8 @@ getTargetAddressesQueryHandler _ = do
 
 -- | Handler for retrieving current synced chain point.
 getCurrentSyncedBlockHandler
-  :: GetCurrentSyncedBlockParams
-  -- ^ Will always be an empty string as we are ignoring this param, and returning everything
+  :: UnusedRequestParams
+  -- ^ Will be an empty string, empty object, or null, as we are ignoring this param, and returning everything
   -> ReaderHandler SidechainEnv (Either (JsonRpcErr String) GetCurrentSyncedBlockResult)
 getCurrentSyncedBlockHandler _ = do
   indexer <- view $ sidechainIndexersEnv . sidechainAddressUtxoIndexer

--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Routes.hs
@@ -36,7 +36,7 @@ import Marconi.ChainIndex.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Orphans ()
 import Marconi.ChainIndex.Types (TxIndexInBlock)
 import Marconi.Sidechain.CLI (CliArgs)
-import Network.JsonRpc.Types (JsonRpc, RawJsonRpc)
+import Network.JsonRpc.Types (JsonRpc, RawJsonRpc, UnusedRequestParams)
 import Servant.API (Get, JSON, PlainText, (:<|>), (:>))
 
 -- | marconi-sidechain APIs
@@ -62,12 +62,17 @@ type RpcAPI =
 
 type RpcEchoMethod = JsonRpc "echo" String String String
 
-type RpcTargetAddressesMethod = JsonRpc "getTargetAddresses" String String [Text]
+type RpcTargetAddressesMethod =
+  JsonRpc
+    "getTargetAddresses"
+    UnusedRequestParams
+    String
+    [Text]
 
 type RpcCurrentSyncedBlockMethod =
   JsonRpc
     "getCurrentSyncedBlock"
-    GetCurrentSyncedBlockParams
+    UnusedRequestParams
     String
     GetCurrentSyncedBlockResult
 
@@ -124,17 +129,6 @@ instance FromJSON SidechainTip where
           bn <- v .: "blockNo"
           pure $ SidechainTip $ C.ChainTip slotNo bhh bn
      in Aeson.withObject "ChainTip" parseTip obj
-
-data GetCurrentSyncedBlockParams = GetCurrentSyncedBlockParams
-
-instance FromJSON GetCurrentSyncedBlockParams where
-  parseJSON (Aeson.String "") = pure GetCurrentSyncedBlockParams
-  parseJSON Aeson.Null = pure GetCurrentSyncedBlockParams
-  parseJSON (Aeson.Object o) | null o = pure GetCurrentSyncedBlockParams
-  parseJSON _ = fail "The param value must be empty (use '{}', 'null', empty string"
-
-instance ToJSON GetCurrentSyncedBlockParams where
-  toJSON = const Aeson.Null
 
 data GetCurrentSyncedBlockResult
   = GetCurrentSyncedBlockResult (WithOrigin BlockInfo) SidechainTip

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/RpcClientAction.hs
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/RpcClientAction.hs
@@ -20,7 +20,6 @@ import Marconi.Sidechain.Api.Query.Indexers.Utxo qualified as UIQ
 import Marconi.Sidechain.Api.Routes (
   GetBurnTokenEventsParams (GetBurnTokenEventsParams),
   GetBurnTokenEventsResult,
-  GetCurrentSyncedBlockParams (GetCurrentSyncedBlockParams),
   GetCurrentSyncedBlockResult,
   GetUtxosFromAddressParams (GetUtxosFromAddressParams),
   GetUtxosFromAddressResult,
@@ -35,7 +34,7 @@ import Marconi.Sidechain.Env (
  )
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.JsonRpc.Client.Types ()
-import Network.JsonRpc.Types (JsonRpcResponse)
+import Network.JsonRpc.Types (JsonRpcResponse, UnusedRequestParams (UnusedRequestParams))
 import Network.Wai.Handler.Warp (Port)
 import Network.Wai.Handler.Warp qualified as Warp
 import Servant.API ((:<|>) ((:<|>)))
@@ -73,7 +72,7 @@ mkRpcClientAction port = do
       (mkInsertUtxoEventsCallback env)
       (mkInsertMintBurnEventsCallback env)
       (\a -> rpcUtxos $ GetUtxosFromAddressParams a (Utxo.lessThanOrEqual maxBound))
-      (rpcSyncPoint GetCurrentSyncedBlockParams)
+      (rpcSyncPoint UnusedRequestParams)
       (\(p, a) -> rpcMinting $ GetBurnTokenEventsParams p a Nothing Nothing)
 
 baseUrl :: Warp.Port -> BaseUrl


### PR DESCRIPTION
* `getCurrentSyncedBlock` method
* `getTargetAddresses` method
* Update documentation
* Improve error reporting in `marconi-sidechain/examples/run-pre-prod-queries`

Note that we allow `params` to be empty but not missing, because we don't want `params` to be optional for other methods and they all share a common `Request p` datatype.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
