### PR TITLE
PLT-7542 Improve error handling in `queryBlockNoAtSlotNo`

### DIFF
--- a/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/MintBurn.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Api/Query/Indexers/MintBurn.hs
@@ -78,16 +78,17 @@ queryByPolicyAndAssetId securityParam env policyId assetId slotNo txId = do
             Nothing -> do
               -- The user didn't provide an upper bound slot number. Therefore, we query the latest
               -- block number of the local node.
-              blockNoE <- Utxo.queryCurrentNodeBlockNo $ env ^. sidechainAddressUtxoIndexer
+              blockNoE <- Utxo.queryCurrentNodeBlockNo (env ^. sidechainAddressUtxoIndexer)
               pure $ do
                 blockNo <- blockNoE
                 pure $ toAssetIdTxResult blockNo <$> mintBurnRows
             Just s -> do
               -- The user provided an upper bound slot number. Therefore, we convert the provided
               -- slot number to a block number by using the indexer which indexes that information.
-              let addressUtxoIndexerEnv = env ^. sidechainAddressUtxoIndexer
-              blockNo <- Utxo.queryBlockNoAtSlotNo addressUtxoIndexerEnv s
-              pure $ Right $ toAssetIdTxResult blockNo <$> mintBurnRows
+              blockNoE <- Utxo.queryBlockNoAtSlotNo (env ^. sidechainAddressUtxoIndexer) s
+              pure $ do
+                blockNo <- blockNoE
+                pure $ toAssetIdTxResult blockNo <$> mintBurnRows
         Left (CI.QueryError MintBurn.InvalidInterval{}) ->
           pure $
             Left $


### PR DESCRIPTION
The `getBurnTokenEvents` RPC from `marconi-sidechain` was producing an internal error when an invalid slot number was given (eg because it's ahead of what the UTXO indexer has seen). This is because the `queryBlockNoAtSlotNo` function was throwing an exception.

Adding a test for this specific case seemed unwarranted, so I tested it using (a modified version of) `marconi-sidechain/examples/run-pre-prod-queries`:

```
getBurnTokenEvents({
  "policyId": "00000000000000000000000000000000000000000000000000000000",
  "createdBeforeSlotNo": 1000000
}) =
{
  "error": {
    "code": -32602,
    "data": "Slot number doesn't exist yet",
    "message": "Invalid params"
  },
  "id": 1,
  "jsonrpc": "2.0"
}
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
