### PR TITLE
PLT-7885 support filtering mint token events by policyid

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -297,6 +297,7 @@ filterByTargetAssetIds assetIds =
     hasPolicyAndMaybeName :: C.AssetId -> NonEmpty (C.PolicyId, Maybe C.AssetName) -> Bool
     hasPolicyAndMaybeName C.AdaAssetId _ = False
     hasPolicyAndMaybeName (C.AssetId pid name) pidLookup = any (isPolicyAndMaybeName pid name) pidLookup
+    isPolicyAndMaybeName :: C.PolicyId -> C.AssetName -> (C.PolicyId, Maybe C.AssetName) -> Bool
     isPolicyAndMaybeName pid _ (pid', Nothing) = pid == pid'
     isPolicyAndMaybeName pid name (pid', Just name') = pid == pid' && name == name'
 

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -129,7 +129,13 @@ type MintTokenEventIndexer = Core.SQLiteIndexer MintTokenBlockEvents
 -- | A SQLite 'MintTokenBlockEvents' indexer with Catchup
 type StandardMintTokenEventIndexer m = StandardSQLiteIndexer m MintTokenBlockEvents
 
-newtype MintTokenEventConfig = MintTokenEventConfig {_configTrackedAssetIds :: [C.AssetId]}
+{- | 'MintTokenEventConfig' allows for specifying a list of @C.'PolicyId'@s and
+possibly @C.'AssetName'@s by which to filter a query. 'Nothing' represents the case
+in which no filtering should occur.
+-}
+newtype MintTokenEventConfig = MintTokenEventConfig
+  { _configTrackedAssetIds :: Maybe (NonEmpty (C.PolicyId, Maybe C.AssetName))
+  }
 
 -- | Minting events given for each block.
 newtype MintTokenBlockEvents = MintTokenBlockEvents

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -137,6 +137,7 @@ in which no filtering should occur.
 newtype MintTokenEventConfig = MintTokenEventConfig
   { _configTrackedAssetIds :: Maybe (NonEmpty (C.PolicyId, Maybe C.AssetName))
   }
+  deriving (Show)
 
 -- | Minting events given for each block.
 newtype MintTokenBlockEvents = MintTokenBlockEvents

--- a/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Experimental/Run.hs
@@ -59,7 +59,8 @@ run appName = withGracefulTermination_ $ do
       stopCatchupDistance = 100
       volatileEpochStateSnapshotInterval = 100
       filteredAddresses = []
-      filteredAssetIds = []
+      -- TODO: PLT-7885 This was an existing bug to be fixed shortly in PLT-7793.
+      filteredAssetIds = Nothing
       includeScript = True
       socketPath = Cli.optionsSocketPath $ Cli.commonOptions o
       networkId = Cli.optionsNetworkId $ Cli.commonOptions o

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Experimental/Indexers/MintTokenEvent.hs
@@ -515,13 +515,7 @@ propRunnerTracksSelectedAssetId = H.property $ do
   events <- H.forAll genTimedEvents
   let allAssetIds = getAssetIdsFromTimedEvents $ mapMaybe sequence events
 
-  -- We take a subset of the AssetIds to track them. If the subset is empty, we track all the
-  -- assetIds.
-  assetIdSubset <-
-    H.forAll $
-      H.Gen.filter (not . null) $
-        H.Gen.subsequence allAssetIds
-  let trackedAssetIds = if null assetIdSubset then allAssetIds else assetIdSubset
+  (MintTokenEventConfig trackedAssetIds, _) <- H.forAll $ genTrackedAssetIds allAssetIds
 
   listIndexer <- Core.indexAll events Core.mkListIndexer
   listIndexerEvents <- queryListIndexerEventsMatchingTargetAssetIds trackedAssetIds listIndexer
@@ -537,20 +531,16 @@ propRunnerDoesntTrackUnselectedAssetId = H.property $ do
   events <- H.forAll genTimedEvents
   let allAssetIds = getAssetIdsFromTimedEvents $ mapMaybe sequence events
 
-  -- TODO: PLT-7885 update this block with new generator
-  -- We take a subset of the AssetIds to track them. If the subset is empty, we track all the
-  -- assetIds.
-  let notAllAddressesPredicate xs = all ($ xs) [not . null, (/= allAssetIds)]
-  trackedAssetIds <- H.forAll $ H.Gen.filter notAllAddressesPredicate $ H.Gen.subsequence allAssetIds
-  let untrackedAssetIds = allAssetIds \\ trackedAssetIds
+  (MintTokenEventConfig trackedAssetIds, untrackedPolicyIds) <-
+    H.forAll $ genTrackedAssetIds allAssetIds
 
   sqlIndexer <- indexWithRunner trackedAssetIds events
 
-  forM_ untrackedAssetIds $ \untrackedAssetId -> do
-    let query =
-          case untrackedAssetId of
-            C.AdaAssetId -> QueryByAssetId "" (Just "") Nothing Nothing Nothing
-            C.AssetId policyId assetName -> QueryByAssetId policyId (Just assetName) Nothing Nothing Nothing
+  -- If untracked assets is empty, the test does nothing.
+  H.cover 50 "Non-empty untracked assets" $ not (null untrackedPolicyIds)
+
+  forM_ untrackedPolicyIds $ \policyid -> do
+    let query = QueryByAssetId policyid Nothing Nothing Nothing Nothing
     (sqlIndexerEvents :: [Core.Timed C.ChainPoint MintTokenBlockEvents]) <-
       H.evalM $ H.evalExceptT $ Core.queryLatest query sqlIndexer
     sqlIndexerEvents === []
@@ -578,11 +568,12 @@ indexWithRunner trackedAssetIds events = do
 
 -- | Query the events of the 'ListIndexer' and only keep the events that contain tracked AssetId.
 queryListIndexerEventsMatchingTargetAssetIds
-  :: NonEmpty (C.PolicyId, Maybe C.AssetName)
+  :: Maybe (NonEmpty (C.PolicyId, Maybe C.AssetName))
   -> Core.ListIndexer MintTokenBlockEvents
   -> PropertyT IO [Core.Timed C.ChainPoint MintTokenBlockEvents]
 queryListIndexerEventsMatchingTargetAssetIds assetIds indexer = do
-  let query = MintTokenEventsMatchingQuery (filterByTargetAssetIds assetIds)
+  -- If assetIds is Nothing, query does no filtering (looks for all ids).
+  let query = MintTokenEventsMatchingQuery $ maybe Just filterByTargetAssetIds assetIds
   H.evalExceptT $ Core.queryLatest query indexer
 
 getPolicyIdFromAssetId :: C.AssetId -> C.PolicyId
@@ -684,14 +675,20 @@ genEventType = do
   H.Gen.maybe $ H.Gen.element [MintEventType, BurnEventType]
 
 {- | Generator for 'MintTokenEventConfig' along with a list of @C.'PolicyId'@ s not selected for
-tracking.
+tracking. It is enough to mark untracked assets by policy id, since those must be unique to an asset.
+https://developers.cardano.org/docs/native-tokens/minting-nfts/
 -}
 genTrackedAssetIds :: [C.AssetId] -> Gen (MintTokenEventConfig, [C.PolicyId])
-genTrackedAssetIds allAssetIds = do
+genTrackedAssetIds assetIds = do
   -- Here we let the empty list mark the 'Nothing' case in the config,
-  -- for convenience.
-  trackedAssetIds <- H.Gen.filter (not . (C.AdaAssetId `elem`)) $ H.Gen.subsequence allAssetIds
-  let untrackedPolicyIds = map getPolicyIdFromAssetId $ allAssetIds \\ trackedAssetIds
+  -- for convenience. Therefore, the untrackedPolicyIds must be [] in that case.
+  -- nubBy policy id since the input assetIds might have assets with different names
+  -- but the same policy id.
+  let allAssetIds = List.nubBy (\a1 a2 -> getPolicyIdFromAssetId a1 == getPolicyIdFromAssetId a2) assetIds
+  trackedAssetIds <- H.Gen.filter (not . (C.AdaAssetId `elem`)) (H.Gen.subsequence allAssetIds)
+  let untrackedPolicyIds = case trackedAssetIds of
+        [] -> []
+        xs -> map getPolicyIdFromAssetId $ allAssetIds \\ xs
 
   -- Generate a list of bools to decide randomly whether the name is used or not.
   keepNameIndicator <- H.Gen.list (H.Range.singleton (length trackedAssetIds)) H.Gen.bool


### PR DESCRIPTION
* Adds support in the "experimental" indexers for filtering a `MintToken` event indexer by `PolicyId` and (maybe) `AssetName`. Previously, both were required as part of a filter on `AssetId` s. Such functionality is supported in the CLI and in the "legacy" indexers.
* Change `MintTokenEventConfig` type to match the CLI input type and to support the new functionality.

Note this intentionally does not fix a known bug (PLT-7793), which can be fixed easily if this PR is merged.

Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
