### PR TITLE
Added manually defined prisms to make HLS run

### DIFF
--- a/marconi-core/src/Marconi/Core/Type.hs
+++ b/marconi-core/src/Marconi/Core/Type.hs
@@ -134,28 +134,28 @@ _IndexerInternalError :: APrism' IndexerError Text
 _IndexerInternalError = prism' f g
   where
     f = IndexerInternalError
-    g (IndexerInternalError mt) = Just mt
+    g (IndexerInternalError txt) = Just txt
     g _ = Nothing
 
 _InvalidIndexer :: APrism' IndexerError Text
 _InvalidIndexer = prism' f g
   where
     f = InvalidIndexer
-    g (InvalidIndexer mt) = Just mt
+    g (InvalidIndexer txt) = Just txt
     g _ = Nothing
 
 _StopIndexer :: APrism' IndexerError (Maybe Text)
 _StopIndexer = prism' f g
   where
     f = StopIndexer
-    g (StopIndexer mt) = Just mt
+    g (StopIndexer mtxt) = Just mtxt
     g _ = Nothing
 
 _ResumingFailed :: APrism' IndexerError Text
 _ResumingFailed = prism' f g
   where
     f = ResumingFailed
-    g (ResumingFailed mt) = Just mt
+    g (ResumingFailed txt) = Just txt
     g _ = Nothing
 
 _IndexerCloseTimeoutError :: APrism' IndexerError ()
@@ -169,7 +169,7 @@ _OtherIndexError :: APrism' IndexerError Text
 _OtherIndexError = prism' f g
   where
     f = OtherIndexError
-    g (OtherIndexError mt) = Just mt
+    g (OtherIndexError txt) = Just txt
     g _ = Nothing
 
 instance Exception IndexerError

--- a/marconi-core/src/Marconi/Core/Type.hs
+++ b/marconi-core/src/Marconi/Core/Type.hs
@@ -35,6 +35,7 @@ module Marconi.Core.Type (
 
 import Control.Exception (Exception)
 import Control.Lens (Lens, Lens', makePrisms)
+import Control.Lens.Prism (APrism', prism')
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Data (Typeable)
 import Data.List.NonEmpty (NonEmpty)
@@ -122,7 +123,54 @@ data IndexerError
   | -- | Any other cause of failure
     OtherIndexError Text
 
-makePrisms ''IndexerError
+_RollbackBehindHistory :: APrism' IndexerError ()
+_RollbackBehindHistory = prism' f g
+  where
+    f = const RollbackBehindHistory
+    g RollbackBehindHistory = Just ()
+    g _ = Nothing
+
+_IndexerInternalError :: APrism' IndexerError Text
+_IndexerInternalError = prism' f g
+  where
+    f = IndexerInternalError
+    g (IndexerInternalError mt) = Just mt
+    g _ = Nothing
+
+_InvalidIndexer :: APrism' IndexerError Text
+_InvalidIndexer = prism' f g
+  where
+    f = InvalidIndexer
+    g (InvalidIndexer mt) = Just mt
+    g _ = Nothing
+
+_StopIndexer :: APrism' IndexerError (Maybe Text)
+_StopIndexer = prism' f g
+  where
+    f = StopIndexer
+    g (StopIndexer mt) = Just mt
+    g _ = Nothing
+
+_ResumingFailed :: APrism' IndexerError Text
+_ResumingFailed = prism' f g
+  where
+    f = ResumingFailed
+    g (ResumingFailed mt) = Just mt
+    g _ = Nothing
+
+_IndexerCloseTimeoutError :: APrism' IndexerError ()
+_IndexerCloseTimeoutError = prism' f g
+  where
+    f = const IndexerCloseTimeoutError
+    g IndexerCloseTimeoutError = Just ()
+    g _ = Nothing
+
+_OtherIndexError :: APrism' IndexerError Text
+_OtherIndexError = prism' f g
+  where
+    f = OtherIndexError
+    g (OtherIndexError mt) = Just mt
+    g _ = Nothing
 
 instance Exception IndexerError
 


### PR DESCRIPTION
My HLS wasn't running properly in projects which depend upon `marconi-core`. The error was about `Marconi.Core.Type` not exporting prisms for `IndexerError`, which it did. Manually defining the prisms makes the problem go away.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
