### PR TITLE
EpochState performances and queries

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -230,7 +230,7 @@ epochStateBuilder
       ( Core.WorkerIndexer
           IO
           (WithDistance BlockEvent)
-          (WithDistance (C.BlockInMode C.CardanoMode))
+          (WithDistance (EpochState.ExtLedgerState, C.BlockInMode C.CardanoMode))
           (Core.WithResume EpochState.EpochStateIndexer)
       )
 epochStateBuilder securityParam catchupConfig epochStateConfig logger path =

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -46,7 +46,7 @@ buildIndexers
   -> Core.CatchupConfig
   -> Utxo.UtxoIndexerConfig
   -> MintTokenEvent.MintTokenEventConfig
-  -> EpochState.EpochStateConfig
+  -> EpochState.EpochStateWorkerConfig
   -> BM.Trace IO Text
   -> FilePath
   -> ExceptT
@@ -223,14 +223,14 @@ epochStateBuilder
   :: (MonadIO n, MonadError Core.IndexerError n)
   => SecurityParam
   -> Core.CatchupConfig
-  -> EpochState.EpochStateConfig
+  -> EpochState.EpochStateWorkerConfig
   -> BM.Trace IO (Core.IndexerEvent C.ChainPoint)
   -> FilePath
   -> n
       ( Core.WorkerIndexer
           IO
           (WithDistance BlockEvent)
-          (WithDistance (EpochState.ExtLedgerState, C.BlockInMode C.CardanoMode))
+          (WithDistance (Maybe EpochState.ExtLedgerState, C.BlockInMode C.CardanoMode))
           (Core.WithResume EpochState.EpochStateIndexer)
       )
 epochStateBuilder securityParam catchupConfig epochStateConfig logger path =

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Coordinator.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Coordinator.hs
@@ -30,4 +30,4 @@ coordinatorWorker
   -> m (Core.WorkerIndexer IO (WithDistance a) b (Core.WithTrace IO Core.Coordinator))
 coordinatorWorker name logger extract workers = liftIO $ do
   coordinator <- standardCoordinator logger workers
-  Core.createWorker name extract coordinator
+  Core.createWorker name (Core.traverseMaybeEvent extract) coordinator

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Coordinator.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Coordinator.hs
@@ -8,7 +8,7 @@ module Marconi.ChainIndex.Experimental.Indexers.Coordinator (
 ) where
 
 import Cardano.BM.Tracing (Trace)
-import Control.Monad.Cont (MonadIO (liftIO))
+import Control.Monad.Cont (MonadIO (liftIO), MonadTrans (lift))
 import Data.Text (Text)
 import Marconi.ChainIndex.Experimental.Extract.WithDistance (WithDistance)
 import Marconi.ChainIndex.Experimental.Indexers.Orphans qualified ()
@@ -30,4 +30,4 @@ coordinatorWorker
   -> m (Core.WorkerIndexer IO (WithDistance a) b (Core.WithTrace IO Core.Coordinator))
 coordinatorWorker name logger extract workers = liftIO $ do
   coordinator <- standardCoordinator logger workers
-  Core.createWorker name (Core.traverseMaybeEvent extract) coordinator
+  Core.createWorker name (Core.traverseMaybeEvent $ lift . extract) coordinator

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Worker.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Worker.hs
@@ -112,7 +112,8 @@ mkStandardWorkerWithFilter
   -> indexer event
   -> n (StandardWorker m input event indexer)
 mkStandardWorkerWithFilter config eventFilter indexer = do
