### PR TITLE
PLT-7739 Add missing parameters to mint burn indexer

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -543,6 +543,7 @@ convertEventsMatchingErrorToQueryByAssetIdError = \case
   Core.NotStoredAnymore -> Core.NotStoredAnymore
   (Core.IndexerQueryError t) -> Core.IndexerQueryError t
   (Core.AheadOfLastSync r) -> Core.AheadOfLastSync r
+  (Core.PointTooEarly r) -> Core.PointTooEarly r
 
 instance
   (MonadIO m, MonadError (Core.QueryError (QueryByAssetId MintTokenBlockEvents)) m)

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -531,16 +531,14 @@ instance
     -- order by slot number.
     either throwError pure $ filterBySlotNoBounds lowerTxId validUpperSlotNo sortedTimedEvents
 
--- TODO: reference comment about requirement for user-provided valid lower bound in docs.
-
 {- | Helper for ListIndexer query.
  Filter timed events to within the upper/lower slot bounds, returning 'Left' only if
  lowerTxId slot number is found and is not <= the upper bound. This function assumes the
  events are sorted in ascending order by ChainPoint SlotNo. It's purpose is to avoid a double
  pass in first finding the slot number associated with the lower bound.
 
- It assumes there is a matching transaction for lowerTxId and will not distinguish between cases
- where there are no such transactions and ones where no events are below the upper bound.
+ It requires there to be a matching transaction for 'lowerTxId' and will not distinguish between
+ cases where there are no such transactions and ones where no events are below the upper bound.
 -}
 filterBySlotNoBounds
   :: Maybe C.TxId
@@ -654,7 +652,11 @@ instance
       config
       ix
 
--- TODO: docstring and further cleanup
+{- | Helper for MintTokenEventIndexer in the case where a 'lowerTxId' is provided.
+Query to look up the earliest SlotNo matching a TxId. This is implemented as a separate query so
+as to be able to check that the 'lowerSlotNo' found is <= 'upperSlotNo'. If not, it will
+throw an error.
+-}
 queryLowerSlotNoByTxId
   :: (MonadIO m, MonadError (Core.QueryError (QueryByAssetId MintTokenBlockEvents)) m)
   => C.SlotNo

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -491,8 +491,9 @@ instance
                 NonEmpty.nonEmpty $
                   NonEmpty.filter (\e -> isAssetId e && isEventType e) events
 
-    -- TODO: need to augment the error type with new variant
-    unless (pointSufficient point) $ throwError undefined
+    unless (pointSufficient point) $
+      throwError $
+        Core.PointTooEarly ("Point " <> Text.pack (show point) <> " precedes query upper SlotNo")
 
     timedEventsE <- runExceptT $ Core.query point queryByAssetIdPredicate ix
     timedEvents <-

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -555,8 +555,8 @@ filterBySlotNoBounds txIdM validUpperSlotNo =
       -- This tx is the one setting the lower bound. Check for validity, then accumulate if <=
       -- the upper bound.
       | matchingTxIdFromTimedEvent txId e =
-          if getSlotNo e <= Just validUpperSlotNo
-            then Right (accumulateIfWithinUpper validUpperSlotNo es e, True)
+          if isBeforeUpperSlotNo validUpperSlotNo e
+            then Right (e : es, True)
             else
               Left $
                 Core.SlotNoBoundsInvalid "SlotNo associated with query lowerTxId not found within upperSlotNo bound"

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -556,6 +556,11 @@ instance
       -- before the query.
       validUpperSlotNo = upperSlotNoIfValid point (config ^. queryByAssetIdUpperSlotNo)
 
+    unless (isJust validUpperSlotNo) $
+      throwError $
+        Core.SlotNoBoundsInvalid ("Point " <> Text.pack (show point) <> " precedes query upperSlotNo")
+
+    let
       -- Query events with slotNo <= validUpperSlotNo and txId == lowerTxId.
       lowerTxIdQuery :: SQL.Query
       lowerTxIdQuery = mkMintTokenEventQueryBy (Just "txId == :lowerTxId")
@@ -579,10 +584,6 @@ instance
           ix
 
     lowerSlotNoM <- either throwError (pure . slotNoOfLowerTxIdQuery) lowerSlotNo
-
-    unless (isJust validUpperSlotNo) $
-      throwError $
-        Core.SlotNoBoundsInvalid ("Point " <> Text.pack (show point) <> " precedes query upperSlotNo")
 
     unless (isJust lowerSlotNoM) $
       throwError $

--- a/marconi-core/src/Marconi/Core/Type.hs
+++ b/marconi-core/src/Marconi/Core/Type.hs
@@ -122,6 +122,8 @@ data QueryError query
     NotStoredAnymore
   | -- | The indexer query failed
     IndexerQueryError Text
+  | -- | The requested point is too early to answer the query completely.
+    PointTooEarly Text
 
 deriving stock instance (Show (Result query)) => Show (QueryError query)
 deriving instance (Typeable query, Show (Result query)) => Exception (QueryError query)

--- a/marconi-core/src/Marconi/Core/Type.hs
+++ b/marconi-core/src/Marconi/Core/Type.hs
@@ -122,8 +122,9 @@ data QueryError query
     NotStoredAnymore
   | -- | The indexer query failed
     IndexerQueryError Text
-  | -- | The requested point is too early to answer the query completely.
-    PointTooEarly Text
+  | -- | Upper or lower SlotNo bounds provided in the query are not consistent. For example,
+    -- the requested point is too early to answer the query completely.
+    SlotNoBoundsInvalid Text
 
 deriving stock instance (Show (Result query)) => Show (QueryError query)
 deriving instance (Typeable query, Show (Result query)) => Exception (QueryError query)


### PR DESCRIPTION
* Add fields corresponding to `beforeSlotNo` and `afterTx` from the marconi-sidechain JSON RPC endpoint for burn token events to the `QueryByAssetId` type of `marconi-chain-index`.

* Modify the logic of both the list and SQLite indexer instances of `Queryable` for `MintTokenBlockEvents`, to consume the two new parameters and apply them to the query.

* Add a variant `SlotNoBoundsInvalid` to `QueryError` of `marconi-core`, which will be thrown from the updated query routines if either:
   * The lower-bound slot number associated with `afterTx` is greater than the upper bound `beforeSlotNo` (or the requested query point),
   * The upper-bound slot number `beforeSlotNo` is greater than the requested query point.

* Update the `QueryByAssetId` configuration type to be a record with lenses.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
