### PR TITLE
PLT-5743 - Deploy Haddock GitHub page

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -1,0 +1,42 @@
+name: "Build and Deploy to Github Pages"
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+jobs:
+  build-haddock-site:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment:
+      name: github-pages
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cachix/install-nix-action@v22
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+      - name: Build haddock site
+        run: |
+          ghcup nuke
+          nix develop --command bash -c '
+              which cabal
+              cabal update
+              cabal haddock marconi-core
+              cabal haddock marconi-chain-index
+              cabal haddock marconi-core-json-rpc
+            '
+          mkdir dist
+          mkdir dist/marconi-core
+          mkdir dist/marconi-chain-index
+          mkdir dist/marconi-core-json-rpc
+          cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-core-1.2.0.0/doc/html/marconi-core/* ./dist/marconi-core
+          cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-chain-index-1.2.0.0/doc/html/marconi-chain-index/* ./dist/marconi-chain-index
+          cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-chain-json-rpc-1.2.0.0/doc/html/marconi-core-json-rpc/* ./dist/marconi-core-json-rpc
+      - uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: dist
+          target-folder: ${{ github.ref_name }}

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - will/PLT-5743/deploy-haddock-github-page
     tags:
       - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 jobs:

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           ghcup nuke
           nix develop --command bash -c '
-              which cabal
               cabal update
               cabal haddock marconi-core
               cabal haddock marconi-chain-index
@@ -36,7 +35,7 @@ jobs:
           mkdir dist/marconi-core-json-rpc
           cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-core-1.2.0.0/doc/html/marconi-core/* ./dist/marconi-core
           cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-chain-index-1.2.0.0/doc/html/marconi-chain-index/* ./dist/marconi-chain-index
-          cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-core-json-rpc-1.2.0.0/doc/marconi-core-json-rpc/* ./dist/marconi-core-json-rpc
+          cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-core-json-rpc-1.2.0.0/doc/html/marconi-core-json-rpc/* ./dist/marconi-core-json-rpc
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: dist

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -35,7 +35,7 @@ jobs:
           mkdir dist/marconi-core-json-rpc
           cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-core-1.2.0.0/doc/html/marconi-core/* ./dist/marconi-core
           cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-chain-index-1.2.0.0/doc/html/marconi-chain-index/* ./dist/marconi-chain-index
-          cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-chain-json-rpc-1.2.0.0/doc/html/marconi-core-json-rpc/* ./dist/marconi-core-json-rpc
+          cp -RL ./dist-newstyle/build/x86_64-linux/ghc-9.2.8/marconi-core-json-rpc-1.2.0.0/doc/marconi-core-json-rpc/* ./dist/marconi-core-json-rpc
       - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: dist

--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - will/PLT-5743/deploy-haddock-github-page
     tags:
       - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
 jobs:

--- a/README.adoc
+++ b/README.adoc
@@ -29,6 +29,7 @@ The more in-depth user documentation is available in our http://example.com/TODO
 === Haddock documentation
 
 The Haskell API documentation (Haddock) for the Marconi libraries is hosted here:
+
 * https://input-output-hk.github.io/marconi/main/marconi-core[marconi-core]
 * https://input-output-hk.github.io/marconi/main/marconi-chain-index[marconi-chain-index]
 * https://input-output-hk.github.io/marconi/main/marconi-core-json-rpc[marconi-core-json-rpc]

--- a/README.adoc
+++ b/README.adoc
@@ -28,7 +28,10 @@ The more in-depth user documentation is available in our http://example.com/TODO
 
 === Haddock documentation
 
-The Haskell API documentation (Haddock) for the Marconi libraries are hosted http://example.com/TODO[here].
+The Haskell API documentation (Haddock) for the Marconi libraries is hosted here:
+* https://input-output-hk.github.io/marconi/main/marconi-core[marconi-core]
+* https://input-output-hk.github.io/marconi/main/marconi-chain-index[marconi-chain-index]
+* https://input-output-hk.github.io/marconi/main/marconi-core-json-rpc[marconi-core-json-rpc]
 
 You may generate them directly with `Cabal` for each component:
 


### PR DESCRIPTION
I've added a workflow which pushes builds Haddock documentation and pushes to the `gh-pages` branch. Combined with the configuration I've added to our repo settings, we'll now have Haddock sites deploy to: 
- https://input-output-hk.github.io/marconi/main/marconi-core
- https://input-output-hk.github.io/marconi/main/marconi-chain-index
- https://input-output-hk.github.io/marconi/main/marconi-core-json-rpc

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