-  let mapEventUnderDistance = fmap sequence . traverse (eventExtractor config)
+  let mapEventUnderDistance =
+        Core.traverseMaybeEvent $ fmap sequence . traverse (eventExtractor config)
   transformedIndexer <- mkStandardIndexerWithFilter config eventFilter indexer
   Core.WorkerIndexer idx worker <-
     Core.createWorker (workerName config) mapEventUnderDistance transformedIndexer

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Worker.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Worker.hs
@@ -15,7 +15,7 @@ module Marconi.ChainIndex.Experimental.Indexers.Worker (
 import Cardano.Api qualified as C
 import Cardano.BM.Tracing (Trace)
 import Control.Concurrent (MVar)
-import Control.Monad.Cont (MonadIO)
+import Control.Monad.Cont (MonadIO, MonadTrans (lift))
 import Control.Monad.Except (ExceptT)
 import Data.Text (Text)
 import Data.Word (Word64)
@@ -113,7 +113,7 @@ mkStandardWorkerWithFilter
   -> n (StandardWorker m input event indexer)
 mkStandardWorkerWithFilter config eventFilter indexer = do
   let mapEventUnderDistance =
-        Core.traverseMaybeEvent $ fmap sequence . traverse (eventExtractor config)
+        Core.traverseMaybeEvent $ fmap sequence . traverse (lift . eventExtractor config)
   transformedIndexer <- mkStandardIndexerWithFilter config eventFilter indexer
   Core.WorkerIndexer idx worker <-
     Core.createWorker (workerName config) mapEventUnderDistance transformedIndexer

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
@@ -29,6 +29,7 @@ run appName = do
   o <- Cli.parseOptions
   let batchSize = 5000
       stopCatchupDistance = 100
+      volatileEpochStateSnapshotInterval = 100
       filteredAddresses = []
       filteredAssetIds = []
       includeScript = True
@@ -52,7 +53,10 @@ run appName = do
         (Core.CatchupConfig batchSize stopCatchupDistance)
         (Utxo.UtxoIndexerConfig filteredAddresses includeScript)
         (MintTokenEvent.MintTokenEventConfig filteredAssetIds)
-        (EpochState.EpochStateConfig nodeConfigPath 500)
+        ( EpochState.EpochStateWorkerConfig
+            (EpochState.NodeConfig nodeConfigPath)
+            volatileEpochStateSnapshotInterval
+        )
         trace
         (Cli.optionsDbPath o)
   (indexerLastSyncPoints, _utxoQueryIndexer, indexers) <-

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Runner.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Runner.hs
@@ -92,7 +92,7 @@ runIndexer trace securityParam retryConfig socketPath networkId startingPoints i
 
 -- | Event preprocessing, to ease the coordinator work
 mkEventStream
-  :: STM.TBQueue (Core.ProcessedInput (WithDistance BlockEvent))
+  :: STM.TBQueue (Core.ProcessedInput C.ChainPoint (WithDistance BlockEvent))
   -> S.Stream (S.Of (ChainSyncEvent BlockEvent)) IO r
   -> IO r
 mkEventStream q =
@@ -106,7 +106,7 @@ mkEventStream q =
 
       processEvent
         :: ChainSyncEvent BlockEvent
-        -> Core.ProcessedInput (WithDistance BlockEvent)
+        -> Core.ProcessedInput C.ChainPoint (WithDistance BlockEvent)
       processEvent (RollForward x ct) = Core.Index $ Just <$> blockTimed x ct
       processEvent (RollBackward x _) = Core.Rollback x
    in S.mapM_ $ STM.atomically . STM.writeTBQueue q . processEvent

--- a/marconi-chain-index/src/Marconi/ChainIndex/Utils.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Utils.hs
@@ -115,7 +115,7 @@ querySecurityParamEra shelleyBasedEra networkId socketPath = do
     Left err -> toError err
     Right (Left err) -> toError err
     Right (Right x) -> pure x
-  return $ fromIntegral $ C.protocolParamSecurity genesisParameters
+  pure $ fromIntegral $ C.protocolParamSecurity genesisParameters
   where
     localNodeConnectInfo :: C.LocalNodeConnectInfo C.CardanoMode
     localNodeConnectInfo = C.mkLocalNodeConnectInfo networkId socketPath

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -78,6 +78,7 @@ library
     Marconi.Core.Experiment.Transformer.WithTransform
     Marconi.Core.Experiment.Type
     Marconi.Core.Experiment.Worker
+    Marconi.Core.Experiment.Worker.Transformer
     Marconi.Core.Storable
     Marconi.Core.TracedStorable
 
@@ -101,6 +102,7 @@ library
     , containers
     , directory
     , filepath
+    , foldl
     , lens
     , mtl
     , primitive

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -361,6 +361,11 @@ module Marconi.Core.Experiment (
   ProcessedInput (..),
 
   -- ***  Workers transformers
+
+  -- | Transformers are used to alter the incoming the events sent to an indexer
+  -- through a worker.
+  --
+  -- It allows to transform the content of a block or to silence some events.
   Transformer,
   mapEvent,
   mapMaybeEvent,

--- a/marconi-core/src/Marconi/Core/Experiment.hs
+++ b/marconi-core/src/Marconi/Core/Experiment.hs
@@ -360,6 +360,18 @@ module Marconi.Core.Experiment (
   createWorkerPure,
   ProcessedInput (..),
 
+  -- ***  Workers transformers
+  Transformer,
+  mapEvent,
+  mapMaybeEvent,
+  traverseEvent,
+  traverseMaybeEvent,
+  scanEvent,
+  scanEventM,
+  scanMaybeEventM,
+  transformer,
+  transformerM,
+
   -- ** Coordinator
   Coordinator,
   workers,
@@ -410,6 +422,7 @@ module Marconi.Core.Experiment (
   PointCompare (..),
   WithResume,
   withResume,
+  resumedIndexer,
 
   -- ** Delay
   WithDelay,
@@ -619,6 +632,7 @@ import Marconi.Core.Experiment.Transformer.WithResume (
   OrdPoint (comparePoint),
   PointCompare (..),
   WithResume,
+  resumedIndexer,
   withResume,
  )
 import Marconi.Core.Experiment.Transformer.WithTracer (
@@ -642,6 +656,7 @@ import Marconi.Core.Experiment.Transformer.WithTransform (
 import Marconi.Core.Experiment.Type (
   IndexerError (..),
   Point,
+  ProcessedInput (..),
   QueryError (..),
   Result,
   Timed (..),
@@ -649,7 +664,6 @@ import Marconi.Core.Experiment.Type (
   point,
  )
 import Marconi.Core.Experiment.Worker (
-  ProcessedInput (..),
   Worker,
   WorkerIndexer (..),
   WorkerIndexerType,
@@ -658,6 +672,18 @@ import Marconi.Core.Experiment.Worker (
   createWorker',
   createWorkerPure,
   startWorker,
+ )
+import Marconi.Core.Experiment.Worker.Transformer (
+  Transformer,
+  mapEvent,
+  mapMaybeEvent,
+  scanEvent,
+  scanEventM,
+  scanMaybeEventM,
+  transformer,
+  transformerM,
+  traverseEvent,
+  traverseMaybeEvent,
  )
 
 {- | Try to rollback to a given point to resume the indexer.

--- a/marconi-core/src/Marconi/Core/Experiment/Transformer/WithResume.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Transformer/WithResume.hs
@@ -17,6 +17,7 @@
 module Marconi.Core.Experiment.Transformer.WithResume (
   WithResume,
   withResume,
+  resumedIndexer,
   OrdPoint (comparePoint),
   PointCompare (..),
 ) where
@@ -95,8 +96,8 @@ deriving via
   instance
     (Class.Queryable m event query indexer) => Class.Queryable m event query (WithResume indexer)
 
-resumeIndexer :: Lens.Lens' (WithResume indexer event) (indexer event)
-resumeIndexer = resumeWrapper . Wrapper.wrappedIndexer
+resumedIndexer :: Lens.Lens' (WithResume indexer event) (indexer event)
+resumedIndexer = resumeWrapper . Wrapper.wrappedIndexer
 
 resumeState :: Lens.Lens' (WithResume indexer event) (ResumeState event)
 resumeState = resumeWrapper . Wrapper.wrapperConfig
@@ -111,7 +112,7 @@ hasStarted :: Lens.Lens' (WithResume indexer event) Bool
 hasStarted = resumeState . stateHasStarted
 
 instance IndexerTrans WithResume where
-  unwrap = resumeIndexer
+  unwrap = resumedIndexer
 
 -- | A comparison for points, quite similar to 'Ordering' but add a way to identify forks
 data PointCompare

--- a/marconi-core/src/Marconi/Core/Experiment/Type.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Type.hs
@@ -10,6 +10,7 @@
 module Marconi.Core.Experiment.Type (
   -- * Types and type families
   Point,
+  ProcessedInput (..),
   Result,
   Timed (Timed),
   point,
@@ -23,6 +24,7 @@ module Marconi.Core.Experiment.Type (
 import Control.Exception (Exception)
 import Control.Lens (Lens, Lens')
 import Data.Data (Typeable)
+import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -56,6 +58,27 @@ deriving stock instance Functor (Timed point)
 deriving stock instance Foldable (Timed point)
 deriving stock instance Traversable (Timed point)
 deriving stock instance Generic (Timed point event)
+
+{- | The different types of input event that should be handled by an indexer
+used to map the chain incoming events to something that an indexer should be able to digest.
+-}
+data ProcessedInput point event
+  = -- | A rollback happen and indexers need to go back to the given point in time
+    Rollback point
+  | -- | A new event has to be indexed
+    Index (Timed point (Maybe event))
+  | -- | A new event has to be indexed
+    IndexAllDescending (NonEmpty (Timed point (Maybe event)))
+  | -- | Processing stops
+    Stop
+
+deriving stock instance (Show event, Show point) => Show (ProcessedInput point event)
+deriving stock instance (Eq event, Eq point) => Eq (ProcessedInput point event)
+deriving stock instance (Ord event, Ord point) => Ord (ProcessedInput point event)
+deriving stock instance Functor (ProcessedInput point)
+deriving stock instance Foldable (ProcessedInput point)
+deriving stock instance Traversable (ProcessedInput point)
+deriving stock instance Generic (ProcessedInput point event)
 
 -- | When was this event created
 point :: Lens' (Timed point event) point

--- a/marconi-core/src/Marconi/Core/Experiment/Worker.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Worker.hs
@@ -13,7 +13,6 @@ module Marconi.Core.Experiment.Worker (
   WorkerIndexerType,
   WorkerM (..),
   Worker,
-  ProcessedInput (..),
   createWorker,
   createWorkerPure,
   createWorker',
@@ -25,24 +24,25 @@ import Control.Concurrent qualified as Con
 import Control.Concurrent.STM (TChan)
 import Control.Concurrent.STM qualified as STM
 import Control.Exception (SomeException (SomeException), catch, finally)
-import Control.Lens.Operators ((^.))
 import Control.Monad (void)
 import Control.Monad.Except (ExceptT, runExceptT)
-import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Monad.Trans (MonadTrans (lift))
+import Control.Monad.State.Strict (
+  MonadIO (liftIO),
+  MonadTrans (lift),
+ )
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Marconi.Core.Experiment.Class (
   Closeable (close),
-  IsIndex (index, rollback),
-  IsSync (lastSyncPoint),
+  IsIndex (index, indexAllDescending, rollback),
+  IsSync,
  )
 import Marconi.Core.Experiment.Type (
   IndexerError (OtherIndexError, StopIndexer),
   Point,
-  Timed,
-  point,
+  ProcessedInput (Index, IndexAllDescending, Rollback, Stop),
  )
+import Marconi.Core.Experiment.Worker.Transformer (Transformer, runTransformer)
 
 -- | Worker which also provides direct access to the indexer hidden inside it.
 data WorkerIndexer m input event indexer = WorkerIndexer
@@ -69,7 +69,7 @@ data WorkerM m input point = forall indexer event n.
   -- ^ use to identify the worker in logs
   , workerState :: MVar (indexer event)
   -- ^ the indexer controlled by this worker
-  , transformInput :: input -> m (Maybe event)
+  , transformInput :: Transformer m point input event
   -- ^ adapt the input event givent by the coordinator to the worker type
   , hoistError :: forall a. n a -> ExceptT IndexerError m a
   -- ^ adapt the monadic stack of the indexer to the one of the worker
@@ -78,15 +78,6 @@ data WorkerM m input point = forall indexer event n.
 -- | A worker that operates in @IO@.
 type Worker = WorkerM IO
 
--- | The different types of input of a worker
-data ProcessedInput event
-  = -- | A rollback happen and indexers need to go back to the given point in time
-    Rollback (Point event)
-  | -- | A new event has to be indexed
-    Index (Timed (Point event) (Maybe event))
-  | -- | Processing stops
-    Stop
-
 -- Create workers
 
 -- | create a worker for an indexer, retuning the worker and the @MVar@ it's using internally
@@ -94,18 +85,18 @@ createWorker'
   :: (MonadIO f, WorkerIndexerType n event indexer)
   => (forall a. n a -> ExceptT IndexerError m a)
   -> Text
-  -> (input -> m (Maybe event))
+  -> Transformer m (Point event) input event
   -> indexer event
   -> f (WorkerIndexer m input event indexer)
-createWorker' hoist name getEvent ix = liftIO $ do
+createWorker' hoist name f ix = liftIO $ do
   workerState <- Con.newMVar ix
-  pure $ WorkerIndexer workerState $ Worker name workerState getEvent hoist
+  pure $ WorkerIndexer workerState $ Worker name workerState f hoist
 
 -- | create a worker for an indexer that doesn't throw error
 createWorkerPure
   :: (MonadIO f, MonadIO m, WorkerIndexerType m event indexer)
   => Text
-  -> (input -> m (Maybe event))
+  -> Transformer m (Point event) input event
   -> indexer event
   -> f (WorkerIndexer m input event indexer)
 createWorkerPure = createWorker' lift
@@ -114,22 +105,10 @@ createWorkerPure = createWorker' lift
 createWorker
   :: (MonadIO f, WorkerIndexerType (ExceptT IndexerError m) event indexer)
   => Text
-  -> (input -> m (Maybe event))
+  -> Transformer m (Point event) input event
   -> indexer event
   -> f (WorkerIndexer m input event indexer)
 createWorker = createWorker' id
-
-mapIndex
-  :: (Applicative f, Point event ~ Point event')
-  => (event -> f (Maybe event'))
-  -> ProcessedInput event
-  -> f (ProcessedInput event')
-mapIndex _ (Rollback p) = pure $ Rollback p
-mapIndex f (Index timedEvent) =
-  let mapEvent Nothing = pure Nothing
-      mapEvent (Just e) = f e
-   in Index <$> traverse mapEvent timedEvent
-mapIndex _ Stop = pure Stop
 
 {- | The worker notify its coordinator that it's ready
  and starts waiting for new events and process them as they come
@@ -138,7 +117,7 @@ startWorker
   :: forall input m
    . (MonadIO m)
   => (Ord (Point input))
-  => TChan (ProcessedInput input)
+  => TChan (ProcessedInput (Point input) input)
   -> MVar IndexerError
   -> QSemN
   -> QSemN
@@ -151,16 +130,16 @@ startWorker chan errorBox endTokens tokens (Worker name ix transformInput hoistE
       notifyEndToCoordinator :: IO ()
       notifyEndToCoordinator = Con.signalQSemN endTokens 1
 
-      fresherThan :: (Ord (Point event)) => Timed (Point event) (Maybe event) -> Point event -> Bool
-      fresherThan evt p = evt ^. point > p
-
       indexEvent timedEvent = do
         Con.modifyMVar ix $ \indexer -> do
-          result <- runExceptT $ do
-            indexerLastPoint <- hoistError $ lastSyncPoint indexer
-            if timedEvent `fresherThan` indexerLastPoint
-              then hoistError $ index timedEvent indexer
-              else pure indexer
+          result <- runExceptT $ hoistError $ index timedEvent indexer
+          case result of
+            Left err -> pure (indexer, Just err)
+            Right res -> pure (res, Nothing)
+
+      indexAllEventsDescending timedEvents = do
+        Con.modifyMVar ix $ \indexer -> do
+          result <- runExceptT $ hoistError $ indexAllDescending timedEvents indexer
           case result of
             Left err -> pure (indexer, Just err)
             Right res -> pure (res, Nothing)
@@ -193,31 +172,35 @@ startWorker chan errorBox endTokens tokens (Worker name ix transformInput hoistE
       process = \case
         Rollback p -> handleRollback p
         Index e -> indexEvent e
+        IndexAllDescending es -> indexAllEventsDescending es
         Stop -> pure $ Just $ OtherIndexError "Stop"
 
-      safeProcessEvent :: ProcessedInput input -> IO (Maybe IndexerError)
-      safeProcessEvent input = do
-        processedInput <- mapIndex transformInput input
-        process processedInput
-          `catch` \(SomeException e) -> pure $ Just $ StopIndexer (Just $ name <> " " <> Text.pack (show e))
+      onProcessError (SomeException e) =
+        pure $ Just $ StopIndexer (Just $ name <> " " <> Text.pack (show e))
 
-      loop :: TChan (ProcessedInput input) -> IO ()
+      safeProcessEvent f input = do
+        (processedInput, f') <- runTransformer f (Just input)
+        case processedInput of
+          Nothing -> pure (Nothing, f)
+          Just p -> (,f') <$> process p `catch` onProcessError
+
+      loop :: TChan (ProcessedInput (Point input) input) -> IO ()
       loop chan' =
-        let loop' = do
+        let loop' f = do
               err <- checkError
               case err of
                 Nothing -> do
                   event <- STM.atomically $ STM.readTChan chan'
-                  result <- safeProcessEvent event
+                  (result, f') <- safeProcessEvent f event
                   case result of
                     Nothing -> do
                       unlockCoordinator
-                      loop'
+                      loop' f'
                     Just err' -> do
                       notifyCoordinatorOnError err'
                       unlockCoordinator
                 Just _ -> unlockCoordinator
-         in loop'
+         in loop' transformInput
    in liftIO $ do
         chan' <- STM.atomically $ STM.dupTChan chan
         Con.forkFinally (loop chan') (const swallowPill)

--- a/marconi-core/src/Marconi/Core/Experiment/Worker/Transformer.hs
+++ b/marconi-core/src/Marconi/Core/Experiment/Worker/Transformer.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE LambdaCase #-}
+
+{- | 'Transformer's are used in a worker to transform the incoming events.
+
+   'Transformer's can carry an internal state, that can be updated on each incoming @ProcessingInput@.
+
+   'Transfromer's are composable using 'Control.Category' operators (@.@, @>>>@ and @<<<@)
+-}
+module Marconi.Core.Experiment.Worker.Transformer (
+  Transformer,
+  runTransformer,
+
+  -- * Stateless transformers
+  mapEvent,
+  mapMaybeEvent,
+  traverseEvent,
+  traverseMaybeEvent,
+
+  -- * Stateful transformers
+  scanEvent,
+  scanEventM,
+  scanMaybeEvent,
+  scanMaybeEventM,
+
+  -- * Generic builder
+  transformer,
+  transformerM,
+) where
+
+import Control.Arrow (Arrow (arr))
+import Control.Lens.Operators ((%~))
+import Control.Monad.State.Strict (StateT (runStateT), (<=<))
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
+import Control.Monad.Trans.State.Strict (State)
+import Control.Scanl (Scan (Scan), ScanM (ScanM), arrM, generalize)
+import Marconi.Core.Experiment.Type (
+  ProcessedInput (Index, IndexAllDescending, Rollback, Stop),
+  event,
+ )
+
+-- | Stateful tranformer.
+type Transformer m point a b =
+  ScanM m (Maybe (ProcessedInput point a)) (Maybe (ProcessedInput point b))
+
+-- | Apply a transformer to an element and retrieve the updated transformer
+runTransformer
+  :: (Monad m)
+  => Transformer m point a b
+  -> Maybe (ProcessedInput point a)
+  -> m (Maybe (ProcessedInput point b), Transformer m point a b)
+runTransformer (ScanM f mState) input = do
+  state <- mState
+  (res, state') <- f input `runStateT` state
+  pure (res, ScanM f (pure state'))
+
+-- | Lift a function on events to a transformer
+mapEvent :: (Monad m) => (a -> b) -> Transformer m point a b
+mapEvent = arr . fmap . fmap
+
+-- | Lift a function that may emit an event to a transformer.
+mapMaybeEvent :: (Monad m) => (a -> Maybe b) -> Transformer m point a b
+mapMaybeEvent f =
+  -- TODO later, we should remove empty events from it
+  let mapOneEvent = event %~ (>>= f)
+      go (Index x) = Just $ Index $ mapOneEvent x
+      go (IndexAllDescending xs) = Just . IndexAllDescending $ mapOneEvent <$> xs
+      go (Rollback p) = Just $ Rollback p
+      go Stop = Just Stop
+   in arr (go =<<)
+
+-- | Lift an effectful function on events to a transformer
+traverseEvent :: (Monad m) => (a -> m b) -> Transformer m point a b
+traverseEvent f = arrM (traverse $ traverse f)
+
+-- | Lift an effectful function that may emit an event to a transformer
+traverseMaybeEvent :: (Monad m) => (a -> m (Maybe b)) -> Transformer m point a b
+traverseMaybeEvent f =
+  -- TODO later, we should remove empty events from it
+  let mapOneEvent = event (runMaybeT . (MaybeT . f <=< MaybeT . pure))
+      go (Index x) = Just . Index <$> mapOneEvent x
+      go (IndexAllDescending xs) = Just . IndexAllDescending <$> traverse mapOneEvent xs
+      go (Rollback p) = pure . Just $ Rollback p
+      go Stop = pure $ Just Stop
+   in arrM $ \case
+        Nothing -> pure Nothing
+        Just e -> go e
+
+-- | Create a tranformer from a strict stateful computation
+scanEvent :: forall m s point a b. (Monad m) => (a -> State s b) -> s -> Transformer m point a b
+scanEvent f x =
+  let go :: Maybe (ProcessedInput point a) -> State s (Maybe (ProcessedInput point b))
+      go = traverse (traverse f)
+   in generalize $ Scan go x
+
+-- | Create a tranformer from a strict stateful computation
+scanMaybeEvent
+  :: forall m s point a b. (Monad m) => (a -> State s (Maybe b)) -> s -> Transformer m point a b
+scanMaybeEvent f =
+  let mapOneEvent = event (runMaybeT . (MaybeT . f <=< MaybeT . pure))
+      goEvent (Index x) = Just . Index <$> mapOneEvent x
+      goEvent (IndexAllDescending xs) = Just . IndexAllDescending <$> traverse mapOneEvent xs
+      goEvent (Rollback p) = pure . Just $ Rollback p
+      goEvent Stop = pure $ Just Stop
+      go :: Maybe (ProcessedInput point a) -> State s (Maybe (ProcessedInput point b))
+      go Nothing = pure Nothing
+      go (Just y) = goEvent y
+   in generalize . Scan go
+
+-- | Create a tranformer from a strict stateful computation
+scanEventM
+  :: forall m s point a b. (Monad m) => (a -> StateT s m b) -> m s -> Transformer m point a b
+scanEventM f x =
+  let go :: Maybe (ProcessedInput point a) -> StateT s m (Maybe (ProcessedInput point b))
+      go = traverse (traverse f)
+   in ScanM go x
+
+-- | Create a tranformer from a strict stateful computation
+scanMaybeEventM
+  :: forall m s point a b. (Monad m) => (a -> StateT s m (Maybe b)) -> m s -> Transformer m point a b
+scanMaybeEventM f =
+  let mapOneEvent = event (runMaybeT . (MaybeT . f <=< MaybeT . pure))
+      goEvent (Index x) = Just . Index <$> mapOneEvent x
+      goEvent (IndexAllDescending xs) = Just . IndexAllDescending <$> traverse mapOneEvent xs
+      goEvent (Rollback p) = pure . Just $ Rollback p
+      goEvent Stop = pure $ Just Stop
+      go :: Maybe (ProcessedInput point a) -> StateT s m (Maybe (ProcessedInput point b))
+      go Nothing = pure Nothing
+      go (Just y) = goEvent y
+   in ScanM go
+
+transformer
+  :: (Monad m)
+  => (ProcessedInput point a -> State s (Maybe (ProcessedInput point b)))
+  -> s
+  -> Transformer m point a b
+transformer f =
+  let go Nothing = pure Nothing
+      go (Just x) = f x
+   in generalize . Scan go
+
+transformerM
+  :: (Monad m)
+  => (ProcessedInput point a -> StateT s m (Maybe (ProcessedInput point b)))
+  -> m s
+  -> Transformer m point a b
+transformerM f =
+  let go Nothing = pure Nothing
+      go (Just x) = f x
+   in ScanM go


### PR DESCRIPTION
Introduce Worker transformers and apply them to the `EpochStateIndexer`.
Implements the missing endpoints for the epoch state indexer.

Pros:
- Huge speed improvement for the `EpochStateIndexer` (and potentially for others after migration of the current trasformers).

Con:
- The refactoring led to the removal of the `WithResume` layer for the `EpochStateIndexer`, making resuming unavailable for `marconi-chain-index-experimental` at the moment

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
