### PR TITLE
PLT-8321 - Added WithTrace to the indexer used for the current sync point query

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -146,7 +146,7 @@ buildIndexers securityParam catchupConfig utxoConfig mintEventConfig epochStateC
   mainCoordinator <- lift $ standardCoordinator mainLogger [blockCoordinator, chainTipWorker]
 
   let currentSyncPointIndexer =
-        Core.withTrace mainLogger $
+        Core.withTrace (BM.appendName "currentSyncPointEvent" mainLogger) $
           CurrentSyncPoint.CurrentSyncPointQueryIndexer
             mainCoordinator
             blockInfoMVar

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -61,7 +61,11 @@ type MintTokenEventIndexer =
   StandardIndexer IO Core.SQLiteIndexer MintTokenEvent.MintTokenBlockEvents
 type BlockInfoIndexer = StandardIndexer IO Core.SQLiteIndexer Block.BlockInfo
 type UtxoIndexer = UtxoQuery.UtxoQueryIndexer IO
-type CurrentSyncPointIndexer = CurrentSyncPoint.CurrentSyncPointQueryIndexer TipOrBlock
+type CurrentSyncPointIndexer =
+  Core.WithTrace
+    IO
+    CurrentSyncPoint.CurrentSyncPointQueryIndexer
+    TipOrBlock
 
 -- | Container for all the queryable indexers of marconi-chain-index.
 data MarconiChainIndexQueryables = MarconiChainIndexQueryables
@@ -142,10 +146,11 @@ buildIndexers securityParam catchupConfig utxoConfig mintEventConfig epochStateC
   mainCoordinator <- lift $ standardCoordinator mainLogger [blockCoordinator, chainTipWorker]
 
   let currentSyncPointIndexer =
-        CurrentSyncPoint.CurrentSyncPointQueryIndexer
-          mainCoordinator
-          blockInfoMVar
-          chainTipMVar
+        Core.withTrace mainLogger $
+          CurrentSyncPoint.CurrentSyncPointQueryIndexer
+            mainCoordinator
+            blockInfoMVar
+            chainTipMVar
       queryables =
         MarconiChainIndexQueryables
           epochStateMVar


### PR DESCRIPTION
Modified the type of the indexer used in the current sync point query so that we log any errors raised in the `MonadError` context.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
