### PR TITLE
PLT-7132 Fix git revision in marconi-sidechain and marconi-chain-index-experimental

### DIFF
--- a/nix/project.nix
+++ b/nix/project.nix
@@ -74,6 +74,8 @@ let
     (_: prev: {
       hsPkgs = prev.pkgs.pkgsHostTarget.setGitRevForPaths prev.pkgs.gitrev [
         "marconi-chain-index.components.exes.marconi-chain-index"
+        "marconi-chain-index.components.exes.marconi-chain-index-experimental"
+        "marconi-sidechain.components.exes.marconi-sidechain"
       ]
         prev.hsPkgs;
     })


### PR DESCRIPTION
This was working already in `marconi-chain-index`.

Tested as follows:

```shellsession
$ for EXE in marconi-{sidechain,chain-index{-experimental,}}; do
>   $(nix build --quiet --no-link --print-out-paths .#$EXE)/bin/$EXE --version
> done
1.2.0.0-8968b7e6df657be5cd23677296d8dd4ffa852294
[marconi-sidechain:Info:27] [2023-10-13 22:31:40.68 UTC] marconi-sidechain-1.2.0.0-8968b7e6df657be5cd23677296d8dd4ffa852294
1.2.0.0-8968b7e6df657be5cd23677296d8dd4ffa852294
[marconi-chain-index-experimental:Info:29] [2023-10-13 22:31:40.82 UTC] marconi-chain-index-experimental-1.2.0.0-8968b7e6df657be5cd23677296d8dd4ffa852294
1.2.0.0-8968b7e6df657be5cd23677296d8dd4ffa852294
[marconi-chain-index:Info:27] [2023-10-13 22:31:40.97 UTC] marconi-chain-index-1.2.0.0-8968b7e6df657be5cd23677296d8dd4ffa852294
```
<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [x] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
