### PR TITLE
PLT-7842 temporary non-degenerate genTxId

### DIFF
--- a/marconi-chain-index/cardano-api-extended/src/Cardano/Api/Extended/Gen.hs
+++ b/marconi-chain-index/cardano-api-extended/src/Cardano/Api/Extended/Gen.hs
@@ -1,0 +1,14 @@
+module Cardano.Api.Extended.Gen where
+
+import Cardano.Api qualified as C
+import Cardano.Crypto.Hash.Class qualified as Crypto
+import Hedgehog qualified as H
+import Hedgehog.Gen qualified as H.Gen
+import Hedgehog.Range qualified as H.Range
+
+{- | Temporary utility to generate @C.'TxId'@ whose values reasonably can be expected
+ - to be unique over small collections of generated events. It's only purpose is to
+ provide unique ids for testing.
+-}
+genTxId :: H.Gen C.TxId
+genTxId = C.TxId . Crypto.castHash . Crypto.hashWith id <$> H.Gen.bytes (H.Range.singleton 30)

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -169,6 +169,7 @@ library cardano-api-extended
     Cardano.Api.Extended
     Cardano.Api.Extended.Block
     Cardano.Api.Extended.ExtLedgerState
+    Cardano.Api.Extended.Gen
     Cardano.Api.Extended.IPC
     Cardano.Api.Extended.Streaming
     Cardano.Api.Extended.Streaming.Callback
@@ -183,9 +184,11 @@ library cardano-api-extended
     , base16-bytestring
     , bytestring
     , cardano-api                    ^>=8.8
+    , cardano-crypto-class
     , cardano-crypto-wrapper
     , cardano-ledger-byron
     , cardano-slotting
+    , hedgehog
     , memory
     , ouroboros-consensus
     , ouroboros-consensus-cardano

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -3,11 +3,9 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
--- TODO: return this after ad-hoc testing in repl
--- module Spec.Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent (
---  tests,
--- ) where
-module Spec.Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent where
+module Spec.Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent (
+  tests,
+) where
 
 import Cardano.Api qualified as C
 import Cardano.Api.Extended.Gen as CEGen

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -8,10 +8,10 @@ module Spec.Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent (
 ) where
 
 import Cardano.Api qualified as C
-import Cardano.Api.Extended.Gen as CEGen
+import Cardano.Api.Extended.Gen qualified as CEGen
 import Control.Concurrent qualified as Concurrent
 import Control.Lens (toListOf, view, (^.))
-import Control.Monad (forM, forM_, void, when)
+import Control.Monad (forM, forM_, void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Tracer (nullTracer)
 import Data.List ((\\))
@@ -43,8 +43,6 @@ import Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent (
   mintAssetPolicyId,
   mintAssetQuantity,
   mintTokenEventAsset,
-  mintTokenEventLocation,
-  mintTokenEventTxId,
   mintTokenEvents,
  )
 import Marconi.ChainIndex.Experimental.Indexers.MintTokenEvent qualified as MintTokenEvent
@@ -114,17 +112,6 @@ tests =
             "Don't find anything at untrack AssetId"
             "propRunnerDoesntTrackUnselectedAssetId"
             propRunnerDoesntTrackUnselectedAssetId
-        ]
-    , testGroup
-        "Generator testing"
-        [ testPropertyNamed
-            "genTimedEvents creates mint/burn events whose TxIds are all the same (PLT-7842)"
-            "propGenTimedEventsHaveConstantTxId"
-            propGenTimedEventsHaveConstantTxId
-        , testPropertyNamed
-            "genTxId from cardano-api is degenerate"
-            "propTxIdGenIsDegenerate"
-            propTxIdGenIsDegenerate
         ]
     ]
 


### PR DESCRIPTION
Creates a `genTxId` in `cardano-api-extended` as drop-in replacement for the same generator from `cardano-api`, which is degenerate. This allows us to generate `TxId` values reasonably expected to be unique across events in samples. Intended as a temporary replacement.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
