### PR TITLE
PLT-7932 Add tracking of the chain tip

### DIFF
--- a/marconi-chain-index/cardano-api-extended/src/Cardano/Api/Extended/Block.hs
+++ b/marconi-chain-index/cardano-api-extended/src/Cardano/Api/Extended/Block.hs
@@ -10,3 +10,7 @@ bimSlotNo (C.BlockInMode (C.Block (C.BlockHeader slotNo _ _) _) _) = slotNo
 
 bimBlockHeaderHash :: C.BlockInMode C.CardanoMode -> C.Hash C.BlockHeader
 bimBlockHeaderHash (C.BlockInMode (C.Block (C.BlockHeader _ bhh _) _) _) = bhh
+
+chainTipBlockNo :: C.ChainTip -> C.BlockNo
+chainTipBlockNo C.ChainTipAtGenesis = 0
+chainTipBlockNo (C.ChainTip _ _ bn) = bn

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -67,6 +67,7 @@ library
     Marconi.ChainIndex.Experimental.Extract.WithDistance
     Marconi.ChainIndex.Experimental.Indexers
     Marconi.ChainIndex.Experimental.Indexers.BlockInfo
+    Marconi.ChainIndex.Experimental.Indexers.ChainTip
     Marconi.ChainIndex.Experimental.Indexers.Coordinator
     Marconi.ChainIndex.Experimental.Indexers.Datum
     Marconi.ChainIndex.Experimental.Indexers.EpochState
@@ -366,6 +367,7 @@ test-suite marconi-chain-index-test
     Spec.Marconi.ChainIndex.Coordinator
     Spec.Marconi.ChainIndex.Experimental.Indexers
     Spec.Marconi.ChainIndex.Experimental.Indexers.BlockInfo
