### PR TITLE
Epoch state for the new indexer

### DIFF
--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -62,6 +62,7 @@ library
     Marconi.ChainIndex.Experimental.Indexers.BlockInfo
     Marconi.ChainIndex.Experimental.Indexers.Coordinator
     Marconi.ChainIndex.Experimental.Indexers.Datum
+    Marconi.ChainIndex.Experimental.Indexers.EpochState
     Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent
     Marconi.ChainIndex.Experimental.Indexers.Orphans
     Marconi.ChainIndex.Experimental.Indexers.Spent

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -65,7 +65,7 @@ buildIndexers securityParam catchupConfig utxoConfig mintEventConfig epochStateC
   StandardWorker blockInfoMVar blockInfoWorker <-
     blockInfoBuilder securityParam catchupConfig mainLogger path
 
-  StandardWorker _epochStateMVar epochStateWorker <-
+  Core.WorkerIndexer _epochStateMVar epochStateWorker <-
     epochStateBuilder securityParam catchupConfig epochStateConfig mainLogger path
 
   StandardWorker utxoMVar utxoWorker <-
@@ -219,13 +219,19 @@ mintBuilder securityParam catchupConfig mintEventConfig logger path =
 
 -- | Configure and start the @EpochState@ indexer
 epochStateBuilder
-  :: (MonadIO n, MonadError Core.IndexerError n, MonadIO m)
+  :: (MonadIO n, MonadError Core.IndexerError n)
   => SecurityParam
   -> Core.CatchupConfig
   -> EpochState.EpochStateConfig
-  -> BM.Trace m (Core.IndexerEvent C.ChainPoint)
+  -> BM.Trace IO (Core.IndexerEvent C.ChainPoint)
   -> FilePath
-  -> n (StandardWorker m BlockEvent (C.BlockInMode C.CardanoMode) EpochState.EpochStateIndexer)
+  -> n
+      ( Core.WorkerIndexer
+          IO
+          (WithDistance BlockEvent)
+          (WithDistance (C.BlockInMode C.CardanoMode))
+          EpochState.EpochStateIndexer
+      )
 epochStateBuilder securityParam catchupConfig epochStateConfig logger path =
   let epochStateWorkerConfig =
         StandardWorkerConfig

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -230,7 +230,7 @@ epochStateBuilder
           IO
           (WithDistance BlockEvent)
           (WithDistance (C.BlockInMode C.CardanoMode))
-          EpochState.EpochStateIndexer
+          (Core.WithResume EpochState.EpochStateIndexer)
       )
 epochStateBuilder securityParam catchupConfig epochStateConfig logger path =
   let epochStateWorkerConfig =

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
@@ -56,6 +56,7 @@ import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes)
+import Data.Ord (comparing)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
@@ -322,14 +323,9 @@ buildEpochStateIndexer codecConfig path =
          in blockNoAsText evt : chainPointTexts
    in Core.mkFileIndexer
         path
-        False
-        "epochState"
-        "cbor"
-        serialiseLedgerState
-        deserialiseLedgerState
-        metadataAsText
-        deserialiseMetadata
-        metadataChainpoint
+        (Core.FileStorageConfig True (Just 50) (comparing metadataChainpoint) 0) -- TODO use securityParam as a limit
+        (Core.FileBuilder "epochState" "cbor" metadataAsText serialiseLedgerState)
+        (Core.EventBuilder deserialiseMetadata metadataChainpoint deserialiseLedgerState)
 
 buildBlockIndexer
   :: (MonadIO m, MonadError Core.IndexerError m)
@@ -355,14 +351,9 @@ buildBlockIndexer codecConfig path =
          in blockNoAsText evt : chainPointTexts
    in Core.mkFileIndexer
         path
-        True
-        "block"
-        "cbor"
-        serialiseBlock
-        deserialiseBlock
-        metadataAsText
-        deserialiseMetadata
-        metadataChainpoint
+        (Core.FileStorageConfig True (Just 5000) (comparing metadataChainpoint) 0) -- TODO use securityParam as a limit
+        (Core.FileBuilder "block" "cbor" metadataAsText serialiseBlock)
+        (Core.EventBuilder deserialiseMetadata metadataChainpoint deserialiseBlock)
 
 -- TODO placeholder, to implement
 buildEpochSDDIndexer

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
@@ -370,7 +370,7 @@ buildBlockIndexer codecConfig path = do
     (Core.FileBuilder "block" "cbor" metadataAsText serialiseBlock)
     (Core.EventBuilder deserialiseMetadata metadataChainpoint deserialiseBlock)
 
