### PR TITLE
Start the chainSync protocol in a dedicated thread

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Runner.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Runner.hs
@@ -19,8 +19,9 @@ import Cardano.BM.Trace qualified as Trace
 import Control.Concurrent qualified as Concurrent
 import Control.Concurrent.STM qualified as STM
 import Control.Exception (catch)
-import Control.Monad.Except (ExceptT, void)
+import Control.Monad.Except (ExceptT)
 
+import Control.Concurrent.Async qualified as Async
 import Data.Text (Text)
 import Data.Void (Void)
 import Marconi.ChainIndex.Experimental.Extract.WithDistance (WithDistance)
@@ -70,8 +71,9 @@ runIndexer trace retryConfig socketPath networkId _startingPoint indexer = do
               Pretty.layoutPretty
                 Pretty.defaultLayoutOptions
                 "No intersection found"
-    void $ runChainSyncStream `catch` whenNoIntersectionFound
-    Core.processQueue eventQueue cBox
+    Async.concurrently_
+      (runChainSyncStream `catch` whenNoIntersectionFound)
+      (Core.processQueue eventQueue cBox)
 
 -- | Run several indexers under a unique coordinator
 runIndexers


### PR DESCRIPTION
It's weird that `marconi-chain-index-experimental` was still working without this fix: we didn't start the chain sync protocol in a dedicated thread and thus this was blocking the indexing.
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
