### PR TITLE
PLT-7045 - Marconi sidechain exit codes during SIGINT or SIGTERM

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Error.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Error.hs
@@ -18,6 +18,7 @@ data IndexerError a
   | CantInsertEvent !Text
   | CantRollback !Text
   | InvalidIndexer !Text
+  | Timeout !Text
   deriving stock (Show)
 
 instance (Exception a) => Exception (IndexerError a)
@@ -58,4 +59,5 @@ ignoreQueryError x = ExceptT $ do
     Left (CantInsertEvent msg) -> Left (CantInsertEvent msg)
     Left (CantRollback msg) -> Left (CantRollback msg)
     Left (InvalidIndexer msg) -> Left (InvalidIndexer msg)
+    Left (Timeout msg) -> Left (Timeout msg)
     Right result -> Right result

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -733,7 +733,7 @@ runIndexers
             waitQSemN (coordinator ^. barrier) (coordinator ^. indexerCount)
         case res of
           Just _ -> logInfo stdoutTrace "Done!"
-          Nothing -> throwIO (Timeout @Void "Timed out.")
+          Nothing -> throwIO (Timeout @Void "Timed out.") -- TODO: What useful info can go here?
 
 updateProcessedBlocksMetric
   :: S.Stream (S.Of (ChainSyncEvent BlockEvent)) IO r

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -733,7 +733,8 @@ runIndexers
             waitQSemN (coordinator ^. barrier) (coordinator ^. indexerCount)
         case res of
           Just _ -> logInfo stdoutTrace "Done!"
-          Nothing -> throwIO (Timeout @Void "Timed out.") -- TODO: What useful info can go here?
+          -- TODO: When it's possible, let's put some useful information in this exception
+          Nothing -> throwIO (Timeout @Void "Timed out.")
 
 updateProcessedBlocksMetric
   :: S.Stream (S.Of (ChainSyncEvent BlockEvent)) IO r

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -735,9 +735,8 @@ runIndexers
             <> Text.pack (show secondsBeforeTimeout)
             <> "s) ..."
         res <-
-          timeout 1 $
-            threadDelay 1000000
-              >> waitQSemN (coordinator ^. barrier) (coordinator ^. indexerCount) -- (secondsBeforeTimeout * 1_000_000) $
+          timeout (secondsBeforeTimeout * 1_000_000) $
+            waitQSemN (coordinator ^. barrier) (coordinator ^. indexerCount)
         case res of
           Just _ -> logInfo stdoutTrace "Done!"
           Nothing -> throwIO TimeoutException

--- a/marconi-sidechain/marconi-sidechain.cabal
+++ b/marconi-sidechain/marconi-sidechain.cabal
@@ -40,15 +40,8 @@ common lang
     -Wnoncanonical-monad-instances -Wredundant-constraints
     -Wunused-packages
 
-common maybe-unix
-  if !os(windows)
-    build-depends: unix
-
 library
-  import:
-    lang
-    , maybe-unix
-
+  import:          lang
   hs-source-dirs:  src
   exposed-modules:
     Marconi.Sidechain.Api.HttpServer
@@ -103,6 +96,7 @@ library
     , stm                   >=2.5
     , text
     , time
+    , unix
     , wai-extra
     , warp
 

--- a/marconi-sidechain/marconi-sidechain.cabal
+++ b/marconi-sidechain/marconi-sidechain.cabal
@@ -58,6 +58,7 @@ library
     Marconi.Sidechain.Api.Routes
     Marconi.Sidechain.Bootstrap
     Marconi.Sidechain.CLI
+    Marconi.Sidechain.Concurrency
     Marconi.Sidechain.Env
     Marconi.Sidechain.Error
     Marconi.Sidechain.Run

--- a/marconi-sidechain/marconi-sidechain.cabal
+++ b/marconi-sidechain/marconi-sidechain.cabal
@@ -40,8 +40,15 @@ common lang
     -Wnoncanonical-monad-instances -Wredundant-constraints
     -Wunused-packages
 
+common maybe-unix
+  if !os(windows)
+    build-depends: unix
+
 library
-  import:          lang
+  import:
+    lang
+    , maybe-unix
+
   hs-source-dirs:  src
   exposed-modules:
     Marconi.Sidechain.Api.HttpServer
@@ -96,7 +103,6 @@ library
     , stm                   >=2.5
     , text
     , time
-    , unix
     , wai-extra
     , warp
 