--- TODO placeholder, to implement
+-- TODO placeholder, to implement (at the moment we don't store any info except the point)
 buildEpochSDDIndexer
   :: (MonadIO m, MonadError Core.IndexerError m)
   => FilePath
@@ -384,7 +384,7 @@ buildEpochSDDIndexer path =
     Sync.syncRollbackPlan
     Sync.syncLastPointsQuery
 
--- TODO placeholder, to implement
+-- TODO placeholder, to implement (at the moment we don't store any info except the point)
 buildEpochNonceIndexer
   :: (MonadIO m, MonadError Core.IndexerError m)
   => FilePath

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
@@ -509,9 +509,7 @@ instance
   where
   index timedEvent@(Core.Timed p Nothing) indexer = do
     let newTimeToSnapshot = pred $ indexer ^. blocksBeforeNextSnapshot
-    indexer' <-
-      indexer
-        & performSnapshots newTimeToSnapshot timedEvent
+    indexer' <- indexer & performSnapshots newTimeToSnapshot timedEvent
     storeEmptyEpochStateRelatedInfo p indexer'
   index timedEvent@(Core.Timed p (Just (WithDistance d bim))) indexer = do
     let oldEpoch = currentEpoch indexer
@@ -523,6 +521,7 @@ instance
         & currentLedgerState .~ newEpochState
         & performSnapshots newTimeToSnapshot timedEvent
     let epochIsNew = oldEpoch /= newEpoch
+        -- We dont populate the event for SQL indexers if we don't have a new epoch
         epochStateEvent = Core.Timed p $ guard epochIsNew $> WithDistance d newEpochState
     storeEpochStateRelatedInfo epochStateEvent indexer'
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -Wno-deferred-out-of-scope-variables #-}
 
 module Marconi.ChainIndex.Experimental.Indexers.EpochState (
   -- * Events

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
@@ -36,10 +36,8 @@ import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.UMap qualified as Ledger
 import Cardano.Protocol.TPraos.API qualified as Shelley
 import Cardano.Protocol.TPraos.Rules.Tickn qualified as Shelley
-
 import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
-
 import Control.Exception (throw)
 import Control.Lens (Lens')
 import Control.Lens qualified as Lens
@@ -47,7 +45,6 @@ import Control.Lens.Operators ((&), (.~), (^.))
 import Control.Monad (foldM, guard, (<=<))
 import Control.Monad.Cont (MonadIO (liftIO))
 import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
-
 import Data.Bifunctor (bimap)
 import Data.ByteString.Base16 qualified as Base16
 import Data.Coerce (coerce)
@@ -66,12 +63,10 @@ import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.VMap (VMap)
 import Data.VMap qualified as VMap
-
 import Database.SQLite.Simple qualified as SQL
 import Database.SQLite.Simple.QQ (sql)
-
+import Database.SQLite.Simple.ToField qualified as SQL
 import GHC.Generics (Generic)
-
 import Marconi.ChainIndex.Experimental.Extract.WithDistance (
   WithDistance (WithDistance),
  )
@@ -88,7 +83,6 @@ import Marconi.ChainIndex.Experimental.Indexers.Worker (
 import Marconi.ChainIndex.Orphans ()
 import Marconi.ChainIndex.Types (SecurityParam (SecurityParam))
 import Marconi.Core.Experiment qualified as Core
-
 import Ouroboros.Consensus.Cardano.Block qualified as O
 import Ouroboros.Consensus.Config qualified as O
 import Ouroboros.Consensus.HeaderValidation qualified as O
@@ -97,11 +91,8 @@ import Ouroboros.Consensus.Protocol.Praos qualified as O
 import Ouroboros.Consensus.Protocol.TPraos qualified as O
 import Ouroboros.Consensus.Shelley.Ledger qualified as O
 import Ouroboros.Consensus.Storage.Serialisation qualified as O
-
 import System.Directory (createDirectoryIfMissing, doesDirectoryExist, listDirectory)
 import System.FilePath ((</>))
-
-import Database.SQLite.Simple.ToField qualified as SQL
 import Text.Read qualified as Text
 
 type ExtLedgerState = O.ExtLedgerState (O.HardForkBlock (O.CardanoEras O.StandardCrypto))

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/EpochState.hs
@@ -1,0 +1,595 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Marconi.ChainIndex.Experimental.Indexers.EpochState (
+  -- * Events
+  EpochState (EpochState),
+  extLedgerState,
+  blockNo,
+  EpochNonce (EpochNonce),
+  nonceEpochNo,
+  nonceNonce,
+  nonceBlockNo,
+  EpochSDD (EpochSDD),
+  sddEpochNo,
+  sddPoolId,
+  sddLovelace,
+  sddBlockNo,
+  EpochMetadata (..),
+
+  -- * Indexer and worker
+  EpochStateIndexer,
+  EpochStateConfig (..),
+  StandardEpochStateIndexer,
+  mkEpochStateIndexer,
+  mkEpochStateWorker,
+) where
+
+import Cardano.Api qualified as C
+import Cardano.Api.Extended.ExtLedgerState qualified as CE
+import Cardano.Api.Shelley qualified as C
+import Cardano.Ledger.Shelley.API qualified as Ledger
+import Cardano.Ledger.UMap qualified as Ledger
+import Cardano.Protocol.TPraos.API qualified as Shelley
+import Cardano.Protocol.TPraos.Rules.Tickn qualified as Shelley
+import Codec.CBOR.Read qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
+import Control.Exception (throw)
+import Control.Lens (Lens')
+import Control.Lens qualified as Lens
+import Control.Lens.Operators ((&), (.~), (^.))
+import Control.Monad (foldM, guard, (<=<))
+import Control.Monad.Cont (MonadIO (liftIO))
+import Control.Monad.Except (MonadError (throwError), runExceptT)
+import Data.Bifunctor (bimap)
+import Data.ByteString.Base16 qualified as Base16
+import Data.Coerce (coerce)
+import Data.Data (Proxy (Proxy))
+import Data.Foldable (Foldable (toList))
+import Data.Functor (($>))
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Maybe (catMaybes)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.VMap (VMap)
+import Data.VMap qualified as VMap
+import Database.SQLite.Simple qualified as SQL
+import Database.SQLite.Simple.QQ (sql)
+import GHC.Generics (Generic)
+import Marconi.ChainIndex.Experimental.Indexers.Orphans ()
+import Marconi.ChainIndex.Experimental.Indexers.SyncHelper qualified as Sync
+import Marconi.ChainIndex.Experimental.Indexers.Worker (
+  StandardIndexer,
+  StandardWorker,
+  StandardWorkerConfig,
+  mkStandardWorker,
+ )
+import Marconi.ChainIndex.Orphans ()
+import Marconi.Core.Experiment qualified as Core
+import Ouroboros.Consensus.Cardano.Block qualified as O
+import Ouroboros.Consensus.Config qualified as O
+import Ouroboros.Consensus.HeaderValidation qualified as O
+import Ouroboros.Consensus.Ledger.Extended qualified as O
+import Ouroboros.Consensus.Protocol.Praos qualified as O
+import Ouroboros.Consensus.Protocol.TPraos qualified as O
+import Ouroboros.Consensus.Shelley.Ledger qualified as O
+import Ouroboros.Consensus.Storage.Serialisation qualified as O
+import System.Directory (createDirectoryIfMissing)
+import System.FilePath ((</>))
+import Text.Read qualified as Text
+
+type ExtLedgerState = O.ExtLedgerState (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
+type ExtLedgerConfig = O.ExtLedgerCfg (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
+type instance Core.Point (C.BlockInMode C.CardanoMode) = C.ChainPoint
+type instance Core.Point EpochState = C.ChainPoint
+
+data EpochState = EpochState {extLedgerState :: ExtLedgerState, blockNo :: C.BlockNo}
+
+data EpochNonce = EpochNonce
+  { _nonceEpochNo :: !C.EpochNo
+  , _nonceNonce :: !Ledger.Nonce
+  , _nonceBlockNo :: !C.BlockNo
+  }
+  deriving (Eq, Ord, Show, Generic, SQL.FromRow, SQL.ToRow)
+
+type instance Core.Point EpochNonce = C.ChainPoint
+
+Lens.makeLenses ''EpochNonce
+
+data EpochSDD = EpochSDD
+  { _sddEpochNo :: !C.EpochNo
+  , _sddPoolId :: !C.PoolId
+  , _sddLovelace :: !C.Lovelace
+  , _sddBlockNo :: !C.BlockNo
+  }
+  deriving (Eq, Ord, Show, Generic, SQL.FromRow, SQL.ToRow)
+
+type instance Core.Point (NonEmpty EpochSDD) = C.ChainPoint
+
+data EpochMetadata = EpochMetadata
+  { metadataBlockNo :: Maybe C.BlockNo
+  , metadataChainpoint :: C.ChainPoint
+  }
+
+type instance Core.Point EpochSDD = C.ChainPoint
+
+Lens.makeLenses ''EpochSDD
+
+data EpochStateIndexerState event = EpochStateIndexerState
+  { _stateCurrentLedgerState :: EpochState
+  , _stateTimeToNextSnapshot :: Word
+  , _stateEpochStateIndexer :: Core.FileIndexer EpochMetadata EpochState
+  , _stateBlockIndexer :: Core.FileIndexer EpochMetadata (C.BlockInMode C.CardanoMode)
+  , _stateEpochNonceIndexer :: Core.SQLiteIndexer EpochNonce
+  , _stateEpochSDDIndexer :: Core.SQLiteIndexer (NonEmpty EpochSDD)
+  }
+
+Lens.makeLenses ''EpochStateIndexerState
+
+data EpochStateIndexerConfig event = EpochStateIndexerConfig
+  { _configSnapshotInterval :: Word
+  , _configGenesisConfig :: C.GenesisConfig
+  }
+
+Lens.makeLenses ''EpochStateIndexerConfig
+
+data EpochStateIndexer event = EpochStateIndexer
+  { _epochStateIndexerState :: EpochStateIndexerState event
+  , _epochStateIndexerConfig :: EpochStateIndexerConfig event
+  }
+
+Lens.makeLenses ''EpochStateIndexer
+
+type StandardEpochStateIndexer m = StandardIndexer m EpochStateIndexer (C.BlockInMode C.CardanoMode)
+
+currentLedgerState :: Lens' (EpochStateIndexer event) EpochState
+currentLedgerState = epochStateIndexerState . stateCurrentLedgerState
+
+currentEpoch :: EpochStateIndexer event -> Maybe C.EpochNo
+currentEpoch = Lens.views currentLedgerState (getEpochNo . extLedgerState)
+
+blocksBeforeNextSnapshot :: Lens' (EpochStateIndexer event) Word
+blocksBeforeNextSnapshot = epochStateIndexerState . stateTimeToNextSnapshot
+
+epochNonceIndexer :: Lens' (EpochStateIndexer event) (Core.SQLiteIndexer EpochNonce)
+epochNonceIndexer = epochStateIndexerState . stateEpochNonceIndexer
+
+epochSDDIndexer :: Lens' (EpochStateIndexer event) (Core.SQLiteIndexer (NonEmpty EpochSDD))
+epochSDDIndexer = epochStateIndexerState . stateEpochSDDIndexer
+
+epochStateIndexer :: Lens' (EpochStateIndexer event) (Core.FileIndexer EpochMetadata EpochState)
+epochStateIndexer = epochStateIndexerState . stateEpochStateIndexer
+
+blockIndexer
+  :: Lens' (EpochStateIndexer event) (Core.FileIndexer EpochMetadata (C.BlockInMode C.CardanoMode))
+blockIndexer = epochStateIndexerState . stateBlockIndexer
+
+snapshotInterval :: Lens' (EpochStateIndexer event) Word
+snapshotInterval = epochStateIndexerConfig . configSnapshotInterval
+
+genesisConfig :: Lens' (EpochStateIndexer event) C.GenesisConfig
+genesisConfig = epochStateIndexerConfig . configGenesisConfig
+
+extLedgerConfig :: EpochStateIndexer event -> ExtLedgerConfig
+extLedgerConfig = Lens.views genesisConfig CE.mkExtLedgerConfig
+
+initialEpochState :: EpochStateIndexer event -> EpochState
+initialEpochState = Lens.views genesisConfig (flip EpochState 0 . CE.mkInitExtLedgerState)
+
+toEpochNonce :: EpochState -> Maybe EpochNonce
+toEpochNonce epochState = do
+  let ledgerState = extLedgerState epochState
+  epochNo <- getEpochNo ledgerState
+  pure $ EpochNonce epochNo (getEpochNonce ledgerState) (blockNo epochState)
+
+toEpochSDD :: EpochState -> Maybe (NonEmpty EpochSDD)
+toEpochSDD epochState = NonEmpty.nonEmpty $ do
+  let ledgerState = extLedgerState epochState
+  epochNo <- toList $ getEpochNo ledgerState
+  (poolId, lovelace) <- Map.toList $ getStakeMap $ extLedgerState epochState
+  pure $ EpochSDD epochNo poolId lovelace (blockNo epochState)
+
+data EpochStateConfig = EpochStateConfig
+  { nodeConfig :: FilePath
+  -- ^ node config path
+  , snapshotIntervalInBlocks :: Word
+  -- ^ number of blocks between each snapshot
+  }
+
+mkEpochStateIndexer
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => EpochStateConfig
+  -> FilePath
+  -> m (EpochStateIndexer (C.BlockInMode C.CardanoMode))
+mkEpochStateIndexer cfg rootDir = do
+  genesisCfg <- readGenesisFile (nodeConfig cfg)
+  let config = EpochStateIndexerConfig (snapshotIntervalInBlocks cfg) genesisCfg
+      extLedgerCfg = CE.mkExtLedgerConfig genesisCfg
+      configCodec = O.configCodec . O.getExtLedgerCfg $ extLedgerCfg
+  liftIO $ createDirectoryIfMissing True rootDir
+  epochSDDIndexer' <- buildEpochSDDIndexer (rootDir </> "epochSDD.db")
+  epochNonceIndexer' <- buildEpochNonceIndexer (rootDir </> "epochNonce.db")
+  epochStateIndexer' <- buildEpochStateIndexer configCodec (rootDir </> "epochState")
+  epochBlocksIndexer <- buildBlockIndexer configCodec (rootDir </> "epochBlocks")
+  let state =
+        EpochStateIndexerState
+          (EpochState (CE.mkInitExtLedgerState genesisCfg) 0)
+          (snapshotIntervalInBlocks cfg)
+          epochStateIndexer'
+          epochBlocksIndexer
+          epochNonceIndexer'
+          epochSDDIndexer'
+  pure $ EpochStateIndexer state config
+
+mkEpochStateWorker
+  :: (MonadIO n, MonadError Core.IndexerError n, MonadIO m)
+  => StandardWorkerConfig m input (C.BlockInMode C.CardanoMode)
+  -- ^ General configuration of the indexer (mostly for logging purpose)
+  -> EpochStateConfig
+  -> FilePath
+  -> n (StandardWorker m input (C.BlockInMode C.CardanoMode) EpochStateIndexer)
+mkEpochStateWorker workerConfig epochStateConfig rootDir = do
+  indexer <- mkEpochStateIndexer epochStateConfig rootDir
+  mkStandardWorker workerConfig indexer
+
+deserialiseMetadata :: [Text] -> Maybe EpochMetadata
+deserialiseMetadata [blockNoStr, slotNoStr, bhhStr] = do
+  EpochMetadata
+    <$> parseBlockNo blockNoStr
+    <*> (C.ChainPoint <$> parseSlotNo slotNoStr <*> parseBlockHeaderHash bhhStr)
+  where
+    parseSlotNo = fmap C.SlotNo . Text.readMaybe . Text.unpack
+    parseBlockHeaderHash bhhStr' = do
+      bhhBs <- either (const Nothing) Just $ Base16.decode $ Text.encodeUtf8 bhhStr'
+      either (const Nothing) Just $ C.deserialiseFromRawBytes (C.proxyToAsType Proxy) bhhBs
+    parseBlockNo "" = pure Nothing
+    parseBlockNo bhh = Just . C.BlockNo <$> Text.readMaybe (Text.unpack bhh)
+deserialiseMetadata _ = Nothing
+
+buildEpochStateIndexer
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => O.CodecConfig (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
+  -> FilePath
+  -> m (Core.FileIndexer EpochMetadata EpochState)
+buildEpochStateIndexer codecConfig path =
+  let serialiseLedgerState =
+        CBOR.toLazyByteString
+          . O.encodeExtLedgerState
+            (O.encodeDisk codecConfig)
+            (O.encodeDisk codecConfig)
+            (O.encodeDisk codecConfig)
+          . extLedgerState
+
+      deserialiseLedgerState (EpochMetadata Nothing _) = const (Right Nothing)
+      deserialiseLedgerState (EpochMetadata (Just blockNo') _) =
+        bimap
+          (Text.pack . show)
+          (Just . flip EpochState blockNo' . snd)
+          . CBOR.deserialiseFromBytes
+            ( O.decodeExtLedgerState
+                (O.decodeDisk codecConfig)
+                (O.decodeDisk codecConfig)
+                (O.decodeDisk codecConfig)
+            )
+      blockNoAsText = maybe "" (Text.pack . show . (\(C.BlockNo b) -> b) . blockNo)
+      metadataAsText (Core.Timed C.ChainPointAtGenesis evt) = [blockNoAsText evt]
+      metadataAsText (Core.Timed chainPoint evt) =
+        let chainPointTexts = case chainPoint of
+              C.ChainPoint (C.SlotNo slotNo) blockHeaderHash ->
+                [Text.pack $ show slotNo, C.serialiseToRawBytesHexText blockHeaderHash]
+         in blockNoAsText evt : chainPointTexts
+   in Core.mkFileIndexer
+        path
+        False
+        "epochState"
+        "cbor"
+        serialiseLedgerState
+        deserialiseLedgerState
+        metadataAsText
+        deserialiseMetadata
+        metadataChainpoint
+
+buildBlockIndexer
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => O.CodecConfig (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
+  -> FilePath
+  -> m (Core.FileIndexer EpochMetadata (C.BlockInMode C.CardanoMode))
+buildBlockIndexer codecConfig path =
+  let serialiseBlock =
+        CBOR.toLazyByteString . O.encodeDisk codecConfig . C.toConsensusBlock
+      deserialiseBlock (EpochMetadata Nothing _) = const (Right Nothing)
+      deserialiseBlock _ =
+        bimap
+          (Text.pack . show)
+          (Just . C.fromConsensusBlock C.CardanoMode)
+          . fmap (\(bs', decode) -> decode bs')
+          . CBOR.deserialiseFromBytes (O.decodeDisk codecConfig)
+      blockNoAsText = maybe "" (Text.pack . show . (\(C.BlockNo b) -> b) . getBlockNo)
+      metadataAsText (Core.Timed C.ChainPointAtGenesis evt) = [blockNoAsText evt]
+      metadataAsText (Core.Timed chainPoint evt) =
+        let chainPointTexts = case chainPoint of
+              C.ChainPoint (C.SlotNo slotNo) blockHeaderHash ->
+                [Text.pack $ show slotNo, C.serialiseToRawBytesHexText blockHeaderHash]
+         in blockNoAsText evt : chainPointTexts
+   in Core.mkFileIndexer
+        path
+        True
+        "block"
+        "cbor"
+        serialiseBlock
+        deserialiseBlock
+        metadataAsText
+        deserialiseMetadata
+        metadataChainpoint
+
+-- TODO placeholder, to implement
+buildEpochSDDIndexer
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => FilePath
+  -> m (Core.SQLiteIndexer (NonEmpty EpochSDD))
+buildEpochSDDIndexer path =
+  Core.mkSingleInsertSqliteIndexer
+    path
+    (Lens.view Core.point)
+    Sync.syncTableCreation
+    [sql|INSERT INTO sync (slotNo, blockHeaderHash) VALUES (?, ?)|]
+    Sync.syncRollbackPlan
+    Sync.syncLastPointsQuery
+
+-- TODO placeholder, to implement
+buildEpochNonceIndexer
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => FilePath
+  -> m (Core.SQLiteIndexer EpochNonce)
+buildEpochNonceIndexer path =
+  Core.mkSingleInsertSqliteIndexer
+    path
+    (Lens.view Core.point)
+    Sync.syncTableCreation
+    [sql|INSERT INTO sync (slotNo, blockHeaderHash) VALUES (?, ?)|]
+    Sync.syncRollbackPlan
+    Sync.syncLastPointsQuery
+
+updateEpochState
+  :: (MonadIO m) => C.BlockInMode C.CardanoMode -> EpochStateIndexer event -> m EpochState
+updateEpochState block indexer = do
+  let nextLedgerState = buildNextEpochState (extLedgerConfig indexer)
+      currentState = indexer ^. currentLedgerState
+  liftIO $ nextLedgerState currentState block
+
+performSnapshots
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => Word
+  -> Core.Timed C.ChainPoint (Maybe (C.BlockInMode C.CardanoMode))
+  -> EpochStateIndexer event
+  -> m (EpochStateIndexer event)
+performSnapshots newBlocksBeforeNextSnapshot bim indexer = do
+  let epochState = indexer ^. currentLedgerState
+      (evt, blocksBeforeNextSnapshot') =
+        if newBlocksBeforeNextSnapshot == 0
+          then (Core.Timed (bim ^. Core.point) (Just epochState), indexer ^. snapshotInterval)
+          else (Core.Timed (bim ^. Core.point) Nothing, newBlocksBeforeNextSnapshot)
+      snapshotEpochState = epochStateIndexer $ Core.index evt
+      snapshotBlock = blockIndexer $ Core.index bim
+      indexer' = indexer & blocksBeforeNextSnapshot .~ blocksBeforeNextSnapshot'
+  snapshotEpochState <=< snapshotBlock $ indexer'
+
+storeEmptyEpochStateRelatedInfo
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => C.ChainPoint
+  -> EpochStateIndexer event
+  -> m (EpochStateIndexer event)
+storeEmptyEpochStateRelatedInfo p indexer = do
+  let indexNonce = epochNonceIndexer $ Core.index $ Core.Timed p Nothing
+      indexSDD = epochSDDIndexer $ Core.index $ Core.Timed p Nothing
+  indexNonce <=< indexSDD $ indexer
+
+storeEpochStateRelatedInfo
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => Core.Timed C.ChainPoint (Maybe EpochState)
+  -> EpochStateIndexer event
+  -> m (EpochStateIndexer event)
+storeEpochStateRelatedInfo ledgerState indexer = do
+  let indexNonce = epochNonceIndexer $ Core.index $ (>>= toEpochNonce) <$> ledgerState
+      indexSDD = epochSDDIndexer $ Core.index $ (>>= toEpochSDD) <$> ledgerState
+  indexNonce <=< indexSDD $ indexer
+
+getLatestNonEmpty
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => EpochState
+  -> Core.FileIndexer EpochMetadata EpochState
+  -> m (Core.Timed C.ChainPoint EpochState)
+getLatestNonEmpty firstEpochState indexer = do
+  result <- runExceptT $ Core.queryLatest Core.latestEvent indexer
+  case result of
+    Left _err -> throwError $ Core.IndexerInternalError "Cant resolve last epochState"
+    Right [] -> pure $ Core.Timed Core.genesis firstEpochState
+    Right (x : _) -> pure x
+
+getBlocksFrom
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => C.ChainPoint
+  -> Core.FileIndexer EpochMetadata (C.BlockInMode C.CardanoMode)
+  -> m [C.BlockInMode C.CardanoMode]
+getBlocksFrom from indexer = do
+  result <- runExceptT $ Core.queryLatest (Core.EventsFromQuery from) indexer
+  case result of
+    Left _err -> throwError $ Core.IndexerInternalError "Cant resolve last epochState"
+    Right xs -> pure $ Lens.view Core.event <$> xs
+
+instance
+  (MonadIO m, MonadError Core.IndexerError m)
+  => Core.IsIndex m (C.BlockInMode C.CardanoMode) EpochStateIndexer
+  where
+  index timedEvent@(Core.Timed p Nothing) indexer = do
+    let newTimeToSnapshot = pred $ indexer ^. blocksBeforeNextSnapshot
+    indexer' <-
+      indexer
+        & performSnapshots newTimeToSnapshot timedEvent
+    storeEmptyEpochStateRelatedInfo p indexer'
+  index timedEvent@(Core.Timed p (Just bim)) indexer = do
+    let oldEpoch = currentEpoch indexer
+    newEpochState <- updateEpochState bim indexer
+    let newEpoch = getEpochNo $ extLedgerState newEpochState
+        newTimeToSnapshot = pred $ indexer ^. blocksBeforeNextSnapshot
+    indexer' <-
+      indexer
+        & currentLedgerState .~ newEpochState
+        & performSnapshots newTimeToSnapshot timedEvent
+    let epochIsNew = oldEpoch /= newEpoch
+        epochStateEvent = Core.Timed p $ guard epochIsNew $> newEpochState
+    storeEpochStateRelatedInfo epochStateEvent indexer'
+
+  rollback p indexer = do
+    let rollbackIndexers =
+          epochStateIndexer (Core.rollback p)
+            <=< blockIndexer (Core.rollback p)
+            <=< epochSDDIndexer (Core.rollback p)
+            <=< epochNonceIndexer (Core.rollback p)
+    indexer' <- rollbackIndexers indexer
+    Core.Timed epochStatePoint closestLedgerState <-
+      getLatestNonEmpty (initialEpochState indexer) (indexer ^. epochStateIndexer)
+    blocks :: [C.BlockInMode C.CardanoMode] <- getBlocksFrom epochStatePoint (indexer ^. blockIndexer)
+    newEpochState <-
+      liftIO $
+        foldM
+          (buildNextEpochState $ extLedgerConfig indexer)
+          closestLedgerState
+          blocks
+    pure $ indexer' & currentLedgerState .~ newEpochState
+
+instance
+  (MonadIO m, MonadError Core.IndexerError m)
+  => Core.IsSync m (C.BlockInMode C.CardanoMode) EpochStateIndexer
+  where
+  lastSyncPoint indexer = Core.lastSyncPoint $ indexer ^. blockIndexer
+  lastSyncPoints n indexer = Core.lastSyncPoints n $ indexer ^. blockIndexer
+
+instance (MonadIO m) => Core.Closeable m EpochStateIndexer where
+  close indexer = do
+    Core.close $ indexer ^. epochStateIndexer
+    Core.close $ indexer ^. blockIndexer
+    Core.close $ indexer ^. epochSDDIndexer
+    Core.close $ indexer ^. epochNonceIndexer
+
+{- | From LedgerState, get epoch stake pool delegation: a mapping of pool ID to amount staked in
+ lovelace. We do this by getting the 'ssStakeMark stake snapshot and then use 'ssDelegations' and
+ 'ssStake' to resolve it into the desired mapping.
+-}
+getStakeMap
+  :: O.ExtLedgerState (O.CardanoBlock O.StandardCrypto)
+  -> Map C.PoolId C.Lovelace
+getStakeMap extLedgerState' = case O.ledgerState extLedgerState' of
+  O.LedgerStateByron _ -> mempty
+  O.LedgerStateShelley st -> getStakeMapFromShelleyBlock st
+  O.LedgerStateAllegra st -> getStakeMapFromShelleyBlock st
+  O.LedgerStateMary st -> getStakeMapFromShelleyBlock st
+  O.LedgerStateAlonzo st -> getStakeMapFromShelleyBlock st
+  O.LedgerStateBabbage st -> getStakeMapFromShelleyBlock st
+  O.LedgerStateConway st -> getStakeMapFromShelleyBlock st
+  where
+    getStakeMapFromShelleyBlock
+      :: forall proto era c
+       . (c ~ O.EraCrypto era, c ~ O.StandardCrypto)
+      => O.LedgerState (O.ShelleyBlock proto era)
+      -> Map C.PoolId C.Lovelace
+    getStakeMapFromShelleyBlock st = sdd'
+      where
+        newEpochState :: Ledger.NewEpochState era
+        newEpochState = O.shelleyLedgerState st
+
+        stakeSnapshot :: Ledger.SnapShot c
+        stakeSnapshot = Ledger.ssStakeMark . Ledger.esSnapshots . Ledger.nesEs $ newEpochState
+
+        stakes
+          :: VMap VMap.VB VMap.VP (Ledger.Credential 'Ledger.Staking c) (Ledger.CompactForm Ledger.Coin)
+        stakes = Ledger.unStake $ Ledger.ssStake stakeSnapshot
+
+        delegations
+          :: VMap VMap.VB VMap.VB (Ledger.Credential 'Ledger.Staking c) (Ledger.KeyHash 'Ledger.StakePool c)
+        delegations = Ledger.ssDelegations stakeSnapshot
+
+        sdd' :: Map C.PoolId C.Lovelace
+        sdd' =
+          Map.fromListWith (+) $
+            catMaybes $
+              VMap.elems $
+                VMap.mapWithKey
+                  ( \cred spkHash ->
+                      ( \c ->
+                          ( C.StakePoolKeyHash spkHash
+                          , C.Lovelace $ coerce $ Ledger.fromCompact c
+                          )
+                      )
+                        <$> VMap.lookup cred stakes
+                  )
+                  delegations
+
+{- | Get Nonce per epoch given an extended ledger state. The Nonce is only available starting at
+ Shelley era. Byron era has the neutral nonce.
+-}
+getEpochNonce :: O.ExtLedgerState (O.CardanoBlock O.StandardCrypto) -> Ledger.Nonce
+getEpochNonce extLedgerState' =
+  case O.headerStateChainDep (O.headerState extLedgerState') of
+    O.ChainDepStateByron _ -> Ledger.NeutralNonce
+    O.ChainDepStateShelley st -> extractNonce st
+    O.ChainDepStateAllegra st -> extractNonce st
+    O.ChainDepStateMary st -> extractNonce st
+    O.ChainDepStateAlonzo st -> extractNonce st
+    O.ChainDepStateBabbage st -> extractNoncePraos st
+    O.ChainDepStateConway st -> extractNoncePraos st
+  where
+    extractNonce :: O.TPraosState c -> Ledger.Nonce
+    extractNonce =
+      Shelley.ticknStateEpochNonce . Shelley.csTickn . O.tpraosStateChainDepState
+
+    extractNoncePraos :: O.PraosState c -> Ledger.Nonce
+    extractNoncePraos = O.praosStateEpochNonce
+
+getEpochNo
+  :: O.ExtLedgerState (O.CardanoBlock O.StandardCrypto)
+  -> Maybe C.EpochNo
+getEpochNo extLedgerState' = case O.ledgerState extLedgerState' of
+  O.LedgerStateByron _st -> Nothing
+  O.LedgerStateShelley st -> getEpochNoFromShelleyBlock st
+  O.LedgerStateAllegra st -> getEpochNoFromShelleyBlock st
+  O.LedgerStateMary st -> getEpochNoFromShelleyBlock st
+  O.LedgerStateAlonzo st -> getEpochNoFromShelleyBlock st
+  O.LedgerStateBabbage st -> getEpochNoFromShelleyBlock st
+  O.LedgerStateConway st -> getEpochNoFromShelleyBlock st
+  where
+    getEpochNoFromShelleyBlock = Just . Ledger.nesEL . O.shelleyLedgerState
+
+readGenesisFile
+  :: (MonadIO m, MonadError Core.IndexerError m)
+  => FilePath
+  -> m C.GenesisConfig
+readGenesisFile nodeConfigPath = do
+  nodeCfgE <- liftIO $ runExceptT $ C.readNodeConfig (C.File nodeConfigPath)
+  nodeCfg <- case nodeCfgE of
+    Left err -> throwError . Core.IndexerInternalError . Text.pack . show $ err
+    Right cfg -> pure cfg
+  genesisConfigE <- liftIO $ runExceptT $ C.readCardanoGenesisConfig nodeCfg
+  case genesisConfigE of
+    Left err -> throwError . Core.IndexerInternalError . Text.pack . show . C.renderGenesisConfigError $ err
+    Right cfg -> pure cfg
+
+getBlockNo :: C.BlockInMode C.CardanoMode -> C.BlockNo
+getBlockNo (C.BlockInMode block _eraInMode) =
+  case C.getBlockHeader block of C.BlockHeader _ _ b -> b
+
+buildNextEpochState
+  :: ExtLedgerConfig -> EpochState -> C.BlockInMode C.CardanoMode -> IO EpochState
+buildNextEpochState extLedgerCfg currentState block =
+  let currentLedgerState' = extLedgerState currentState
+      applyBlock = CE.applyBlockExtLedgerState extLedgerCfg C.QuickValidation
+   in case applyBlock block currentLedgerState' of
+        Left err -> throw . Core.IndexerInternalError . Text.pack . show $ err
+        Right res -> pure $ EpochState res (getBlockNo block)

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -126,7 +126,6 @@ mkUtxoIndexer path = do
                  , inlineScript BLOB
                  , inlineScriptHash BLOB
                  , slotNo INT
-                 , blockHeaderHash BLOB
                  )|]
       createAddressIndex = [sql|CREATE INDEX IF NOT EXISTS utxo_address ON utxo (address)|]
       createSlotNoIndex = [sql|CREATE INDEX IF NOT EXISTS utxo_slotNo ON utxo (slotNo)|]
@@ -272,7 +271,7 @@ instance
           JOIN sync ON utxo.slotNo == sync.slotNo
           WHERE utxo.slotNo <= :slotNo
           |]
-        -- \| Group utxos that are of the same block in the same event
+        -- Group utxos that are of the same block in the same event
         groupEvents
           :: NonEmpty (Core.Timed point a)
           -> Core.Timed point (NonEmpty a)

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
@@ -52,7 +52,7 @@ run appName = do
         (Core.CatchupConfig batchSize stopCatchupDistance)
         (Utxo.UtxoIndexerConfig filteredAddresses includeScript)
         (MintTokenEvent.MintTokenEventConfig filteredAssetIds)
-        (EpochState.EpochStateConfig nodeConfigPath 200)
+        (EpochState.EpochStateConfig nodeConfigPath 1000)
         trace
         (Cli.optionsDbPath o)
   (indexerLastSyncPoints, _utxoQueryIndexer, indexers) <-

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
@@ -13,6 +13,7 @@ import Data.Text qualified as Text
 import Data.Void (Void)
 import Marconi.ChainIndex.CLI qualified as Cli
 import Marconi.ChainIndex.Experimental.Indexers (buildIndexers)
+import Marconi.ChainIndex.Experimental.Indexers.EpochState qualified as EpochState
 import Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent qualified as MintTokenEvent
 import Marconi.ChainIndex.Experimental.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Experimental.Logger (defaultStdOutLogger)
@@ -36,11 +37,14 @@ run appName = do
       retryConfig = Cli.optionsRetryConfig $ Cli.commonOptions o
       preferredStartingPoint = Cli.optionsChainPoint $ Cli.commonOptions o
   createDirectoryIfMissing True (Cli.optionsDbPath o)
+  nodeConfigPath <- case Cli.optionsNodeConfigPath o of
+    Just cfg -> pure cfg
+    Nothing -> error "No node config path provided"
   trace <- defaultStdOutLogger appName
-
   securityParam <- withNodeConnectRetry trace retryConfig socketPath $ do
     Utils.toException $ Utils.querySecurityParam @Void networkId socketPath
 
+  logInfo trace $ appName <> "-" <> Text.pack Cli.getVersion
   mindexers <-
     runExceptT $
       buildIndexers
@@ -48,6 +52,7 @@ run appName = do
         (Core.CatchupConfig batchSize stopCatchupDistance)
         (Utxo.UtxoIndexerConfig filteredAddresses includeScript)
         (MintTokenEvent.MintTokenEventConfig filteredAssetIds)
+        (EpochState.EpochStateConfig nodeConfigPath 200)
         trace
         (Cli.optionsDbPath o)
   (indexerLastSyncPoints, _utxoQueryIndexer, indexers) <-
@@ -62,6 +67,7 @@ run appName = do
 
   logInfo trace $ appName <> "-" <> Text.pack Cli.getVersion
 
+  logInfo trace "Indexers ready"
   Runner.runIndexer
     trace
     securityParam

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
@@ -52,7 +52,7 @@ run appName = do
         (Core.CatchupConfig batchSize stopCatchupDistance)
         (Utxo.UtxoIndexerConfig filteredAddresses includeScript)
         (MintTokenEvent.MintTokenEventConfig filteredAssetIds)
-        (EpochState.EpochStateConfig nodeConfigPath 1000)
+        (EpochState.EpochStateConfig nodeConfigPath 500)
         trace
         (Cli.optionsDbPath o)
   (indexerLastSyncPoints, _utxoQueryIndexer, indexers) <-
@@ -67,7 +67,6 @@ run appName = do
 
   logInfo trace $ appName <> "-" <> Text.pack Cli.getVersion
 
-  logInfo trace "Indexers ready"
   Runner.runIndexer
     trace
     securityParam

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Runner.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Runner.hs
@@ -22,6 +22,7 @@ import Control.Exception (catch)
 import Control.Monad.Except (ExceptT, void)
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
+
 import Data.Text (Text)
 import Marconi.ChainIndex.Experimental.Extract.WithDistance (WithDistance)
 import Marconi.ChainIndex.Experimental.Extract.WithDistance qualified as Distance

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Runner.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Runner.hs
@@ -16,7 +16,6 @@ import Cardano.Api.Extended.Streaming (
 import Cardano.BM.Data.Trace (Trace)
 import Cardano.BM.Trace qualified as Trace
 import Control.Concurrent qualified as Concurrent
-import Control.Concurrent.Async qualified as Async
 import Control.Concurrent.STM qualified as STM
 import Control.Exception (catch)
 import Control.Monad.Except (ExceptT, void)
@@ -88,9 +87,8 @@ runIndexer trace securityParam retryConfig socketPath networkId startingPoints i
             PP.renderStrict $
               PP.layoutPretty PP.defaultLayoutOptions $
                 PP.pretty NoIntersectionFoundLog
-    Async.concurrently_
-      (void $ runChainSyncStream `catch` whenNoIntersectionFound)
-      (Core.processQueue eventQueue cBox)
+    void $ Concurrent.forkIO $ runChainSyncStream `catch` whenNoIntersectionFound
+    Core.processQueue eventQueue cBox
 
 -- | Event preprocessing, to ease the coordinator work
 mkEventStream

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -67,10 +67,10 @@ library
     Marconi.Core.Experiment.Query
     Marconi.Core.Experiment.Transformer.Class
     Marconi.Core.Experiment.Transformer.IndexTransformer
-    Marconi.Core.Experiment.Transformer.WithAggregate
     Marconi.Core.Experiment.Transformer.WithCache
     Marconi.Core.Experiment.Transformer.WithCatchup
     Marconi.Core.Experiment.Transformer.WithDelay
+    Marconi.Core.Experiment.Transformer.WithFold
     Marconi.Core.Experiment.Transformer.WithPruning
     Marconi.Core.Experiment.Transformer.WithResume
     Marconi.Core.Experiment.Transformer.WithTracer

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -59,6 +59,7 @@ library
     Marconi.Core.Experiment
     Marconi.Core.Experiment.Class
     Marconi.Core.Experiment.Coordinator
+    Marconi.Core.Experiment.Indexer.FileIndexer
     Marconi.Core.Experiment.Indexer.LastPointIndexer
     Marconi.Core.Experiment.Indexer.ListIndexer
     Marconi.Core.Experiment.Indexer.MixedIndexer
@@ -96,7 +97,10 @@ library
   build-depends:
     , async
     , base           >=4.7 && <5
+    , bytestring
     , containers
+    , directory
+    , filepath
     , lens
     , mtl
     , primitive

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -291,6 +291,9 @@ module Marconi.Core.Experiment (
 
   -- | An indexer that serialise the event to disk
   FileIndexer (FileIndexer),
+  FileStorageConfig (FileStorageConfig),
+  FileBuilder (FileBuilder),
+  EventBuilder (EventBuilder),
   mkFileIndexer,
 
   -- ** Mixed indexer
@@ -510,7 +513,13 @@ import Marconi.Core.Experiment.Coordinator (
   tokens,
   workers,
  )
-import Marconi.Core.Experiment.Indexer.FileIndexer (FileIndexer (FileIndexer), mkFileIndexer)
+import Marconi.Core.Experiment.Indexer.FileIndexer (
+  EventBuilder (EventBuilder),
+  FileBuilder (FileBuilder),
+  FileIndexer (FileIndexer),
+  FileStorageConfig (FileStorageConfig),
+  mkFileIndexer,
+ )
 import Marconi.Core.Experiment.Indexer.LastPointIndexer (LastPointIndexer, lastPointIndexer)
 import Marconi.Core.Experiment.Indexer.ListIndexer (ListIndexer, events, latestPoint, mkListIndexer)
 import Marconi.Core.Experiment.Indexer.MixedIndexer (

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -440,8 +440,8 @@ module Marconi.Core.Experiment (
   WithFold,
   withFold,
   withFoldMap,
-  getLastByQuery,
-  HasFoldConfig (fold),
+  getLastEventAtQueryValue,
+  HasFold (fold),
 
   -- ** Index Wrapper
 
@@ -596,9 +596,9 @@ import Marconi.Core.Experiment.Transformer.WithDelay (
   withDelay,
  )
 import Marconi.Core.Experiment.Transformer.WithFold (
-  HasFoldConfig (..),
+  HasFold (..),
   WithFold,
-  getLastByQuery,
+  getLastEventAtQueryValue,
   withFold,
   withFoldMap,
  )

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -425,9 +425,10 @@ module Marconi.Core.Experiment (
   HasTransformConfig (..),
 
   -- ** Transform an indexer into a fold
-  WithAggregate,
-  withAggregate,
-  HasAggregateConfig (..),
+  WithFold,
+  withFold,
+  withFoldMap,
+  HasFoldConfig (fold),
 
   -- ** Index Wrapper
 
@@ -551,11 +552,6 @@ import Marconi.Core.Experiment.Transformer.IndexTransformer (
   wrappedIndexer,
   wrapperConfig,
  )
-import Marconi.Core.Experiment.Transformer.WithAggregate (
-  HasAggregateConfig (..),
-  WithAggregate,
-  withAggregate,
- )
 import Marconi.Core.Experiment.Transformer.WithCache (
   HasCacheConfig (cache),
   WithCache,
@@ -572,6 +568,12 @@ import Marconi.Core.Experiment.Transformer.WithDelay (
   HasDelayConfig (delayCapacity),
   WithDelay,
   withDelay,
+ )
+import Marconi.Core.Experiment.Transformer.WithFold (
+  HasFoldConfig (..),
+  WithFold,
+  withFold,
+  withFoldMap,
  )
 import Marconi.Core.Experiment.Transformer.WithPruning (
   HasPruningConfig (pruneEvery, securityParam),

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/FileIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/FileIndexer.hs
@@ -193,7 +193,7 @@ deserialiseTimedEvent indexer eventFile = do
       pt = indexer ^. eventBuilder . extractPoint $ meta
   evt <-
     if hasContent eventFile
-      then ExceptT $ deserialise <$> liftIO (BS.readFile $ path eventFile)
+      then ExceptT $ deserialise <$> liftIO (BS.readFile $ fullPath indexer eventFile)
       else pure Nothing
   pure $ Timed pt evt
 

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/FileIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/FileIndexer.hs
@@ -1,0 +1,217 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | An indexer that stores its events to filedisk, using the provided serialisation
+module Marconi.Core.Experiment.Indexer.FileIndexer (
+  FileIndexer (FileIndexer),
+  mkFileIndexer,
+  eventDirectory,
+  eventPrefix,
+  eventSuffix,
+  serialiseEvent,
+  deserialiseEvent,
+  deserialiseTimedEvent,
+  fileEventIdentifier,
+  filePointExtractor,
+  fileIndexerLastSyncPoint,
+  directoryContentWithMeta,
+  EventFile (..),
+) where
+
+import Control.Exception (Exception (displayException), handle)
+import Control.Lens qualified as Lens
+import Control.Lens.Operators ((.~), (^.))
+import Control.Monad (forM_, when)
+import Control.Monad.Except (ExceptT (ExceptT), MonadError (throwError), runExceptT)
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Data.ByteString.Lazy (ByteString)
+import Data.ByteString.Lazy qualified as BS
+import Data.Foldable (Foldable (toList), traverse_)
+import Data.Function ((&))
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Marconi.Core.Experiment.Class (
+  Closeable (close),
+  HasGenesis (genesis),
+  IsIndex (index, indexAllDescending, rollback),
+  IsSync (lastSyncPoint, lastSyncPoints),
+ )
+import Marconi.Core.Experiment.Type (
+  IndexerError (IndexerInternalError),
+  Point,
+  QueryError (IndexerQueryError),
+  Timed (Timed),
+  event,
+  point,
+ )
+import System.Directory (createDirectoryIfMissing, listDirectory, removeFile)
+import System.FilePath ((</>))
+import System.FilePath qualified as FilePath
+
+data FileIndexer meta event = FileIndexer
+  { _eventDirectory :: FilePath
+  -- ^ The directory wher we store the events
+  , _keepEmptyEvent :: Bool
+  , _eventPrefix :: Text
+  -- ^ The prefix used in the filename of the events
+  , _eventSuffix :: Text
+  -- ^ The suffix used in the filename of the events
+  , _serialiseEvent :: event -> ByteString
+  , _deserialiseEvent :: meta -> ByteString -> Either Text (Maybe event)
+  , _fileEventIdentifier :: Timed (Point event) (Maybe event) -> [Text]
+  -- ^ build a list of identifier used in the filename of an event
+  , _fileMetaExtractor :: [Text] -> Maybe meta
+  , _filePointExtractor :: meta -> Point event
+  , _fileIndexerLastSyncPoint :: Point event
+  -- ^ keep track of the last sync point
+  }
+
+Lens.makeLenses ''FileIndexer
+
+mkFileIndexer
+  :: (MonadIO m, MonadError IndexerError m, HasGenesis (Point event), Ord (Point event))
+  => FilePath
+  -> Bool
+  -> Text
+  -> Text
+  -> (event -> ByteString)
+  -> (meta -> ByteString -> Either Text (Maybe event))
+  -> (Timed (Point event) (Maybe event) -> [Text])
+  -> ([Text] -> Maybe meta)
+  -> (meta -> Point event)
+  -> m (FileIndexer meta event)
+mkFileIndexer path keepEmpty prefix suffix serialise deserialise identifier getMeta getPoint =
+  let getLastPoints = extractEventFiles getMeta path
+   in do
+        liftIO $ createDirectoryIfMissing True path
+        eventFiles <- runExceptT getLastPoints
+        lastSyncPoint' <- case eventFiles of
+          Left _ -> throwError $ IndexerInternalError "Invalid files in the indexer directory"
+          Right [] -> pure genesis
+          Right xs -> pure $ maximum $ getPoint . metadata <$> xs
+        pure $
+          FileIndexer
+            path
+            keepEmpty
+            prefix
+            suffix
+            serialise
+            deserialise
+            identifier
+            getMeta
+            getPoint
+            lastSyncPoint'
+
+toFilename :: FileIndexer meta event -> Timed (Point event) (Maybe event) -> FilePath
+toFilename indexer evt =
+  let eventId = (indexer ^. fileEventIdentifier) evt
+      contentFlag = case evt ^. event of
+        Just _ -> "just"
+        Nothing -> "nothing"
+      filename =
+        Text.unpack $
+          (Text.intercalate "_" $ indexer ^. eventPrefix : contentFlag : eventId)
+            <> "."
+            <> (indexer ^. eventSuffix)
+   in (indexer ^. eventDirectory) </> filename
+
+handleIOErrors :: (MonadIO m, MonadError IndexerError m) => IO a -> m a
+handleIOErrors action = do
+  let throwIOError :: IOError -> IO (Either IndexerError b)
+      throwIOError e = pure $ Left $ IndexerInternalError . Text.pack $ displayException e
+  result <- liftIO $ handle throwIOError (Right <$> action)
+  either throwError pure result
+
+data EventFile meta = EventFile
+  { hasContent :: Bool
+  , metadata :: meta
+  , path :: FilePath
+  }
+
+extractEventFiles
+  :: (MonadIO m, MonadError (QueryError q) m)
+  => ([Text] -> Maybe meta)
+  -> FilePath
+  -> m [EventFile meta]
+extractEventFiles metaExtractor eventDir =
+  let extractPoint path = do
+        let filename = FilePath.dropExtension $ FilePath.takeFileName path
+        case Text.splitOn "_" $ Text.pack filename of
+          (_ : contentFlag : parts) -> do
+            let hasContent' = contentFlag == "just"
+            meta <- metaExtractor parts
+            Just $ EventFile hasContent' meta path
+          _ -> Nothing
+   in do
+        files <- liftIO $ listDirectory eventDir
+        case traverse extractPoint files of
+          Nothing -> throwError $ IndexerQueryError $ "Invalid file in directory: " <> Text.pack eventDir
+          Just points -> pure points
+
+directoryContentWithMeta
+  :: (MonadIO m, MonadError (QueryError q) m)
+  => FileIndexer meta event
+  -> m [EventFile meta]
+directoryContentWithMeta indexer = do
+  let eventDir = indexer ^. eventDirectory
+  extractEventFiles (indexer ^. fileMetaExtractor) eventDir
+
+deserialiseTimedEvent
+  :: (MonadIO m)
+  => FileIndexer meta event
+  -> EventFile meta
+  -> ExceptT Text m (Timed (Point event) (Maybe event))
+deserialiseTimedEvent indexer eventFile = do
+  let meta = metadata eventFile
+      deserialise = (indexer ^. deserialiseEvent) meta
+      pt = indexer ^. filePointExtractor $ meta
+  evt <-
+    if hasContent eventFile
+      then ExceptT $ deserialise <$> liftIO (BS.readFile $ path eventFile)
+      else pure Nothing
+  pure $ Timed pt evt
+
+instance (Applicative m) => IsSync m event (FileIndexer meta) where
+  lastSyncPoint = pure . Lens.view fileIndexerLastSyncPoint
+  lastSyncPoints _n = pure . lastSyncPoint -- TODO do better
+
+writeTimedEvent
+  :: (MonadIO m, MonadError IndexerError m)
+  => Timed (Point event) (Maybe event)
+  -> FileIndexer meta event
+  -> m ()
+writeTimedEvent timedEvent indexer =
+  let filename = toFilename indexer timedEvent
+   in case timedEvent ^. event of
+        Nothing -> when (indexer ^. keepEmptyEvent) $ writeIndexerFile filename ""
+        Just evt -> writeIndexerFile filename $ indexer ^. serialiseEvent $ evt
+
+writeIndexerFile :: (MonadIO m, MonadError IndexerError m) => FilePath -> ByteString -> m ()
+writeIndexerFile filename = handleIOErrors . BS.writeFile filename
+
+instance (MonadIO m, MonadError IndexerError m) => IsIndex m event (FileIndexer meta) where
+  index timedEvent indexer = do
+    let currentPoint = timedEvent ^. point
+        setLastSync ix = ix & fileIndexerLastSyncPoint .~ currentPoint
+    writeTimedEvent timedEvent indexer
+    pure $ setLastSync indexer
+
+  indexAllDescending timedEvents indexer =
+    case toList timedEvents of
+      [] -> pure indexer
+      x : _ -> do
+        let currentPoint = x ^. point
+            setLastSync ix = ix & fileIndexerLastSyncPoint .~ currentPoint
+        traverse_ (flip writeTimedEvent indexer) timedEvents
+        pure $ setLastSync indexer
+
+  rollback p indexer = do
+    filesWithMetadata <- runExceptT $ directoryContentWithMeta indexer
+    case filesWithMetadata of
+      Left _err -> throwError $ IndexerInternalError "can't parse directory content"
+      Right xs -> forM_ xs $ \eventFile -> do
+        let pt = indexer ^. filePointExtractor $ metadata eventFile
+        when (pt > p) $ liftIO $ removeFile $ path eventFile
+    pure indexer
+
+instance (Applicative m) => Closeable m (FileIndexer meta) where
+  close = const $ pure ()

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/FileIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/FileIndexer.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE TemplateHaskell #-}
-{-# OPTIONS_GHC -Wno-deferred-out-of-scope-variables #-}
 
 {- | An indexer that stores its events to files, using the provided serialisation.
 

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/MixedIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/MixedIndexer.hs
@@ -42,10 +42,12 @@ import Marconi.Core.Experiment.Class (
   Queryable (query),
  )
 import Marconi.Core.Experiment.Indexer.ListIndexer (ListIndexer, events, latestPoint, mkListIndexer)
-import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (unwrapMap))
+import Marconi.Core.Experiment.Transformer.Class (
+  IndexerMapTrans (unwrapMap),
+  IndexerTrans (unwrap),
+ )
 import Marconi.Core.Experiment.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
-  IndexerTrans (unwrap),
   indexVia,
   wrappedIndexer,
   wrapperConfig,

--- a/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Indexer/SQLiteIndexer.hs
@@ -113,12 +113,12 @@ data SQLiteIndexer event = SQLiteIndexer
   -- ^ We keep the sync point in memory to avoid an SQL to retrieve it
   }
 
-makeLenses 'SQLiteIndexer
+makeLenses ''SQLiteIndexer
 
 {- | Start a new indexer or resume an existing SQLite indexer
 
- The main difference with 'SQLiteIndexer' is
- that we set 'dbLastSync' thanks to the provided query
+ The main difference with 'SQLiteIndexer' is that we set 'dbLastSync' thanks to the provided query.
+ It helps resuming an existing indexer.
 -}
 mkSqliteIndexer
   :: forall event m

--- a/marconi-core/src/Marconi/Core/Experiment/Query.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Query.hs
@@ -9,22 +9,30 @@ module Marconi.Core.Experiment.Query (
   EventAtQuery (EventAtQuery),
   EventsMatchingQuery (EventsMatchingQuery),
   allEvents,
+  LatestEventsQuery (LatestEventsQuery),
+  latestEvent,
+  EventsFromQuery (EventsFromQuery),
 ) where
 
 import Control.Lens qualified as Lens
 import Control.Lens.Operators ((^.), (^..), (^?))
 import Control.Monad (when)
-import Control.Monad.Except (MonadError (catchError, throwError))
-import Data.Maybe (mapMaybe)
-import Marconi.Core.Experiment.Class (
-  AppendResult (appendResult),
-  Queryable (query),
-  isAheadOfSync,
+import Control.Monad.Except (MonadError (catchError, throwError), MonadIO (liftIO), runExceptT)
+import Data.ByteString.Lazy qualified as BS
+import Data.List (find)
+import Data.Maybe (catMaybes, mapMaybe)
+import Marconi.Core.Experiment.Class (AppendResult (appendResult), Queryable (query), isAheadOfSync)
+import Marconi.Core.Experiment.Indexer.FileIndexer (
+  FileIndexer,
+  deserialiseEvent,
+  directoryContentWithMeta,
+  filePointExtractor,
  )
+import Marconi.Core.Experiment.Indexer.FileIndexer qualified as FileIndexer
 import Marconi.Core.Experiment.Indexer.ListIndexer (ListIndexer, events)
 import Marconi.Core.Experiment.Type (
   Point,
-  QueryError (AheadOfLastSync, NotStoredAnymore),
+  QueryError (AheadOfLastSync, IndexerQueryError, NotStoredAnymore),
   Result,
   Timed,
   event,
@@ -54,13 +62,40 @@ instance
     pure $ ix ^? events . Lens.folded . Lens.filtered (`isAtPoint` p) . event
 
 instance
+  (MonadIO m, MonadError (QueryError (EventAtQuery event)) m)
+  => Queryable m event (EventAtQuery event) (FileIndexer meta)
+  where
+  query p EventAtQuery ix = do
+    aHeadOfSync <- isAheadOfSync p ix
+    when aHeadOfSync $ throwError $ AheadOfLastSync Nothing
+    content <- directoryContentWithMeta ix
+    let resultContent = find ((p ==) . (ix ^. filePointExtractor) . FileIndexer.metadata) content
+    case resultContent of
+      Nothing -> pure Nothing
+      Just eventFile -> do
+        let resultFile = FileIndexer.path eventFile
+            deserialise = ix ^. deserialiseEvent $ FileIndexer.metadata eventFile
+        result <- liftIO $ BS.readFile resultFile
+        case deserialise result of
+          Left err -> throwError $ IndexerQueryError err
+          Right res -> pure res
+
+instance
   (MonadError (QueryError (EventAtQuery event)) m)
   => AppendResult m event (EventAtQuery event) ListIndexer
   where
   appendResult p q indexer result =
-    result `catchError` \case
-      -- If we didn't find a result in the 1st indexer, try in memory
-      _inDatabaseError -> query p q indexer
+    let extractDbResult =
+          result `catchError` \case
+            -- If we find an incomplete result in the first indexer, complete it
+            AheadOfLastSync (Just r) -> pure r
+            -- For any other error, forward it
+            inDatabaseError -> throwError inDatabaseError
+     in query p q indexer `catchError` \case
+          -- If we find an incomplete result in the first indexer, complete it
+          NotStoredAnymore -> extractDbResult
+          -- For any other error, forward it
+          inMemoryError -> throwError inMemoryError
 
 {- | Query an indexer to find all events that match a given predicate
 
@@ -86,14 +121,115 @@ instance
             ix ^.. events . Lens.folded . Lens.filtered (isBefore p)
 
     aheadOfSync <- isAheadOfSync p ix
-    when aheadOfSync $
-      throwError . AheadOfLastSync . Just $
-        result
+    when aheadOfSync $ throwError . AheadOfLastSync $ Just result
     pure result
 
 instance
   (MonadError (QueryError (EventsMatchingQuery event)) m)
   => AppendResult m event (EventsMatchingQuery event) ListIndexer
+  where
+  appendResult p q indexer result =
+    let extractDbResult =
+          result `catchError` \case
+            -- If we find an incomplete result in the first indexer, complete it
+            AheadOfLastSync (Just r) -> pure r
+            -- For any other error, forward it
+            inDatabaseError -> throwError inDatabaseError
+
+        extractMemoryResult =
+          query p q indexer `catchError` \case
+            -- If we find an incomplete result in the first indexer, complete it
+            NotStoredAnymore -> pure []
+            -- For any other error, forward it
+            inMemoryError -> throwError inMemoryError
+     in do
+          dbResult <- extractDbResult
+          memoryResult <- extractMemoryResult
+          pure $ memoryResult <> dbResult
+
+-- | Get the 'nbOfEvents' last non empty from the indexer before the point given in the query
+newtype LatestEventsQuery event = LatestEventsQuery {nbOfEvents :: Word}
+
+-- | Get the latest non empty event befor the point given in the query
+latestEvent :: LatestEventsQuery event
+latestEvent = LatestEventsQuery 1
+
+type instance Result (LatestEventsQuery event) = [Timed (Point event) event]
+
+instance
+  (MonadError (QueryError (LatestEventsQuery event)) m)
+  => Queryable m event (LatestEventsQuery event) ListIndexer
+  where
+  query p q ix = do
+    aHeadOfSync <- isAheadOfSync p ix
+    when aHeadOfSync $ throwError $ AheadOfLastSync Nothing
+    pure $
+      take (fromIntegral $ nbOfEvents q) $
+        ix ^.. events . Lens.folded . Lens.filtered (\x -> x ^. point <= p)
+
+instance
+  (MonadIO m, MonadError (QueryError (LatestEventsQuery event)) m)
+  => Queryable m event (LatestEventsQuery event) (FileIndexer meta)
+  where
+  query p q ix = do
+    aHeadOfSync <- isAheadOfSync p ix
+    when aHeadOfSync $ throwError $ AheadOfLastSync Nothing
+    content <- directoryContentWithMeta ix
+    let validCandidate eventFile =
+          (ix ^. filePointExtractor) (FileIndexer.metadata eventFile) <= p
+            && FileIndexer.hasContent eventFile
+        resultFile = filter validCandidate content
+        extractEvents
+          :: [Either a (Timed (Point event) (Maybe event))]
+          -> Either a [Maybe (Timed (Point event) event)]
+        extractEvents = fmap (fmap sequence) . sequence
+    result <- traverse (runExceptT . FileIndexer.deserialiseTimedEvent ix) resultFile
+    case extractEvents result of
+      Left err -> throwError $ IndexerQueryError err
+      Right res -> pure $ take (fromIntegral $ nbOfEvents q) $ catMaybes res
+
+-- | Get the non empty events from the given point (excluded) to the one of the query (included)
+newtype EventsFromQuery event = EventsFromQuery {startingPoint :: Point event}
+
+type instance Result (EventsFromQuery event) = [Timed (Point event) event]
+
+instance
+  (MonadError (QueryError (EventsFromQuery event)) m)
+  => Queryable m event (EventsFromQuery event) ListIndexer
+  where
+  query p q ix = do
+    aHeadOfSync <- isAheadOfSync p ix
+    when aHeadOfSync $ throwError $ AheadOfLastSync Nothing
+    pure $
+      ix
+        ^.. events
+          . Lens.folded
+          . Lens.filtered (\x -> x ^. point <= p && x ^. point > startingPoint q)
+
+instance
+  (MonadIO m, MonadError (QueryError (EventsFromQuery event)) m)
+  => Queryable m event (EventsFromQuery event) (FileIndexer meta)
+  where
+  query p q ix = do
+    aHeadOfSync <- isAheadOfSync p ix
+    when aHeadOfSync $ throwError $ AheadOfLastSync Nothing
+    content <- directoryContentWithMeta ix
+    let validCandidate eventFile =
+          let eventPoint = (ix ^. filePointExtractor) (FileIndexer.metadata eventFile)
+           in eventPoint <= p && eventPoint > startingPoint q && FileIndexer.hasContent eventFile
+        resultFile = filter validCandidate content
+        extractEvents
+          :: [Either a (Timed (Point event) (Maybe event))]
+          -> Either a [Maybe (Timed (Point event) event)]
+        extractEvents = fmap (fmap sequence) . sequence
+    result <- traverse (runExceptT . FileIndexer.deserialiseTimedEvent ix) resultFile
+    case extractEvents result of
+      Left err -> throwError $ IndexerQueryError err
+      Right res -> pure $ catMaybes res
+
+instance
+  (MonadError (QueryError (EventsFromQuery event)) m)
+  => AppendResult m event (EventsFromQuery event) ListIndexer
   where
   appendResult p q indexer result =
     let extractDbResult =

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/Class.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/Class.hs
@@ -3,22 +3,15 @@
    It allows the generalisation of properties amongst all indexer transformers.
 -}
 module Marconi.Core.Experiment.Transformer.Class (
-  IndexerTrans (Config, wrap, unwrap),
-  IndexerMapTrans (ConfigMap, wrapMap, unwrapMap),
+  IndexerTrans (unwrap),
+  IndexerMapTrans (unwrapMap),
 ) where
 
 import Control.Lens (Lens')
-import Data.Kind (Type)
 
 -- | An indexer transformer: it adds a configurable capability to a tranformer
 class IndexerTrans t where
-  -- | The type of the configuration of a transformer
-  type Config t :: Type -> Type
-
-  -- | Wrap an existing indexer in its transformer
-  wrap :: Config t event -> indexer event -> t indexer event
-
-  -- | Unwray the underlying indexer
+  -- | Unwrap the underlying indexer
   unwrap :: Lens' (t indexer event) (indexer event)
 
 {- | An indexer transformer: it adds a configurable capability to a tranformer
@@ -26,11 +19,5 @@ class IndexerTrans t where
  This one allow also the transformation of the event, contrary to 'IndexerTrans'.
 -}
 class IndexerMapTrans t where
-  -- | The type of the configuration of a transformer
-  type ConfigMap t :: Type -> Type -> Type
-
-  -- | Wrap an existing indexer in its transformer
-  wrapMap :: ConfigMap t output event -> indexer output -> t indexer output event
-
-  -- | Unwray the underlying indexer
+  -- | Unwrap the underlying indexer
   unwrapMap :: Lens' (t indexer output event) (indexer output)

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCache.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCache.hs
@@ -42,10 +42,12 @@ import Marconi.Core.Experiment.Class (
   queryLatest,
  )
 import Marconi.Core.Experiment.Indexer.SQLiteAggregateQuery (HasDatabasePath)
-import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (unwrapMap))
+import Marconi.Core.Experiment.Transformer.Class (
+  IndexerMapTrans (unwrapMap),
+  IndexerTrans (unwrap),
+ )
 import Marconi.Core.Experiment.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
-  IndexerTrans (Config, unwrap, wrap),
   indexAllDescendingVia,
   indexVia,
   lastSyncPointVia,
@@ -182,10 +184,6 @@ addCacheFor q indexer = do
     Right result -> pure $ indexer & cache %~ Map.insert q result
 
 instance IndexerTrans (WithCache query) where
-  type Config (WithCache query) = CacheConfig query
-
-  wrap cfg = WithCache . IndexTransformer cfg
-
   unwrap = cacheWrapper . wrappedIndexer
 
 rollbackCache

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCatchup.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithCatchup.hs
@@ -29,10 +29,12 @@ import Marconi.Core.Experiment.Class (
   Resetable (reset),
  )
 import Marconi.Core.Experiment.Indexer.SQLiteAggregateQuery (HasDatabasePath)
-import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (unwrapMap))
+import Marconi.Core.Experiment.Transformer.Class (
+  IndexerMapTrans (unwrapMap),
+  IndexerTrans (unwrap),
+ )
 import Marconi.Core.Experiment.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
-  IndexerTrans (Config, unwrap, wrap),
   indexAllDescendingVia,
   indexVia,
   resetVia,
@@ -119,10 +121,6 @@ caughtUpIndexer :: Lens.Lens' (WithCatchup indexer event) (indexer event)
 caughtUpIndexer = catchupWrapper . wrappedIndexer
 
 instance IndexerTrans WithCatchup where
-  type Config WithCatchup = CatchupContext
-
-  wrap cfg = WithCatchup . IndexTransformer cfg
-
   unwrap = caughtUpIndexer
 
 {- | A typeclass that allows an indexer with a @WitchCatchup@ transformer to configure

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithDelay.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithDelay.hs
@@ -29,10 +29,12 @@ import Marconi.Core.Experiment.Class (
   Resetable (reset),
  )
 import Marconi.Core.Experiment.Indexer.SQLiteAggregateQuery (HasDatabasePath)
-import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (unwrapMap))
+import Marconi.Core.Experiment.Transformer.Class (
+  IndexerMapTrans (unwrapMap),
+  IndexerTrans (unwrap),
+ )
 import Marconi.Core.Experiment.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
-  IndexerTrans (Config, unwrap, wrap),
   indexVia,
   resetVia,
   rollbackVia,
@@ -91,10 +93,6 @@ deriving via
     (Queryable m event query indexer) => Queryable m event query (WithDelay indexer)
 
 instance IndexerTrans WithDelay where
-  type Config WithDelay = DelayConfig
-
-  wrap cfg = WithDelay . IndexTransformer cfg
-
   unwrap = delayedIndexer
 
 delayedIndexer :: Lens' (WithDelay indexer event) (indexer event)

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithFold.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithFold.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE StrictData #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{- |
+    A transformer that allows an indexer to fold incoming events:
+    each new event is the result of a computation between the last result in the indexer
+    and the incoming event.
+
+
+    See "Marconi.Core.Experiment" for documentation.
+-}
+module Marconi.Core.Experiment.Transformer.WithFold (
+  WithFold,
+  withFold,
+  withFoldMap,
+  HasFoldConfig (fold),
+) where
+
+import Control.Lens (Getter, Lens', makeLenses, (.~))
+import Control.Lens.Operators ((?~), (^.))
+import Control.Monad.Except (ExceptT, MonadError (throwError))
+import Data.Foldable (Foldable (toList))
+import Data.Function ((&))
+import Data.List (scanl', sortOn)
+import Data.Maybe (fromMaybe)
+import Marconi.Core.Experiment.Class (
+  Closeable (close),
+  HasGenesis (genesis),
+  IsIndex (index, indexAllDescending, rollback),
+  IsSync (lastSyncPoint, lastSyncPoints),
+  Queryable (query),
+  Resetable (reset),
+  queryEither,
+ )
+import Marconi.Core.Experiment.Query (EventAtQuery (EventAtQuery))
+import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (ConfigMap, unwrapMap, wrapMap))
+import Marconi.Core.Experiment.Transformer.IndexTransformer (
+  closeVia,
+  indexAllDescendingVia,
+  indexVia,
+  lastSyncPointVia,
+  lastSyncPointsVia,
+  queryVia,
+  resetVia,
+  rollbackVia,
+ )
+import Marconi.Core.Experiment.Type (
+  IndexerError (IndexerInternalError),
+  Point,
+  QueryError,
+  Timed (Timed),
+  event,
+  point,
+ )
+
+data FoldConfig output input = FoldConfig
+  { _initialConfig :: output
+  , _foldConfig :: output -> input -> output
+  }
+
+makeLenses ''FoldConfig
+
+-- | 'WithFold' fold incoming @event@ to produce an @output@.
+data WithFold indexer output input = WithFold
+  { _config :: FoldConfig output input
+  , _foldedIndexer :: indexer output
+  }
+
+makeLenses ''WithFold
+
+-- | A smart constructor for 'WitFold'
+withFold
+  :: output
+  -> (output -> input -> output)
+  -> indexer output
+  -> WithFold indexer output input
+withFold init' fold' _foldedIndexer =
+  WithFold
+    { _config = FoldConfig init' fold'
+    , _foldedIndexer
+    }
+
+-- | A smart constructor for 'WitFold'
+withFoldMap
+  :: (Monoid output)
+  => (input -> output)
+  -> indexer output
+  -> WithFold indexer output input
+withFoldMap f _foldedIndexer =
+  WithFold
+    { _config = FoldConfig mempty (\acc x -> acc <> f x)
+    , _foldedIndexer
+    }
+
+-- | There are few scenarios where you want to modify the fold function but it may happen
+class HasFoldConfig input output indexer where
+  initial :: Getter (indexer input) output
+  fold :: Lens' (indexer input) (output -> input -> output)
+
+instance HasFoldConfig input output (WithFold indexer output) where
+  initial = config . initialConfig
+  fold = config . foldConfig
+
+instance IndexerMapTrans WithFold where
+  type ConfigMap WithFold = FoldConfig
+  wrapMap = WithFold
+  unwrapMap = foldedIndexer
+
+{- | Get the previous value stored by the indexer, or the initial value if the previous value
+doesn't exist
+-}
+getPreviousValue
+  :: ( MonadError IndexerError m
+     , HasGenesis (Point output)
+     , Point input ~ Point output
+     , IsSync m output indexer
+     , Queryable (ExceptT (QueryError (EventAtQuery output)) m) output (EventAtQuery output) indexer
+     , Ord (Point output)
+     )
+  => WithFold indexer output input
+  -> m (Timed (Point output) (Maybe output))
+getPreviousValue indexer = do
+  lSync <- lastSyncPoint indexer
+  evt <-
+    if lSync == genesis
+      then pure Nothing
+      else do
+        lastAggregateOrError <- queryEither lSync EventAtQuery indexer
+        case lastAggregateOrError of
+          Left _ -> throwError $ IndexerInternalError "can't find last aggregate"
+          Right previous -> pure previous
+  pure $ Timed lSync evt
+
+instance
+  (Point output ~ Point event, IsSync m output indexer)
+  => IsSync m event (WithFold indexer output)
+  where
+  lastSyncPoint = lastSyncPointVia unwrapMap
+  lastSyncPoints = lastSyncPointsVia unwrapMap
+
+instance
+  ( Queryable m output query indexer
+  , Point input ~ Point output
+  )
+  => Queryable m input query (WithFold indexer output)
+  where
+  query = queryVia unwrapMap
+
+instance
+  ( Functor m
+  , Resetable m output indexer
+  , HasGenesis (Point event)
+  )
+  => Resetable m event (WithFold indexer output)
+  where
+  reset = resetVia unwrapMap
+
+instance (Closeable m indexer) => Closeable m (WithFold indexer output) where
+  close = closeVia unwrapMap
+
+instance
+  ( MonadError IndexerError m
+  , HasGenesis (Point output)
+  , Point input ~ Point output
+  , IsSync m output indexer
+  , IsIndex m output indexer
+  , Queryable (ExceptT (QueryError (EventAtQuery output)) m) output (EventAtQuery output) indexer
+  , Ord (Point output)
+  )
+  => IsIndex m input (WithFold indexer output)
+  where
+  index timedEvent indexer = do
+    Timed _ previous <- getPreviousValue indexer
+    let foldEvent Nothing = previous
+        foldEvent (Just evt) = Just $ (indexer ^. fold) (fromMaybe (indexer ^. initial) previous) evt
+    indexVia unwrapMap (foldEvent <$> timedEvent) indexer
+
+  indexAllDescending events indexer = case sortOn (^. point) $ toList events of
+    [] -> pure indexer
+    xs -> do
+      previousTimedEvent <- getPreviousValue indexer
+      let foldEvent p te = case (p ^. event, te ^. event) of
+            (previous, Nothing) -> te & event .~ previous
+            (previous, Just evt) ->
+              let previous' = fromMaybe (indexer ^. initial) previous
+               in te & event ?~ (indexer ^. fold) previous' evt
+          asOutputs = scanl' foldEvent
+      indexAllDescendingVia unwrapMap (asOutputs previousTimedEvent xs) indexer
+
+  rollback = rollbackVia unwrapMap

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithPruning.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithPruning.hs
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 {- |
-    A transformer that cache result of some queries
+    A transformer that prune the content of an indexer
 
     See "Marconi.Core.Experiment" for documentation.
 -}
@@ -38,10 +38,12 @@ import Marconi.Core.Experiment.Class (
   Resetable (reset),
  )
 import Marconi.Core.Experiment.Indexer.MixedIndexer (MixedIndexer, inDatabase)
-import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (unwrapMap))
+import Marconi.Core.Experiment.Transformer.Class (
+  IndexerMapTrans (unwrapMap),
+  IndexerTrans (unwrap),
+ )
 import Marconi.Core.Experiment.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
-  IndexerTrans (Config, unwrap, wrap),
   indexVia,
   resetVia,
   rollbackVia,
@@ -186,10 +188,6 @@ instance
   pruneEvery = unwrap . pruneEvery
 
 instance IndexerTrans WithPruning where
-  type Config WithPruning = PruningConfig
-
-  wrap cfg = WithPruning . IndexTransformer cfg
-
   unwrap = pruningWrapper . wrappedIndexer
 
 pruneAt

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithTracer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithTracer.hs
@@ -46,10 +46,12 @@ import Marconi.Core.Experiment.Class (
   Resetable (reset),
  )
 import Marconi.Core.Experiment.Indexer.SQLiteAggregateQuery (HasDatabasePath)
-import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (unwrapMap))
+import Marconi.Core.Experiment.Transformer.Class (
+  IndexerMapTrans (unwrapMap),
+  IndexerTrans (unwrap),
+ )
 import Marconi.Core.Experiment.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
-  IndexerTrans (Config, unwrap, wrap),
   closeVia,
   indexAllDescendingVia,
   indexAllVia,
@@ -137,10 +139,6 @@ instance (Queryable m event query indexer) => Queryable m event query (WithTrace
   query = queryVia unwrap
 
 instance IndexerTrans (WithTracer m) where
-  type Config (WithTracer m) = IndexerTracer m
-
-  wrap cfg = WithTracer . IndexTransformer cfg
-
   unwrap = tracerWrapper . unwrap
 
 {- | It gives access to the tracer. The provided instances allows access to the tracer event below
@@ -331,10 +329,6 @@ instance (Queryable m event query indexer) => Queryable m event query (WithTrace
   query = queryVia unwrap
 
 instance IndexerTrans (WithTrace m) where
-  type Config (WithTrace m) = IndexerTrace m
-
-  wrap cfg = WithTrace . IndexTransformer cfg
-
   unwrap = traceWrapper . unwrap
 
 {- | It gives access to the tracer. The provided instances allows access to the tracer event below

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithTransform.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithTransform.hs
@@ -25,7 +25,7 @@ import Marconi.Core.Experiment.Class (
   Resetable (reset),
  )
 import Marconi.Core.Experiment.Indexer.SQLiteAggregateQuery (HasDatabasePath (getDatabasePath))
-import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (ConfigMap, unwrapMap, wrapMap))
+import Marconi.Core.Experiment.Transformer.Class (IndexerMapTrans (unwrapMap))
 import Marconi.Core.Experiment.Transformer.IndexTransformer (
   closeVia,
   getDatabasePathVia,
@@ -80,9 +80,6 @@ transformPoint :: Lens' (WithTransform indexer output input) (Point input -> Poi
 transformPoint = config . transformPointConfig
 
 instance IndexerMapTrans WithTransform where
-  type ConfigMap WithTransform = TransformConfig
-
-  wrapMap = WithTransform
   unwrapMap = transformedIndexer
 
 instance

--- a/marconi-core/src/Marconi/Core/Experiment/Worker.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Worker.hs
@@ -24,13 +24,14 @@ import Control.Concurrent (MVar, QSemN, ThreadId)
 import Control.Concurrent qualified as Con
 import Control.Concurrent.STM (TChan)
 import Control.Concurrent.STM qualified as STM
-import Control.Exception (SomeException, catch, finally)
+import Control.Exception (SomeException (SomeException), catch, finally)
 import Control.Lens.Operators ((^.))
 import Control.Monad (void)
 import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Trans (MonadTrans (lift))
 import Data.Text (Text)
+import Data.Text qualified as Text
 import Marconi.Core.Experiment.Class (
   Closeable (close),
   IsIndex (index, rollback),
@@ -198,7 +199,7 @@ startWorker chan errorBox endTokens tokens (Worker name ix transformInput hoistE
       safeProcessEvent input = do
         processedInput <- mapIndex transformInput input
         process processedInput
-          `catch` \(_ :: SomeException) -> pure $ Just $ StopIndexer (Just name)
+          `catch` \(SomeException e) -> pure $ Just $ StopIndexer (Just $ name <> " " <> Text.pack (show e))
 
       loop :: TChan (ProcessedInput input) -> IO ()
       loop chan' =

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -1280,20 +1280,18 @@ resumeLastSyncProperty rehydrate gen =
     lift $ Core.close indexer''
     pure $ origSyncPoint === resumedSyncPoint
 
--- TODO Became very slow since commit 50e35a71f7106500b87ec8eb6d2ff820c2f08b96
 resumeSQLiteLastSyncTest :: Tasty.TestTree
 resumeSQLiteLastSyncTest =
   Tasty.testProperty "SQLiteIndexer - stop and restart restore lastSyncPoint" $
-    Test.withMaxSuccess 5 $
+    Test.withMaxSuccess 100 $
       resumeLastSyncProperty
         sqliteModelIndexerWithFile
         (view chainWithoutEmptyEvents <$> Test.arbitrary)
 
--- TODO Became very slow since commit 50e35a71f7106500b87ec8eb6d2ff820c2f08b96
 resumeMixedLastSyncTest :: Tasty.TestTree
 resumeMixedLastSyncTest =
   Tasty.testProperty "MixedIndexer - stop and restart restore lastSyncPoint" $
-    Test.withMaxSuccess 5 $
+    Test.withMaxSuccess 100 $
       resumeLastSyncProperty
         mixedModelNoMemoryIndexerWithFile
         (view chainWithoutEmptyEvents <$> Test.arbitrary)
@@ -1568,14 +1566,27 @@ withResumeTest =
 
 -- | A runner for a the 'WithFold' tranformer (using withFoldMap)
 withFoldMapRunner
-  :: (Monad m, Monoid output)
+  :: ( MonadError Core.IndexerError m
+     , Monoid output
+     , Core.IsSync m output wrapped
+     , Core.HasGenesis (Core.Point output)
+     , Core.Queryable
+        ( ExceptT
+            (Core.QueryError (Core.EventAtQuery output))
+            m
+        )
+        output
+        (Core.EventAtQuery output)
+        wrapped
+     , Ord (Core.Point output)
+     )
   => (input -> output)
   -> Model.IndexerTestRunner m output wrapped
-  -> Model.IndexerTestRunner m input (Core.WithFold wrapped output)
+  -> Model.IndexerTestRunner m input (Core.WithFold m wrapped output)
 withFoldMapRunner f wRunner =
   Model.IndexerTestRunner
     (wRunner ^. Model.indexerRunner)
-    (Core.withFoldMap f <$> wRunner ^. Model.indexerGenerator)
+    (Core.withFoldMap Core.getLastByQuery f <$> wRunner ^. Model.indexerGenerator)
 
 deriving via (Sum Int) instance Semigroup TestEvent
 deriving via (Sum Int) instance Monoid TestEvent
@@ -1634,8 +1645,6 @@ withRollbackFailureRunner wRunner =
     (WithRollbackFailure . Core.IndexTransformer (Const ()) <$> (wRunner ^. Model.indexerGenerator))
 
 instance Core.IndexerTrans WithRollbackFailure where
-  type Config WithRollbackFailure = Const ()
-  wrap cfg = WithRollbackFailure . Core.IndexTransformer cfg
   unwrap = withRollbackFailure . Core.wrappedIndexer
 
 deriving via

--- a/marconi-core/test/Marconi/Core/Spec/Experiment.hs
+++ b/marconi-core/test/Marconi/Core/Spec/Experiment.hs
@@ -1586,7 +1586,7 @@ withFoldMapRunner
 withFoldMapRunner f wRunner =
   Model.IndexerTestRunner
     (wRunner ^. Model.indexerRunner)
-    (Core.withFoldMap Core.getLastByQuery f <$> wRunner ^. Model.indexerGenerator)
+    (Core.withFoldMap Core.getLastEventAtQueryValue f <$> wRunner ^. Model.indexerGenerator)
 
 deriving via (Sum Int) instance Semigroup TestEvent
 deriving via (Sum Int) instance Monoid TestEvent


### PR DESCRIPTION
The performance isn't good. From the various tests, it seems that the main issue is the ledger state computation but it doesn't explain why it's slower than the original experimentation.

Missing features:
- tests
- queries

Issues:
- resuming doesn't work when the indexer is ahead of the other indexers
- performance

Why do we propose it then?
Once these points are covered, we should be able to have a better alternative than the current epoch state, especially once synced:
- we store only new blocks, not epoch-state, after each block
- we've decomposed the monolithic indexer into smaller parts.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