+    Spec.Marconi.ChainIndex.Experimental.Indexers.ChainTip
     Spec.Marconi.ChainIndex.Experimental.Indexers.Datum
     Spec.Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent
     Spec.Marconi.ChainIndex.Experimental.Indexers.Spent

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/ChainTip.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/ChainTip.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | An indexer that tracks the chainTip of the ledger, storing the tip in a file.
+module Marconi.ChainIndex.Experimental.Indexers.ChainTip (
+  ChainTipIndexer,
+  mkChainTipIndexer,
+  ChainTipConfig (ChainTipConfig),
+  chainTipWorker,
+) where
+
+import Cardano.Api.Extended qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.BM.Trace qualified as BM
+import Codec.CBOR.Decoding qualified as CBOR
+import Codec.CBOR.Encoding qualified as CBOR
+import Codec.CBOR.Read qualified as CBOR
+import Codec.CBOR.Write qualified as CBOR
+import Control.Monad.Cont (MonadIO)
+import Control.Monad.Except (MonadError)
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BS.Lazy
+import Data.ByteString.Short qualified as BS.Short
+import Data.Text (Text)
+import Marconi.ChainIndex.Experimental.Indexers.Orphans ()
+import Marconi.Core qualified as Core
+
+type instance Core.Point C.ChainTip = C.ChainPoint
+
+type ChainTipIndexer m = Core.WithTrace m Core.LastEventIndexer C.ChainTip
+
+data ChainTipConfig = ChainTipConfig
+  { path :: FilePath
+  -- ^ path to save the chain tip
+  , saveEvery :: Word
+  -- ^ how often (in blocks) we save the chain tip (an extra save would be performed on closing)
+  }
+
+-- | Configure and start the 'ChainTip' indexer
+mkChainTipIndexer
+  :: (MonadIO n, MonadError Core.IndexerError n, MonadIO m)
+  => BM.Trace m (Core.IndexerEvent C.ChainPoint)
+  -> ChainTipConfig
+  -> n (ChainTipIndexer m)
+mkChainTipIndexer tracer cfg = do
+  let lastEventConfig =
+        Core.LastEventConfig
+          (path cfg)
+          False
+          serialisePoint
+          deserialisePoint
+          serialiseTip
+          deserialiseTip
+          (saveEvery cfg)
+
+  indexer <- Core.mkLastEventIndexer lastEventConfig
+  pure $ Core.withTrace tracer indexer
+
+-- | Start a 'ChainTipIndexer' and put it in a worker
+chainTipWorker
+  :: (MonadIO n, MonadError Core.IndexerError n, MonadIO m)
+  => BM.Trace m (Core.IndexerEvent C.ChainPoint)
+  -> (event -> Maybe C.ChainTip)
+  -> ChainTipConfig
+  -> n
+      ( Core.WorkerIndexer
+          m
+          event
+          C.ChainTip
+          (Core.WithTrace m Core.LastEventIndexer)
+      )
+chainTipWorker tracer extractor cfg =
+  Core.createWorker "chainTip" extractor =<< mkChainTipIndexer tracer cfg
+
+serialiseTip :: C.ChainTip -> BS.ByteString
+serialiseTip =
+  let tipEncoding :: C.ChainTip -> CBOR.Encoding
+      tipEncoding C.ChainTipAtGenesis = CBOR.encodeBool False
+      tipEncoding (C.ChainTip (C.SlotNo slotNo) (C.HeaderHash hashBytes) (C.BlockNo blockNo)) =
+        CBOR.encodeBool True
+          <> CBOR.encodeWord64 slotNo
+          <> CBOR.encodeBytes (BS.Short.fromShort hashBytes)
+          <> CBOR.encodeWord64 blockNo
+   in CBOR.toStrictByteString . tipEncoding
+
+deserialiseTip :: BS.ByteString -> Either Text C.ChainTip
+deserialiseTip bs =
+  let tipDecoding = do
+        b <- CBOR.decodeBool
+        if b
+          then do
+            s <- C.SlotNo <$> CBOR.decodeWord64
+            bhh <- C.HeaderHash . BS.Short.toShort <$> CBOR.decodeBytes
+            bn <- C.BlockNo <$> CBOR.decodeWord64
+            pure $ C.ChainTip s bhh bn
+          else pure C.ChainTipAtGenesis
+   in case CBOR.deserialiseFromBytes tipDecoding . BS.fromStrict $ bs of
+        Right (remain, res) | BS.Lazy.null remain -> Right res
+        _other -> Left "Can't read chainpoint"
+
+serialisePoint :: C.ChainPoint -> BS.ByteString
+serialisePoint =
+  let pointEncoding :: C.ChainPoint -> CBOR.Encoding
+      pointEncoding C.ChainPointAtGenesis = CBOR.encodeBool False
+      pointEncoding (C.ChainPoint (C.SlotNo s) (C.HeaderHash bhh)) =
+        CBOR.encodeBool True <> CBOR.encodeWord64 s <> CBOR.encodeBytes (BS.Short.fromShort bhh)
+   in CBOR.toStrictByteString . pointEncoding
+
+deserialisePoint :: BS.ByteString -> Either Text C.ChainPoint
+deserialisePoint bs =
+  let pointDecoding = do
+        b <- CBOR.decodeBool
+        if b
+          then do
+            s <- C.SlotNo <$> CBOR.decodeWord64
+            bhh <- C.HeaderHash . BS.Short.toShort <$> CBOR.decodeBytes
+            pure $ C.ChainPoint s bhh
+          else pure C.ChainPointAtGenesis
+   in case CBOR.deserialiseFromBytes pointDecoding . BS.fromStrict $ bs of
+        Right (remain, res) | BS.Lazy.null remain -> Right res
+        _other -> Left "Can't read chainpoint"

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Coordinator.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/Coordinator.hs
@@ -10,7 +10,6 @@ module Marconi.ChainIndex.Experimental.Indexers.Coordinator (
 import Cardano.BM.Tracing (Trace)
 import Control.Monad.Cont (MonadIO (liftIO), MonadTrans (lift))
 import Data.Text (Text)
-import Marconi.ChainIndex.Experimental.Extract.WithDistance (WithDistance)
 import Marconi.ChainIndex.Experimental.Indexers.Orphans qualified ()
 import Marconi.Core qualified as Core
 
@@ -25,9 +24,9 @@ coordinatorWorker
   :: (MonadIO m, Ord (Core.Point b))
   => Text
   -> Trace IO (Core.IndexerEvent (Core.Point b))
-  -> (WithDistance a -> IO (Maybe b))
+  -> (a -> IO (Maybe b))
   -> [Core.Worker b (Core.Point b)]
-  -> m (Core.WorkerIndexer IO (WithDistance a) b (Core.WithTrace IO Core.Coordinator))
+  -> m (Core.WorkerIndexer IO a b (Core.WithTrace IO Core.Coordinator))
 coordinatorWorker name logger extract workers = liftIO $ do
   coordinator <- standardCoordinator logger workers
   Core.createWorkerWithPreprocessing name (Core.traverseMaybeEvent $ lift . extract) coordinator

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
@@ -19,7 +19,6 @@ import Marconi.ChainIndex.Experimental.Indexers.Utxo qualified as Utxo
 import Marconi.ChainIndex.Experimental.Logger (defaultStdOutLogger)
 import Marconi.ChainIndex.Experimental.Runner qualified as Runner
 import Marconi.ChainIndex.Node.Client.Retry (withNodeConnectRetry)
-import Marconi.ChainIndex.Types (RunIndexerConfig (RunIndexerConfig))
 import Marconi.ChainIndex.Utils qualified as Utils
 import Marconi.Core qualified as Core
 import System.Directory (createDirectoryIfMissing)
@@ -97,8 +96,9 @@ run appName = withGracefulTermination_ $ do
   let startingPoint = getStartingPoint preferredStartingPoint indexerLastStablePoint
 
   Runner.runIndexer
-    ( RunIndexerConfig
+    ( Runner.RunIndexerConfig
         trace
+        Runner.withDistanceAndTipPreprocessor
         retryConfig
         securityParam
         networkId

--- a/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Orphans.hs
@@ -48,6 +48,7 @@ instance ToRow C.ChainTip where
   toRow (C.ChainTip sn bh bno) = [toField sn, toField bh, toField bno]
 
 instance Ord C.ChainTip where
+  compare C.ChainTipAtGenesis C.ChainTipAtGenesis = EQ
   compare C.ChainTipAtGenesis _ = LT
   compare _ C.ChainTipAtGenesis = GT
   compare (C.ChainTip snX haX _bnX) (C.ChainTip snY haY _bnY) = compare (snX, haX) (snY, haY)

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers.hs
@@ -3,6 +3,7 @@ module Spec.Marconi.ChainIndex.Experimental.Indexers (tests) where
 import Test.Tasty (TestTree, localOption, testGroup)
 
 import Spec.Marconi.ChainIndex.Experimental.Indexers.BlockInfo qualified as BlockInfo
+import Spec.Marconi.ChainIndex.Experimental.Indexers.ChainTip qualified as ChainTip
 import Spec.Marconi.ChainIndex.Experimental.Indexers.Datum qualified as Datum
 import Spec.Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent qualified as MintTokenEvent
 import Spec.Marconi.ChainIndex.Experimental.Indexers.Spent qualified as Spent
@@ -19,6 +20,7 @@ tests =
       , Spent.tests
       , Datum.tests
       , BlockInfo.tests
+      , ChainTip.tests
       , UtxoQuery.tests
       , MintTokenEvent.tests
       ]

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/BlockInfo.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/BlockInfo.hs
@@ -99,7 +99,7 @@ getBlockInfoEvents =
         C.ChainPoint slotNo blockHeaderHash
 
       getBlockInfo :: C.BlockNo -> Gen.MockBlockWithInfo era -> BlockInfo.BlockInfo
-      getBlockInfo bno (Gen.MockBlockWithInfo _bh epochNo timestamp _txs) =
+      getBlockInfo bno (Gen.MockBlockWithInfo _bh epochNo timestamp _tip _txs) =
         let timestampAsWord = fst $ properFraction $ Time.nominalDiffTimeToSeconds timestamp
          in BlockInfo.BlockInfo bno timestampAsWord epochNo
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/ChainTip.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/ChainTip.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Spec.Marconi.ChainIndex.Experimental.Indexers.ChainTip (
+  tests,
+) where
+
+import Cardano.Api qualified as C
+import Cardano.BM.Data.Tracer qualified as BM
+import Control.Exception (throw)
+import Control.Lens qualified as Lens
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.Trans.Except (ExceptT, runExceptT)
+import Gen.Marconi.ChainIndex.Mockchain qualified as Gen
+import Hedgehog ((===))
+import Hedgehog qualified
+import Marconi.ChainIndex.Experimental.Indexers.ChainTip (ChainTipIndexer)
+import Marconi.ChainIndex.Experimental.Indexers.ChainTip qualified as ChainTip
+import Marconi.Core qualified as Core
+import System.IO.Temp qualified as Tmp
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hedgehog (testPropertyNamed)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Spec.Marconi.ChainIndex.Experimental.Indexers.ChainTip"
+    [ testGroup
+        "Indexer"
+        [ testPropertyNamed
+            "GetLast works with queryLatest"
+            "propGetLastLatest"
+            propGetLastAtLatest
+        ]
+    ]
+
+withIndexer
+  :: Gen.MockchainWithInfo C.BabbageEra
+  -> ( ChainTipIndexer IO -> ExceptT (Core.QueryError q) IO a
+     )
+  -> ExceptT (Core.QueryError q) IO a
+withIndexer events f = Tmp.withSystemTempDirectory "chainTipIndexer" $ \file -> do
+  let config = ChainTip.ChainTipConfig file 1
+  indexerE <- runExceptT $ ChainTip.mkChainTipIndexer BM.nullTracer config
+  indexer <- case indexerE of
+    Left err -> throw err
+    Right res -> pure res
+  indexer' <- liftIO $ indexMockchain events indexer
+  f indexer'
+
+indexMockchain
+  :: Gen.MockchainWithInfo C.BabbageEra
+  -> ChainTipIndexer IO
+  -> IO (ChainTipIndexer IO)
+indexMockchain events =
+  fmap (either (error . show) id) . Core.indexAllEither (getTimedChainTipEvents events)
+
+propGetLastAtLatest :: Hedgehog.Property
+propGetLastAtLatest = Hedgehog.property $ do
+  events <- Hedgehog.forAll Gen.genMockchainWithInfo
+  (Right res) :: Either (Core.QueryError (Core.GetLastQuery C.ChainTip)) (Maybe C.ChainTip) <-
+    liftIO $ runExceptT $ withIndexer events $ Core.queryLatest Core.GetLastQuery
+  Lens.view Core.event (last $ getTimedChainTipEvents events) === res
+
+getTimedChainTipEvents
+  :: Gen.MockchainWithInfo era
+  -> [Core.Timed C.ChainPoint (Maybe C.ChainTip)]
+getTimedChainTipEvents =
+  let getBlockTimedChainTip block =
+        Core.Timed
+          (C.chainTipToChainPoint $ Gen.mockBlockInfoChainTip block)
+          (Just $ Gen.mockBlockInfoChainTip block)
+   in fmap getBlockTimedChainTip

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -60,6 +60,7 @@ library
     Marconi.Core.Class
     Marconi.Core.Coordinator
     Marconi.Core.Indexer.FileIndexer
+    Marconi.Core.Indexer.LastEventIndexer
     Marconi.Core.Indexer.LastPointIndexer
     Marconi.Core.Indexer.ListIndexer
     Marconi.Core.Indexer.MixedIndexer

--- a/marconi-core/src/Marconi/Core.hs
+++ b/marconi-core/src/Marconi/Core.hs
@@ -300,6 +300,10 @@ module Marconi.Core (
   EventBuilder (EventBuilder),
   EventInfo (fileMetadata),
   mkFileIndexer,
+  LastEventIndexer (LastEventIndexer),
+  mkLastEventIndexer,
+  LastEventConfig (LastEventConfig),
+  GetLastQuery (GetLastQuery),
 
   -- ** Mixed indexer
 
@@ -547,6 +551,12 @@ import Marconi.Core.Indexer.FileIndexer (
   FileIndexer (FileIndexer),
   FileStorageConfig (FileStorageConfig),
   mkFileIndexer,
+ )
+import Marconi.Core.Indexer.LastEventIndexer (
+  GetLastQuery (GetLastQuery),
+  LastEventConfig (LastEventConfig),
+  LastEventIndexer (LastEventIndexer),
+  mkLastEventIndexer,
  )
 import Marconi.Core.Indexer.LastPointIndexer (LastPointIndexer, lastPointIndexer)
 import Marconi.Core.Indexer.ListIndexer (ListIndexer, events, latestPoint, mkListIndexer)

--- a/marconi-core/src/Marconi/Core/Indexer/FileIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Indexer/FileIndexer.hs
@@ -342,10 +342,10 @@ instance (MonadIO m, MonadError IndexerError m) => IsIndex m event (FileIndexer 
   setLastStablePoint p indexer = do
     let currentStable = indexer ^. fileIndexerLastStablePoint
     if p > currentStable
-    then do
-      indexer' <- writeStable p indexer
-      pure $ indexer' & fileIndexerLastStablePoint .~ p
-    else pure indexer
+      then do
+        indexer' <- writeStable p indexer
+        pure $ indexer' & fileIndexerLastStablePoint .~ p
+      else pure indexer
 
 lastStableFilename :: FileIndexer meta event -> FilePath
 lastStableFilename indexer =

--- a/marconi-core/src/Marconi/Core/Indexer/LastEventIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Indexer/LastEventIndexer.hs
@@ -1,0 +1,263 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{- |
+   An indexer that tracks the last event received from the source.
+
+   On rollback we can either decide to remove the last event or to keep the last one we received.
+-}
+module Marconi.Core.Indexer.LastEventIndexer (
+  LastEventIndexer (LastEventIndexer),
+  mkLastEventIndexer,
+  LastEventConfig (LastEventConfig),
+  GetLastQuery (GetLastQuery),
+) where
+
+import Control.Lens (Lens', (&), (.~), (^.))
+import Control.Lens qualified as Lens
+import Control.Monad (void, when)
+import Control.Monad.Cont (MonadIO (liftIO))
+import Control.Monad.Except (MonadError (throwError))
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Foldable (toList)
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Marconi.Core.Class (
+  Closeable,
+  HasGenesis (genesis),
+  IsIndex (index, indexAll, indexAllDescending, rollback, setLastStablePoint),
+  IsSync (lastStablePoint, lastSyncPoint),
+  Queryable (query),
+  close,
+ )
+import Marconi.Core.Type (
+  IndexerError (IndexerInternalError),
+  Point,
+  QueryError (IndexerQueryError),
+  Result,
+  event,
+  point,
+ )
+import System.Directory (createDirectoryIfMissing, doesFileExist)
+import System.FilePath ((</>))
+
+data LastEventConfig event = LastEventConfig
+  { _configDirectory :: FilePath
+  -- ^ The directories where we save content
+  , _configCleanOnRollback :: Bool
+  -- ^ Do we remove the stored event on rollback
+  , _configSerialisePoint :: Point event -> ByteString
+  -- ^ The serialisation function for points
+  , _configDeserialisePoint :: ByteString -> Either Text (Point event)
+  -- ^ The deserialisation function for points
+  , _configSerialiseEvent :: event -> ByteString
+  -- ^ The serialisation function for events
+  , _configDeserialiseEvent :: ByteString -> Either Text event
+  -- ^ The deserialisation function for events
+  , _configSaveEvery :: Word
+  -- ^ How often do we save last event
+  }
+
+Lens.makeLenses ''LastEventConfig
+
+-- The stateful part of the LastEventIndexer
+data LastEventState event = LastEventState
+  { _stateLastEvent :: Maybe event
+  -- ^ Store the last event
+  , _stateLastSync :: Point event
+  -- ^ Store the last sync point
+  , _stateLastStablePoint :: Point event
+  -- ^ Store the last stable point
+  , _stateTimeToNextSave :: Word
+  -- ^ Time before next snapshot
+  }
+
+Lens.makeLenses ''LastEventState
+
+{- | An indexer that only track the latest value of an event
+On rollback, we either delete the value or keep the one provided before the rollback,
+depending on the provided configuration.
+-}
+data LastEventIndexer event = LastEventIndexer
+  { _config :: LastEventConfig event
+  , _state :: LastEventState event
+  }
+
+Lens.makeLenses ''LastEventIndexer
+
+saveDirectory :: Lens' (LastEventIndexer event) FilePath
+saveDirectory = config . configDirectory
+
+deserialisePoint :: Lens' (LastEventIndexer event) (ByteString -> Either Text (Point event))
+deserialisePoint = config . configDeserialisePoint
+
+serialisePoint :: Lens' (LastEventIndexer event) (Point event -> ByteString)
+serialisePoint = config . configSerialisePoint
+
+deserialiseEvent :: Lens' (LastEventIndexer event) (ByteString -> Either Text event)
+deserialiseEvent = config . configDeserialiseEvent
+
+serialiseEvent :: Lens' (LastEventIndexer event) (event -> ByteString)
+serialiseEvent = config . configSerialiseEvent
+
+cleanOnRollback :: Lens' (LastEventIndexer event) Bool
+cleanOnRollback = config . configCleanOnRollback
+
+lastEvent :: Lens' (LastEventIndexer event) (Maybe event)
+lastEvent = state . stateLastEvent
+
+lastSync :: Lens' (LastEventIndexer event) (Point event)
+lastSync = state . stateLastSync
+
+indexerLastStablePoint :: Lens' (LastEventIndexer event) (Point event)
+indexerLastStablePoint = state . stateLastStablePoint
+
+saveEvery :: Lens' (LastEventIndexer event) Word
+saveEvery = config . configSaveEvery
+
+timeToNextSave :: Lens' (LastEventIndexer event) Word
+timeToNextSave = state . stateTimeToNextSave
+
+-- Advance the indexer towards the next snapshot.
+-- If it times, reset the timer and returns true, along with the modified indexer.
+tickSave :: LastEventIndexer event -> (Bool, LastEventIndexer event)
+tickSave indexer = do
+  let timeToNextSave' = indexer ^. timeToNextSave . Lens.to pred
+  if timeToNextSave' == 0
+    then (True, indexer & timeToNextSave .~ indexer ^. saveEvery)
+    else (False, indexer & timeToNextSave .~ timeToNextSave')
+
+instance (MonadIO m, MonadError IndexerError m) => IsIndex m a LastEventIndexer where
+  index timedEvent indexer = do
+    let (saveTime, indexer') =
+          tickSave $
+            indexer
+              & lastSync .~ (timedEvent ^. point)
+              & lastEvent .~ (timedEvent ^. event)
+    when saveTime (savePoint indexer')
+    pure indexer'
+
+  indexAll = indexAllDescending . reverse . toList
+
+  indexAllDescending xs = case toList xs of
+    [] -> pure
+    x : _ -> index x
+
+  rollback p indexer =
+    pure $
+      if indexer ^. cleanOnRollback
+        then indexer & lastSync .~ p & lastEvent .~ Nothing
+        else indexer & lastSync .~ p
+
+  setLastStablePoint p indexer = do
+    let currentStable = indexer ^. indexerLastStablePoint
+     in if p > currentStable
+          then do
+            void $ writeStable p indexer
+            pure $ indexer & indexerLastStablePoint .~ p
+          else do
+            pure indexer
+
+instance (Applicative m) => IsSync m event LastEventIndexer where
+  lastSyncPoint = pure . Lens.view lastSync
+  lastStablePoint = pure . Lens.view indexerLastStablePoint
+
+instance (MonadIO m) => Closeable m LastEventIndexer where
+  -- On close, we perform a last save of the stored values
+  close = savePoint
+
+mkLastEventIndexer
+  :: (HasGenesis (Point event), MonadIO m, MonadError IndexerError m)
+  => LastEventConfig event
+  -> m (LastEventIndexer event)
+mkLastEventIndexer cfg = do
+  liftIO $ createDirectoryIfMissing True (cfg ^. configDirectory)
+  let initialState = LastEventState Nothing genesis genesis (cfg ^. configSaveEvery)
+      indexer = LastEventIndexer cfg initialState
+  lastStablePoint' <- fromMaybe genesis <$> readCurrentStable indexer
+  pure $
+    indexer
+      & indexerLastStablePoint .~ lastStablePoint'
+      & lastSync .~ lastStablePoint'
+
+-- | Datatype used to query the stored value of a 'LastEventIndexer'
+data GetLastQuery a = GetLastQuery
+
+type instance Result (GetLastQuery a) = Maybe a
+
+instance
+  (MonadIO m, MonadError (QueryError (GetLastQuery event)) m)
+  => Queryable m event (GetLastQuery event) LastEventIndexer
+  where
+  query _point _query indexer = do
+    let lastEventFile = eventFilename indexer
+    hasEvent <- liftIO $ doesFileExist lastEventFile
+    if hasEvent
+      then do
+        content <- liftIO $ BS.readFile lastEventFile
+        let result = indexer ^. deserialiseEvent $ content
+        case result of
+          Left err -> throwError $ IndexerQueryError err
+          Right res -> pure $ Just res
+      else pure Nothing
+
+savePoint :: (MonadIO m) => LastEventIndexer a -> m ()
+savePoint indexer = do
+  void $ writeStable (indexer ^. indexerLastStablePoint) indexer
+  maybe (pure ()) (flip writeEvent indexer) (indexer ^. lastEvent)
+
+lastStableFilename :: LastEventIndexer event -> FilePath
+lastStableFilename indexer =
+  let
+    dir = indexer ^. saveDirectory
+    filename = "latestStable.cbor"
+   in
+    dir </> Text.unpack filename
+
+readCurrentStable
+  :: (MonadIO m, MonadError IndexerError m)
+  => LastEventIndexer event
+  -> m (Maybe (Point event))
+readCurrentStable indexer = do
+  let f = lastStableFilename indexer
+      deserialise = indexer ^. deserialisePoint
+  fileExists <- liftIO $ doesFileExist f
+  if fileExists
+    then do
+      res <- deserialise <$> liftIO (BS.readFile f)
+      case res of
+        Left _ -> throwError $ IndexerInternalError "Can't read current stable"
+        Right r -> pure $ Just r
+    else pure Nothing
+
+writeStable
+  :: (MonadIO m)
+  => Point event
+  -> LastEventIndexer event
+  -> m ()
+writeStable p indexer = do
+  let f = lastStableFilename indexer
+      serialise = indexer ^. serialisePoint
+  liftIO $ BS.writeFile f $ serialise p
+
+eventFilename :: LastEventIndexer event -> FilePath
+eventFilename indexer =
+  let
+    dir = indexer ^. saveDirectory
+    filename = "event.cbor"
+   in
+    dir </> filename
+
+writeEvent
+  :: (MonadIO m)
+  => event
+  -> LastEventIndexer event
+  -> m ()
+writeEvent p indexer = do
+  let f = eventFilename indexer
+      serialise = indexer ^. serialiseEvent
+  liftIO $ BS.writeFile f $ serialise p

--- a/marconi-core/src/Marconi/Core/Query.hs
+++ b/marconi-core/src/Marconi/Core/Query.hs
@@ -77,9 +77,8 @@ instance
     case resultContent of
       Nothing -> pure Nothing
       Just eventFile -> do
-        let resultFile = FileIndexer.path eventFile
-            deserialise = ix ^. eventBuilder . deserialiseEvent $ FileIndexer.fileMetadata eventFile
-        result <- liftIO $ BS.readFile resultFile
+        let deserialise = ix ^. eventBuilder . deserialiseEvent $ FileIndexer.fileMetadata eventFile
+        result <- liftIO $ BS.readFile (FileIndexer.fullPath ix eventFile)
         case deserialise result of
           Left err -> throwError $ IndexerQueryError err
           Right res -> pure res

--- a/marconi-tutorial/src/Marconi/Tutorial/Indexers.hs
+++ b/marconi-tutorial/src/Marconi/Tutorial/Indexers.hs
@@ -10,8 +10,12 @@ import Control.Monad.Reader (MonadReader (ask), ReaderT)
 import Data.Text qualified as Text
 import Marconi.ChainIndex.CLI qualified as CommonCLI
 import Marconi.ChainIndex.Experimental.Indexers.Worker qualified as Core
+import Marconi.ChainIndex.Experimental.Runner (
+  RunIndexerConfig (RunIndexerConfig),
+  withDistancePreprocessor,
+ )
 import Marconi.ChainIndex.Experimental.Runner qualified as Runner
-import Marconi.ChainIndex.Types (RunIndexerConfig (RunIndexerConfig), SecurityParam)
+import Marconi.ChainIndex.Types (SecurityParam)
 import Marconi.Core qualified as Core
 import Marconi.Tutorial.CLI qualified as CLI
 import Marconi.Tutorial.Env (Env, envCliArgs, envStdoutTrace)
@@ -49,6 +53,7 @@ runIndexers = do
     Runner.runIndexer
       ( RunIndexerConfig
           stdoutTrace
+          withDistancePreprocessor
           retryConfig
           securityParam
           networkId

--- a/marconi-tutorial/src/Marconi/Tutorial/Indexers/AddressCount.hs
+++ b/marconi-tutorial/src/Marconi/Tutorial/Indexers/AddressCount.hs
@@ -75,8 +75,6 @@ addressCountWorker
       )
 addressCountWorker dbPath securityParam = do
   let extract = getEventsFromBlock
-  -- ix <- Utils.toException $ mkAddressCountMixedIndexer dbPath securityParam
-  -- Core.createWorker "AddressCount" extract ix
   ix <- Utils.toException $ mkAddressCountSqliteIndexer dbPath
   let config =
         Core.StandardWorkerConfig


### PR DESCRIPTION
- The processing of the chain-sync events is modified to issue some events with the chain tip.
- We introduce the `LastEventIndexer`, an indexer that saves the last value of an event on disk, to use it to save chain tips.
- We modify the indexers organisation accordingly.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
