### PR TITLE
PLT-8326 - Added WithTrace to UtxoQueryIndexer

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -127,7 +127,7 @@ buildIndexers securityParam catchupConfig utxoConfig mintEventConfig epochStateC
       [utxoWorker, spentWorker, datumWorker, mintTokenWorker]
 
   utxoQueryIndexer <-
-    Core.withTrace mainLogger
+    Core.withTrace (BM.appendName "utxoQueryEvent" mainLogger)
       <$> ( lift $
               UtxoQuery.mkUtxoSQLiteQuery $
                 UtxoQuery.UtxoQueryAggregate utxoMVar spentMVar datumMVar blockInfoMVar

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers.hs
@@ -127,9 +127,11 @@ buildIndexers securityParam catchupConfig utxoConfig mintEventConfig epochStateC
       [utxoWorker, spentWorker, datumWorker, mintTokenWorker]
 
   utxoQueryIndexer <-
-    lift $
-      UtxoQuery.mkUtxoSQLiteQuery $
-        UtxoQuery.UtxoQueryAggregate utxoMVar spentMVar datumMVar blockInfoMVar
+    Core.withTrace mainLogger
+      <$> ( lift $
+              UtxoQuery.mkUtxoSQLiteQuery $
+                UtxoQuery.UtxoQueryAggregate utxoMVar spentMVar datumMVar blockInfoMVar
+          )
 
   blockCoordinator <-
     lift $

--- a/marconi-chain-index/src/Marconi/ChainIndex/Indexers/UtxoQuery.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Indexers/UtxoQuery.hs
@@ -101,10 +101,11 @@ data UtxoQueryAggregate m = forall
   }
 
 -- | An alias for the 'SQLiteAggregateQuery' that handle the 'UtxoQueryEvent'
-type UtxoQueryIndexer m = Core.SQLiteAggregateQuery m C.ChainPoint UtxoQueryEvent
+type UtxoQueryIndexer m =
+  Core.WithTrace IO (Core.SQLiteAggregateQuery m C.ChainPoint) UtxoQueryEvent
 
 -- | Generate a @UtxoQueryIndexer@ from the given source
-mkUtxoSQLiteQuery :: UtxoQueryAggregate m -> IO (UtxoQueryIndexer m)
+mkUtxoSQLiteQuery :: UtxoQueryAggregate m -> IO (Core.SQLiteAggregateQuery m C.ChainPoint event)
 mkUtxoSQLiteQuery (UtxoQueryAggregate _utxo _spent _datum _blockInfo) =
   Core.mkSQLiteAggregateQuery $
     Map.fromList


### PR DESCRIPTION
Modified the type of the indexer used in the UTXO query so that we log any errors raised in the MonadError context.

Note: There isn't a straightforward way to test this, since we don't seem to be using the instance anywhere. Are we going to add an endpoint which calls this instance in the future?

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