--- a/marconi-sidechain/marconi-sidechain.cabal
+++ b/marconi-sidechain/marconi-sidechain.cabal
@@ -40,8 +40,15 @@ common lang
     -Wnoncanonical-monad-instances -Wredundant-constraints
     -Wunused-packages
 
+common maybe-unix
+  if !os(windows)
+    build-depends: unix
+
 library
-  import:          lang
+  import:
+    lang
+    , maybe-unix
+
   hs-source-dirs:  src
   exposed-modules:
     Marconi.Sidechain.Api.HttpServer

--- a/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Marconi.Sidechain.Concurrency (
+  HandledAction (Handled, Unhandled),
+  raceSignalHandled_,
+  raceSignalHandled,
+) where
+
+import Control.Concurrent.Async (race)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, tryTakeMVar)
+import Control.Exception (Exception, catch, throwIO)
+import Control.Monad (void)
+import Data.Void (Void)
+import Marconi.Sidechain.Error (HasExitCode (toExitCode), signalToExit, withSignalHandling)
+import System.Exit (ExitCode (ExitFailure), exitWith)
+
+-- * Graceful exception handling after SIGINT or SIGTERM
+
+{- These purpose of these functions is as follows:
+
+  If we try to naiively exit with a different exit code than that of the received signal, our new
+	exit code will be ignored, We can work around this by using `installHandler`; catching the
+	signal and setting our own exit code.
+
+  We can use exceptions to map our domain failures to these exit codes.
+
+  To do this, we use an MVar to hold any overwritten exit code. The exit code is overwritten
+  by a handler function, which catches exceptions of the desired type. The type is then
+  pattern matched and the exit code is chosen based on the contructor.
+
+  If the program is exiting due to a SIGINT or SIGTERM and if we've got an MVar in our result,
+  we set the exit code to whatever it specifies. If either of the previous points aren't true,
+  we exit with whatever signal (SIGINT or SIGTERM) requested shutdown. -}
+
+{- | A data type representing an action with explicit instructions as to whether concurrent
+		 operations should attempt to map any exceptions it throws to Unix exit codes.
+
+		It has two type parameters:
+
+		* 'e' the exception type, 'Void' in the unhandled case
+
+    * 'a' the type returned by the action
+-}
+data HandledAction e a where
+  Handled :: (Exception e, HasExitCode e) => IO a -> HandledAction e a
+  Unhandled :: IO a -> HandledAction Void a
+
+{- | Perform two actions, with explicit handling instructions, concurrently (with the chosen scheme)
+
+		Takes:
+
+		* 'concOp' - A concurrent operation (`race` or `concurrent`)
+		* 'left' - The "left" `HandledAction` for the concurrent operation to run
+		* 'right - The "right" `HandledAction` for the concurrent operation to run
+
+		Returns whatever the concurrent operation would, if called plainly.
+
+		If the program is already shutting as a result of `SIGINT` or `SIGTERM`, any handled actions
+		will have their exceptions caught and mapped to an exit code.
+-}
+concOpSignalHandled
+  :: forall e1 e2 a b f
+   . (IO a -> IO b -> IO (f a b))
+  -> HandledAction e1 a
+  -> HandledAction e2 b
+  -> IO (f a b)
+concOpSignalHandled concOp hleft hright = do
+  mvar <- newEmptyMVar
+  let withHandler :: forall e c. HandledAction e c -> IO c
+      withHandler handledAction = case handledAction of
+        Handled action -> action `catch` (\e -> putMVar mvar (toExitCode @e e) >> throwIO e)
+        Unhandled action -> action
+  res <-
+    withSignalHandling $
+      concOp
+        (withHandler hleft)
+        (withHandler hright)
+  var' <- tryTakeMVar mvar
+  case var' of
+    Just code -> exitWith (ExitFailure code)
+    Nothing -> case res of
+      Right result -> pure result
+      Left cint -> exitWith (ExitFailure (signalToExit $ fromIntegral cint))
+
+{- | Race two actions, with explicit handling instructions, concurrently.
+
+		Takes two `HandledAction`s (the mechanism to explicitly specify handling instructions), and
+		returns whatever `race` would, if called directly.
+
+		If the program is already shutting as a result of `SIGINT` or `SIGTERM`, any handled actions
+		will have their exceptions caught and mapped to an exit code.
+-}
+raceSignalHandled
+  :: forall e1 e2 a b
+   . HandledAction e1 a
+  -> HandledAction e2 b
+  -> IO (Either a b)
+raceSignalHandled = concOpSignalHandled race
+
+-- | The same as `raceSignalHandled`, but discards its result.
+raceSignalHandled_
+  :: forall e1 e2 a b
+   . HandledAction e1 a
+  -> HandledAction e2 b
+  -> IO ()
+raceSignalHandled_ hleft hright = void $ raceSignalHandled hleft hright

