### PR TITLE
PLT-7794 - Check if file exists and strictly evaluate error textification

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Logger.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Logger.hs
@@ -4,15 +4,16 @@ module Marconi.ChainIndex.Experimental.Logger (
   defaultStdOutLogger,
 ) where
 
+import Cardano.BM.Backend.Switchboard qualified as BM
 import Cardano.BM.Configuration qualified as BM
 import Cardano.BM.Data.Trace (Trace)
+import Cardano.BM.Setup qualified as BM
 import Cardano.BM.Tracing qualified as BM
-
 import Data.Text (Text)
 
 -- | StdOut logger, only log stuff above the Info level
-defaultStdOutLogger :: Text -> IO (Trace IO Text)
+defaultStdOutLogger :: Text -> IO (Trace IO Text, BM.Switchboard Text)
 defaultStdOutLogger appName = do
   cfg <- BM.defaultConfigStdout
   BM.setMinSeverity cfg BM.Info
-  BM.setupTrace (Right cfg) appName
+  BM.setupTrace_ cfg appName


### PR DESCRIPTION
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
There was a race condition between the mapping of errors returned by `buildIndexers` to `Text` and the exiting of the program with a failure condition. 

~I've resolved it by strictly evaluating the mapping.~

I've resolved it by using the `shutdown` function from `Cardano.BM`. This tells the logger to shutdown, and also waits for the shutdown to complete. The shutdown involves draining the queue, guaranteeing our message is processed.

Also, I'm now checking if the specified JSON file exists at the top level before continuing, which isn't strictly necessary as a part of this ticket now that I've fixed the root cause, but it makes sense so I'm leaving it in.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
