### PR TITLE
PLT-7457 Fixed runtime error "UNIQUE constraint failed: lastSync.slotNo"

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/SyncHelper.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/SyncHelper.hs
@@ -21,10 +21,18 @@ import Database.SQLite.Simple.QQ (sql)
 import Marconi.ChainIndex.Orphans ()
 import Marconi.Core.Experiment qualified as Core
 
--- | A simple table to store the passed chainpoints
+{- | A simple table to store the passed chain points.
+
+Note that in Byron era, there can be multiple added blocks in the same slot. That explains why we
+can't use the `PRIMARY KEY` constraint for `slotNo` only.
+-}
 syncTableCreation :: SQL.Query
 syncTableCreation =
-  [sql|CREATE TABLE IF NOT EXISTS sync (slotNo INT PRIMARY KEY, blockHeaderHash BLOB)|]
+  [sql|CREATE TABLE IF NOT EXISTS sync
+         ( slotNo INT NOT NULL
+         , blockHeaderHash BLOB NOT NULL
+         , PRIMARY KEY (slotNo, blockHeaderHash)
+         )|]
 
 {- | NOTE: NOT AT ALL PERFORMANT. DO NOT USE.
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/UtxoQuery.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/UtxoQuery.hs
@@ -264,7 +264,7 @@ baseQuery =
     spentBlockInfo.blockNo,
     spentBlockInfo.blockTimestamp,
     spentBlockInfo.epochNo,
-    futureSpent.spentAt,
+    futureSpent.spentAtTxId,
 
     -- UtxoResult.inputs
     GROUP_CONCAT(HEX(txIn.txId)),
@@ -276,7 +276,7 @@ baseQuery =
   -- Attach datum
   LEFT JOIN datum.datum d ON d.datumHash = u.datumHash
   -- Attach TxIns
-  LEFT JOIN spent.spent txIn ON txIn.spentAt = u.txId
+  LEFT JOIN spent.spent txIn ON txIn.spentAtTxId = u.txId
   -- Attach utxo block info
   LEFT JOIN blockInfo.blockInfo utxoBlockInfo ON utxoBlockInfo.slotNo = u.slotNo
   -- Attach spent block info

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -626,9 +626,9 @@ mkIndexerStream' f coordinator =
       waitQSemN _barrier _indexerCount
       pure c'
 
-    -- give 3 minutes (180s) for a step to finish
+    -- give 30 minutes (1800s) for a step to finish
     safeStep c event = do
-      result <- timeout 180_000_000 $ step c event
+      result <- timeout 1_800_000_000 $ step c event
       case result of
         Nothing -> error "At least one indexer is stuck, closing marconi"
         Just res -> pure res

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/LastSync.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/LastSync.hs
@@ -24,8 +24,9 @@ createLastSyncTable c =
   SQL.execute_
     c
     [sql|CREATE TABLE IF NOT EXISTS lastSync
-    ( slotNo INT PRIMARY KEY
+    ( slotNo INT NOT NULL
     , blockHeaderHash BLOB NOT NULL
+    , PRIMARY KEY (slotNo, blockHeaderHash)
     )|]
 
 -- | update the last sync point of the indexer

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -648,11 +648,12 @@ open dbPath (Depth k) isToVacuume = do
     SQL.execute_
       c
       [sql|CREATE TABLE IF NOT EXISTS blockInfo
-                    ( slotNo INT PRIMARY KEY
+                    ( slotNo INT NOT NULL
                     , blockHeaderHash BLOB NOT NULL
                     , blockNo INT NOT NULL
                     , blockTimestamp INT NOT NULL
                     , epochNo INT NOT NULL
+                    , PRIMARY KEY (slotNo, blockHeaderHash)
                     )|]
 
   lift $

--- a/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Mockchain.hs
+++ b/marconi-chain-index/test-lib/Gen/Marconi/ChainIndex/Mockchain.hs
@@ -47,7 +47,7 @@ type Mockchain era = [MockBlock era]
 deriving stock instance Show C.BlockHeader
 
 data MockBlock era = MockBlock
-  { mockBlockChainPoint :: !C.BlockHeader
+  { mockBlockHeader :: !C.BlockHeader
   , mockBlockTxs :: ![C.Tx era]
   }
   deriving (Show)

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/Datum.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/Datum.hs
@@ -80,17 +80,11 @@ getDatumsEvents
   :: Gen.Mockchain era
   -> [Core.Timed C.ChainPoint (Maybe (NonEmpty Datum.DatumInfo))]
 getDatumsEvents =
-  let getChainPoint :: Gen.BlockHeader -> C.ChainPoint
-      getChainPoint (Gen.BlockHeader slotNo blockHeaderHash _blockNo) =
-        C.ChainPoint slotNo blockHeaderHash
-
-      getBlockDatumsEvent
+  let getBlockDatumsEvent
         :: Gen.MockBlock era
         -> Core.Timed C.ChainPoint (Maybe (NonEmpty Datum.DatumInfo))
-
-      getBlockDatumsEvent block =
-        Core.Timed (getChainPoint $ Gen.mockBlockChainPoint block)
-          . NonEmpty.nonEmpty
-          . (Datum.getDataFromTxBody . C.getTxBody =<<)
-          $ Gen.mockBlockTxs block
+      getBlockDatumsEvent (Gen.MockBlock (C.BlockHeader slotNo bhh _) txs) =
+        Core.Timed (C.ChainPoint slotNo bhh) $
+          NonEmpty.nonEmpty $
+            concatMap (Datum.getDataFromTxBody . C.getTxBody) txs
    in fmap getBlockDatumsEvent

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/Utxo.hs
@@ -216,14 +216,12 @@ getTimedUtxosEvents =
    in fmap getBlockTimedUtxosEvent
 
 getBlockUtxosEvent :: (C.IsCardanoEra era) => Gen.MockBlock era -> Maybe (NonEmpty Utxo.Utxo)
-getBlockUtxosEvent = NonEmpty.nonEmpty . join . zipWith Utxo.getUtxosFromTx [0 ..] . Gen.mockBlockTxs
+getBlockUtxosEvent (Gen.MockBlock _ txs) =
+  NonEmpty.nonEmpty $ join $ zipWith Utxo.getUtxosFromTx [0 ..] txs
 
 extractChainPoint :: Gen.MockBlock era -> C.ChainPoint
-extractChainPoint =
-  let getChainPoint :: Gen.BlockHeader -> C.ChainPoint
-      getChainPoint (Gen.BlockHeader slotNo blockHeaderHash _blockNo) =
-        C.ChainPoint slotNo blockHeaderHash
-   in getChainPoint . Gen.mockBlockChainPoint
+extractChainPoint (Gen.MockBlock (C.BlockHeader slotNo blockHeaderHash _) _) =
+  C.ChainPoint slotNo blockHeaderHash
 
 -- Generate a random 'Utxo'
 genUtxo :: Hedgehog.Gen Utxo.Utxo

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo/UtxoIndex.hs
@@ -24,7 +24,7 @@ import Data.Maybe (isJust, isNothing, mapMaybe)
 import Data.Set qualified as Set
 import Gen.Marconi.ChainIndex.Indexers.Utxo (genShelleyEraUtxoEvents, genUtxoEvents)
 import Gen.Marconi.ChainIndex.Indexers.Utxo qualified as UtxoGen
-import Gen.Marconi.ChainIndex.Mockchain (MockBlock (mockBlockChainPoint, mockBlockTxs))
+import Gen.Marconi.ChainIndex.Mockchain (MockBlock (mockBlockHeader, mockBlockTxs))
 import Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Gen.Marconi.ChainIndex.Types qualified as Gen
 import Hedgehog (Gen, Property, cover, forAll, property, (/==), (===))
@@ -826,7 +826,7 @@ propGetUtxoEventFromBlock :: Property
 propGetUtxoEventFromBlock = Hedgehog.property $ do
   utxoEventsWithTxs <- Hedgehog.forAll UtxoGen.genUtxoEventsWithTxs
   forM_ utxoEventsWithTxs $ \(expectedUtxoEvent, block) -> do
-    let (C.BlockHeader sno bhh bn) = mockBlockChainPoint block
+    let (C.BlockHeader sno bhh bn) = mockBlockHeader block
         txs = mockBlockTxs block
         bi = BlockInfo sno bhh bn 0 1
         tip = C.ChainTip sno bhh bn

--- a/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Bootstrap.hs
@@ -4,7 +4,6 @@
 -}
 module Marconi.Sidechain.Bootstrap where
 
-import Cardano.Api qualified as C
 import Control.Concurrent.STM (atomically)
 import Control.Lens (view, (^.))
 import Control.Monad.Reader (ReaderT, lift)
@@ -85,7 +84,7 @@ runSidechainIndexers = do
       (CLI.optionsRetryConfig cliArgs)
       (CLI.socketFilePath cliArgs)
       (CLI.networkId cliArgs)
-      C.ChainPointAtGenesis
+      (CLI.optionsChainPoint cliArgs)
       (CLI.minIndexingDepth cliArgs)
       (CLI.optionsFailsIfResync cliArgs)
       indexers

--- a/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/CLI.hs
@@ -44,6 +44,7 @@ data CliArgs = CliArgs
   -- ^ Fails resuming if at least one indexer will resync from genesis instead of one of its lastest
   -- synced point.
   , optionsRetryConfig :: !RetryConfig
+  , optionsChainPoint :: !C.ChainPoint
   }
   deriving (Show, Generic, FromJSON, ToJSON)
 
@@ -72,3 +73,4 @@ parserCliArgs =
     <*> Cli.commonMaybeTargetAssetParser
     <*> Cli.commonShouldFailIfResyncParser
     <*> Cli.commonRetryConfigParser
+    <*> Cli.chainPointParser

--- a/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___help.help
+++ b/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___help.help
@@ -10,7 +10,9 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain
 
@@ -50,3 +52,13 @@ Available options:
   --no-max-retry-time      Unlimited retries.
   --max-retry-time NATURAL Max time (in seconds) allowed after startup for
                            retries. Defaults to 30min.
+  -n,--slot-no SLOT-NO     Slot number of the preferred starting point. Note
+                           that you also need to provide the starting point
+                           block header hash with `--block-header-hash`. Might
+                           fail if the target indexers can't resume from
+                           arbitrary points.
+  -b,--block-header-hash BLOCK-HEADER-HASH
+                           Block header hash of the preferred starting point.
+                           Note that you also need to provide the starting point
+                           slot number with `--slot-no`. Might fail if the
+                           target indexers can't resume from arbitrary points.

--- a/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___socket.help
+++ b/marconi-sidechain/test/Spec/Golden/Cli/marconi-sidechain___socket.help
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddress-MissingBech32Prefix.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddress-MissingBech32Prefix.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddress-badFormat.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddress-badFormat.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddressPrefix-stake1.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddressPrefix-stake1.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddressPrefix-stake_test.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddressPrefix-stake_test.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddress_1CharShort.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAddress_1CharShort.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-assetName-invalidBase16Format.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-assetName-invalidBase16Format.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-assetName-invalidBase16Length.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-assetName-invalidBase16Length.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-assetName-tooLong.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-assetName-tooLong.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-1ByteLong.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-1ByteLong.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-1ByteShort.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-1ByteShort.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-1HexCharLong.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-1HexCharLong.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-1HexCharShort.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-1HexCharShort.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain

--- a/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-badBase16Format.golden
+++ b/marconi-sidechain/test/Spec/Marconi/Sidechain/CLIInputValidation/Golden/invalidAssetId-policyId-badBase16Format.golden
@@ -9,6 +9,8 @@ Usage: marconi-sidechain [--version] (-s|--socket-path FILE-PATH)
                          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
                          [--fail-if-resyncing-from-genesis] 
                          [--initial-retry-time NATURAL] 
-                         [--no-max-retry-time | --max-retry-time NATURAL]
+                         [--no-max-retry-time | --max-retry-time NATURAL] 
+                         [(-n|--slot-no SLOT-NO)
+                           (-b|--block-header-hash BLOCK-HEADER-HASH)]
 
   marconi-sidechain


### PR DESCRIPTION
Fixes #153

We get a runtime error "UNIQUE constraint failed: lastSync.slotNo" when running marconi-chain-index and marconi-sidechain on mainnet.

Replaced the use of SlotNo as a primary key for some tables with the composite primary key (SlotNo, BlockHeaderHash) because we can have two blocks in the same slot in Byron era.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