--- a/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
@@ -81,7 +81,7 @@ concOpSignalHandled concOp hleft hright = do
     Just code -> exitWith (ExitFailure code)
     Nothing -> case res of
       Right result -> pure result
-      Left cint -> exitWith (ExitFailure (signalToExit $ fromIntegral cint))
+      Left signal -> exitWith (ExitFailure (signalToExit $ fromIntegral signal))
 
 {- | Race two actions, with explicit handling instructions, concurrently.
 

--- a/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
@@ -11,6 +11,7 @@ import Control.Concurrent.Async (race)
 import Control.Concurrent.MVar (newEmptyMVar, putMVar, tryTakeMVar)
 import Control.Exception (Exception, catch, throwIO)
 import Control.Monad (void)
+import Data.Void (Void)
 import Marconi.Sidechain.Error (HasExit, toExitCode, withSignalHandling)
 import System.Exit (ExitCode (ExitFailure), exitWith)
 
@@ -43,7 +44,7 @@ import System.Exit (ExitCode (ExitFailure), exitWith)
 -}
 data HandledAction e a where
   Handled :: (Exception e, HasExit e) => IO a -> HandledAction e a
-  Unhandled :: IO a -> HandledAction e a
+  Unhandled :: IO a -> HandledAction Void a
 
 {- | Perform two actions, with explicit handling instructions, concurrently (with the chosen scheme)
 

--- a/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
@@ -76,8 +76,8 @@ concOpSignalHandled concOp hleft hright = do
       concOp
         (withHandler hleft)
         (withHandler hright)
-  var' <- tryTakeMVar mvar
-  case var' of
+  mExitCode <- tryTakeMVar mvar
+  case mExitCode of
     Just code -> exitWith (ExitFailure code)
     Nothing -> case res of
       Right result -> pure result

--- a/marconi-sidechain/src/Marconi/Sidechain/Error.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Error.hs
@@ -1,13 +1,26 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
 
-module Marconi.Sidechain.Error where
+module Marconi.Sidechain.Error (
+  QueryExceptions (IndexerInternalError, QueryError, UnexpectedQueryResult, UntrackedPolicy),
+  HasExitCode (toExitCode),
+  withSignalHandling,
+  signalToExit,
+) where
 
 import Cardano.Api qualified as C
+import Control.Concurrent.Async (race)
+import Control.Concurrent.MVar (newEmptyMVar, takeMVar, tryPutMVar)
 import Control.Exception (Exception)
+import Control.Monad (void)
+import Data.Foldable (traverse_)
 import Data.Text (Text)
+import Data.Void (Void)
+import Marconi.ChainIndex.Error (IndexerError (Timeout))
 import Marconi.ChainIndex.Indexers.Utxo (UtxoHandle)
 import Marconi.Core.Storable (StorableQuery)
+import System.Posix (Handler (CatchOnce), Signal, installHandler, sigINT, sigTERM)
 
 data QueryExceptions
   = QueryError !Text
@@ -16,3 +29,48 @@ data QueryExceptions
   | IndexerInternalError !Text
   deriving stock (Show)
   deriving anyclass (Exception)
+
+-- * Mapping of exceptions to exit codes
+
+class HasExitCode e where
+  toExitCode :: e -> Int
+
+instance HasExitCode (IndexerError Void) where
+  toExitCode = indexerExceptionToExit
+
+indexerExceptionToExit :: IndexerError Void -> Int
+indexerExceptionToExit ex =
+  case ex of
+    Timeout _ -> 124
+    _ -> 1
+
+-- * Signal handling
+
+{- | Takes an action and runs it while waiting for either a `SIGINT` or a `SIGTERM` to be thrown.
+	If one is thrown, it's swallowed, but the value is returned to be interpreted by the caller of
+	this function.
+-}
+withSignalHandling :: IO a -> IO (Either Signal a)
+withSignalHandling action = do
+  termVar <- newEmptyMVar
+  let terminate terminationType = void $ tryPutMVar termVar terminationType
+      waitForTermination = takeMVar termVar
+      signals = [sigINT, sigTERM]
+
+  traverse_ (\signal -> installHandler signal (CatchOnce (terminate signal)) Nothing) signals
+  race
+    waitForTermination
+    action
+
+{- | Maps a signal to an exit code.
+
+		Maps SIGINT (2) to 130
+		Maps SIGTERM (15) to 143
+		Maps all other signals to 137 (SIGKILL)
+-}
+signalToExit :: Int -> Int
+signalToExit signal =
+  case signal of
+    2 -> 130
+    15 -> 143
+    _ -> 137

--- a/marconi-sidechain/src/Marconi/Sidechain/Error.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Error.hs
@@ -36,11 +36,11 @@ class HasExitCode e where
   toExitCode :: e -> Int
 
 instance HasExitCode (IndexerError Void) where
-  toExitCode = indexerExceptionToExit
+  toExitCode = indexerErrorToExit
 
-indexerExceptionToExit :: IndexerError Void -> Int
-indexerExceptionToExit ex =
-  case ex of
+indexerErrorToExit :: IndexerError Void -> Int
+indexerErrorToExit err =
+  case err of
     Timeout _ -> 124
     _ -> 1
 

--- a/marconi-sidechain/src/Marconi/Sidechain/Run.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Run.hs
@@ -33,7 +33,7 @@ import Text.Pretty.Simple (pShowDarkBg)
 Exceptions in either thread will end the program
 
 If the program is terminated with SIGINT or SIGTERM, exceptions in the marconi indexer workers
-thread will be mapped to exit codes
+thread will be mapped to exit codes by 'Marconi.Sidechain.Error.toExit'
 -}
 run :: IO ()
 run = do

