### PR TITLE
PLT-7542 Catch exceptions in http handlers and return a JSON-RPC error

### DIFF
--- a/marconi-sidechain/examples/run-pre-prod-queries
+++ b/marconi-sidechain/examples/run-pre-prod-queries
@@ -11,6 +11,15 @@ banner() {
   echo ''
 }
 
+get() {
+  local ENDPOINT=$1
+  local FORMAT=${2-cat}
+
+  echo -n "GET /$ENDPOINT -> "
+  curl -sS --fail-with-body "http://localhost:$PORT/$ENDPOINT" | "$FORMAT"
+  echo ''
+}
+
 query() {
   local method=$1
   local params=$2
@@ -24,9 +33,20 @@ query() {
   echo ''
 }
 
+banner "REST APIs"
+
+get time
+get params jq
+get addresses jq
+get metrics
+
 banner "unknownMethod"
 
 query "unknownMethod" '""'
+
+banner "echo"
+
+query "echo" '"Hello, World!"'
 
 banner "getTargetAddresses"
 

--- a/marconi-sidechain/marconi-sidechain.cabal
+++ b/marconi-sidechain/marconi-sidechain.cabal
@@ -83,6 +83,7 @@ library
     , data-default
     , fast-logger
     , filepath
+    , http-types
     , lens
     , mtl
     , optparse-applicative


### PR DESCRIPTION
Tested by running `marconi-sidechain/examples/run-pre-prod-queries` with an invalid slot number in `getBurnTokenEvents`.

```
getBurnTokenEvents({
  "policyId": "00000000000000000000000000000000000000000000000000000000",
  "createdBeforeSlotNo": 1000000
}) =
curl: (22) The requested URL returned error: 500
{
  "error": {
    "code": -32603,
    "data": null,
    "message": "Internal error"
  },
  "id": null,
  "jsonrpc": "2.0"
}
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