--- a/marconi-sidechain/src/Marconi/Sidechain/Run.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Run.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -7,12 +6,11 @@ module Marconi.Sidechain.Run where
 import Cardano.BM.Setup (withTrace)
 import Cardano.BM.Trace (logInfo)
 import Cardano.BM.Tracing (defaultConfigStdout)
-import Control.Concurrent.Async (race_)
-import Control.Exception (catch, throwIO)
 import Control.Monad.Reader (runReaderT)
 import Data.Text qualified as Text
 import Data.Text.Lazy qualified as Text (toStrict)
 import Data.Void (Void)
+import Marconi.ChainIndex.Error (IndexerError)
 import Marconi.ChainIndex.Node.Client.Retry (withNodeConnectRetry)
 import Marconi.ChainIndex.Utils qualified as Utils
 import Marconi.Sidechain.Api.HttpServer (runHttpServer)
@@ -22,30 +20,10 @@ import Marconi.Sidechain.CLI (
   getVersion,
   parseCli,
  )
+import Marconi.Sidechain.Concurrency (HandledAction (Handled, Unhandled), raceSignalHandled_)
 import Marconi.Sidechain.Env (mkSidechainEnvFromCliArgs)
 import System.Directory (createDirectoryIfMissing)
-import System.Exit (ExitCode (ExitFailure), exitWith)
 import Text.Pretty.Simple (pShowDarkBg)
-
--- See note 4e8b9e02-fae4-448b-8b32-1eee50dd95ab
-
-import Control.Concurrent (MVar, putMVar, tryTakeMVar)
-import Control.Concurrent.Async (race)
-import Control.Concurrent.MVar (
-  newEmptyMVar,
-  takeMVar,
-  tryPutMVar,
- )
-import Data.Foldable (traverse_)
-import Data.Functor (void)
-import Marconi.ChainIndex.Indexers (IndexerException (TimeoutException))
-import System.Posix.Signals (
-  Handler (CatchOnce),
-  Signal,
-  installHandler,
-  sigINT,
-  sigTERM,
- )
 
 {- | Concurrently start:
 
@@ -53,6 +31,9 @@ import System.Posix.Signals (
 * marconi indexer workers
 
 Exceptions in either thread will end the program
+
+If the program is terminated with SIGINT or SIGTERM, exceptions in the sidechain thread will be
+mapped to exit codes
 -}
 run :: IO ()
 run = do
@@ -71,64 +52,9 @@ run = do
 
     rpcEnv <- mkSidechainEnvFromCliArgs securityParam cliArgs trace
 
-    exceptionalExitCodeMvar <- newEmptyMVar
-
-    let timeoutExceptionHandler (e :: IndexerException) = do
-          putMVar exceptionalExitCodeMvar (syncExceptionToExit e)
-          throwIO e
-        action =
-          race_
-            (runReaderT runHttpServer rpcEnv) -- Start HTTP server
-            ( runReaderT
-                runSidechainIndexers
-                rpcEnv
-                `catch` timeoutExceptionHandler
-            ) -- Start the Sidechain indexers
-    res <- withExitHandling action
-    case res of
-      Right _ -> pure ()
-      Left cint -> do
-        var' <- tryTakeMVar exceptionalExitCodeMvar
-        let exitCode = case var' of
-              Just i -> (ExitFailure i)
-              Nothing -> (ExitFailure (signalToExit $ fromIntegral cint))
-        exitWith exitCode
-
--- See note 4e8b9e02-fae4-448b-8b32-1eee50dd95ab
-
-{- | Ensure that @SIGTERM@ is handled gracefully, because it's how containers are stopped.
-
- @action@ will receive an 'AsyncCancelled' exception if @SIGTERM@ is received by the process.
-
- Typical use:
-
- > main :: IO ()
- > main = withGracefulTermination_ $ do
-
- Note that although the Haskell runtime handles @SIGINT@ it doesn't do anything with @SIGTERM@.
- Therefore, when running as PID 1 in a container, @SIGTERM@ will be ignored unless a handler is
- installed for it.
--}
-withExitHandling :: IO () -> IO (Either Signal ())
-withExitHandling action = do
-  termVar <- newEmptyMVar
-  let terminate terminationType = void $ tryPutMVar termVar terminationType
-      waitForTermination = takeMVar termVar
-      signals = [sigINT, sigTERM]
-
-  traverse_ (\signal -> installHandler signal (CatchOnce (terminate signal)) Nothing) signals
-  race
-    waitForTermination
-    action
-
-signalToExit :: Int -> Int
-signalToExit signal =
-  case signal of
-    2 -> 130
-    15 -> 143
-    _ -> 4
-
-syncExceptionToExit :: IndexerException -> Int
-syncExceptionToExit ex =
-  case ex of
-    TimeoutException -> 124
+    {- In an ideal world, we'd map both threads' errors to exit codes, but we'd need some machinery
+    to determine which one takes priority, or something similar. Currently, we only care about
+    timeouts in the sidechain, so this is fine for now. -}
+    raceSignalHandled_
+      (Unhandled (runReaderT runHttpServer rpcEnv))
+      (Handled @(IndexerError Void) (runReaderT runSidechainIndexers rpcEnv))

--- a/marconi-sidechain/src/Marconi/Sidechain/Run.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Run.hs
@@ -32,8 +32,8 @@ import Text.Pretty.Simple (pShowDarkBg)
 
 Exceptions in either thread will end the program
 
-If the program is terminated with SIGINT or SIGTERM, exceptions in the sidechain thread will be
-mapped to exit codes
+If the program is terminated with SIGINT or SIGTERM, exceptions in the marconi indexer workers
+thread will be mapped to exit codes
 -}
 run :: IO ()
 run = do

--- a/marconi-sidechain/src/Marconi/Sidechain/Run.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Run.hs
@@ -71,10 +71,10 @@ run = do
 
     rpcEnv <- mkSidechainEnvFromCliArgs securityParam cliArgs trace
 
-    mvar <- newEmptyMVar
+    exceptionalExitCodeMvar <- newEmptyMVar
 
     let timeoutExceptionHandler (e :: IndexerException) = do
-          putMVar mvar (syncExceptionToExit e)
+          putMVar exceptionalExitCodeMvar (syncExceptionToExit e)
           throwIO e
         action =
           race_
@@ -88,7 +88,7 @@ run = do
     case res of
       Right _ -> pure ()
       Left cint -> do
-        var' <- tryTakeMVar mvar
+        var' <- tryTakeMVar exceptionalExitCodeMvar
         let exitCode = case var' of
               Just i -> (ExitFailure i)
               Nothing -> (ExitFailure (signalToExit $ fromIntegral cint))


### PR DESCRIPTION
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
When the program is closed with SIGINT or SIGTERM, we will now alter the exit code based on whether or not any indexers experience a timeout during shutdown.

I've added generalised machinery to both make these changes easier to read and to allow us to possibly re-use it, if necessary. If we do want to re-use it, we'd most likely want to move it (specifically `Concurrency.hs`) to a different file.

Additionally, this ONLY works _after_ a SIGINT or SIGTERM has been received. It feels like stepping outside the realms of that is going out of scope, because I think there's potentially a bunch more machinery that'll be needed for general exception handling (in the context of remapping exit codes).

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
