### PR TITLE
PLT-8098 new mintburn indexers e2e tests

### DIFF
--- a/STYLEGUIDE.adoc
+++ b/STYLEGUIDE.adoc
@@ -1,6 +1,7 @@
 = Marconi Haskell style guide
 :toc:
 
+
 The purpose of this document is to codify various aspects of how we write Haskell code as we contribute to Marconi.
 
 The goal is twofold:

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -358,6 +358,7 @@ library marconi-chain-index-test-lib
     , cardano-node-socket-emulator
     , contra-tracer
     , data-default
+    , directory
     , hedgehog-extras
     , iohk-monitoring
     , ouroboros-network-protocols

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -358,7 +358,6 @@ library marconi-chain-index-test-lib
     , cardano-node-socket-emulator
     , contra-tracer
     , data-default
-    , directory
     , hedgehog-extras
     , iohk-monitoring
     , ouroboros-network-protocols
@@ -367,6 +366,7 @@ library marconi-chain-index-test-lib
     , plutus-ledger-api             ^>=1.9
     , plutus-tx
     , plutus-tx-plugin
+    , text
 
   ------------------------
   -- Non-IOG dependencies

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -332,9 +332,10 @@ library marconi-chain-index-test-lib
   visibility:      public
   hs-source-dirs:  test-lib
   exposed-modules:
-    Gen.Marconi.ChainIndex.Mockchain
-    Gen.Marconi.ChainIndex.Types
-    Helpers
+    Test.Gen.Marconi.ChainIndex.Mockchain
+    Test.Gen.Marconi.ChainIndex.Types
+    Test.Helpers
+    Test.Integration
 
   --------------------
   -- Local components

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -356,6 +356,7 @@ library marconi-chain-index-test-lib
     , cardano-ledger-core
     , cardano-node-emulator
     , cardano-node-socket-emulator
+    , data-default
     , hedgehog-extras
     , iohk-monitoring
     , ouroboros-network-protocols

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -332,6 +332,7 @@ library marconi-chain-index-test-lib
   visibility:      public
   hs-source-dirs:  test-lib
   exposed-modules:
+    Test.Gen.Marconi.ChainIndex.MintTokenEvent
     Test.Gen.Marconi.ChainIndex.Mockchain
     Test.Gen.Marconi.ChainIndex.Types
     Test.Helpers

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -357,6 +357,7 @@ library marconi-chain-index-test-lib
     , cardano-node-emulator
     , cardano-node-socket-emulator
     , hedgehog-extras
+    , iohk-monitoring
     , ouroboros-network-protocols
     , plutus-core
     , plutus-ledger

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -349,15 +349,18 @@ library marconi-chain-index-test-lib
   -- Other IOG dependencies
   --------------------------
   build-depends:
-    , cardano-api                  ^>=8.20
-    , cardano-api-gen              ^>=8.2
+    , cardano-api                   ^>=8.20
+    , cardano-api-gen               ^>=8.2
     , cardano-binary
     , cardano-crypto-class
     , cardano-ledger-core
+    , cardano-node-emulator
+    , cardano-node-socket-emulator
     , hedgehog-extras
     , ouroboros-network-protocols
     , plutus-core
-    , plutus-ledger-api            ^>=1.9
+    , plutus-ledger
+    , plutus-ledger-api             ^>=1.9
     , plutus-tx
     , plutus-tx-plugin
 

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -356,9 +356,6 @@ library marconi-chain-index-test-lib
     , cardano-ledger-core
     , cardano-node-emulator
     , cardano-node-socket-emulator
-    , contra-tracer
-    , data-default
-    , hedgehog-extras
     , iohk-monitoring
     , ouroboros-network-protocols
     , plutus-core
@@ -366,21 +363,24 @@ library marconi-chain-index-test-lib
     , plutus-ledger-api             ^>=1.9
     , plutus-tx
     , plutus-tx-plugin
-    , text
 
   ------------------------
   -- Non-IOG dependencies
   ------------------------
   build-depends:
     , async
-    , base        >=4.9 && <5
+    , base             >=4.9 && <5
     , bytestring
     , containers
+    , contra-tracer
+    , data-default
     , directory
     , filepath
     , hedgehog
+    , hedgehog-extras
     , lens
     , mtl
     , streaming
     , temporary
+    , text
     , time

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -356,6 +356,7 @@ library marconi-chain-index-test-lib
     , cardano-ledger-core
     , cardano-node-emulator
     , cardano-node-socket-emulator
+    , contra-tracer
     , data-default
     , hedgehog-extras
     , iohk-monitoring

--- a/marconi-chain-index/test-lib/Test/Gen/Marconi/ChainIndex/MintTokenEvent.hs
+++ b/marconi-chain-index/test-lib/Test/Gen/Marconi/ChainIndex/MintTokenEvent.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fplugin-opt PlutusTx.Plugin:target-version=1.0.0 #-}
+
+-- | Generators related to 'MintTokenEvent' indexer and queries.
+module Test.Gen.Marconi.ChainIndex.MintTokenEvent where
+
+import Cardano.Api.Shelley qualified as C
+import Control.Monad (replicateM)
+import Data.Bifunctor (first)
+import Data.Map qualified as Map
+import Hedgehog qualified as H
+import Hedgehog.Gen qualified as H.Gen
+import Hedgehog.Range qualified as Range
+import PlutusLedgerApi.V1 qualified as PlutusV1
+import PlutusLedgerApi.V2 qualified as PlutusV2
+import PlutusTx qualified
+
+genTxMintValue :: H.Gen (C.TxMintValue C.BuildTx C.BabbageEra)
+genTxMintValue = genTxMintValueRange 1 100
+
+genTxMintValueRange :: Integer -> Integer -> H.Gen (C.TxMintValue C.BuildTx C.BabbageEra)
+genTxMintValueRange min' max' = do
+  n :: Int <- H.Gen.integral (Range.constant 1 5)
+  policyAssets <- replicateM n genAsset
+  let (policyId, policyWitness, mintedValues) = mkMintValue commonMintingPolicy policyAssets
+      buildInfo = C.BuildTxWith $ Map.singleton policyId policyWitness
+  pure $ C.TxMintValue C.MultiAssetInBabbageEra mintedValues buildInfo
+  where
+    genAsset :: H.Gen (C.AssetName, C.Quantity)
+    genAsset = (,) <$> genAssetName <*> genQuantity
+    genQuantity = C.Quantity <$> H.Gen.integral (Range.constant min' max')
+
+genAssetName :: H.Gen C.AssetName
+genAssetName = C.AssetName <$> H.Gen.bytes (Range.constant 1 5)
+
+mkMintValue
+  :: MintingPolicy
+  -> [(C.AssetName, C.Quantity)]
+  -> (C.PolicyId, C.ScriptWitness C.WitCtxMint C.BabbageEra, C.Value)
+mkMintValue policy policyAssets = (policyId, policyWitness, mintedValues)
+  where
+    serialisedPolicyScript :: C.PlutusScript C.PlutusScriptV1
+    serialisedPolicyScript = C.PlutusScriptSerialised $ PlutusV2.serialiseCompiledCode policy
+
+    policyId :: C.PolicyId
+    policyId = C.scriptPolicyId $ C.PlutusScript C.PlutusScriptV1 serialisedPolicyScript :: C.PolicyId
+
+    executionUnits :: C.ExecutionUnits
+    executionUnits = C.ExecutionUnits{C.executionSteps = 300000, C.executionMemory = 1000}
+    redeemer :: C.ScriptRedeemer
+    redeemer = C.unsafeHashableScriptData $ C.fromPlutusData $ PlutusV1.toData ()
+    policyWitness :: C.ScriptWitness C.WitCtxMint C.BabbageEra
+    policyWitness =
+      C.PlutusScriptWitness
+        C.PlutusScriptV1InBabbage
+        C.PlutusScriptV1
+        (C.PScript serialisedPolicyScript)
+        C.NoScriptDatumForMint
+        redeemer
+        executionUnits
+
+    mintedValues :: C.Value
+    mintedValues = C.valueFromList $ map (first (C.AssetId policyId)) policyAssets
+
+type MintingPolicy = PlutusTx.CompiledCode (PlutusTx.BuiltinData -> PlutusTx.BuiltinData -> ())
+
+commonMintingPolicy :: MintingPolicy
+commonMintingPolicy = $$(PlutusTx.compile [||\_ _ -> ()||])
+
+--
+
+-- | Get the @Cardano.Api.TxBody.'Value'@ from the @Cardano.Api.TxBody.'TxMintValue'@.
+getValueFromTxMintValue :: C.TxMintValue build era -> C.Value
+getValueFromTxMintValue (C.TxMintValue _ v _) = v
+getValueFromTxMintValue _ = mempty

--- a/marconi-chain-index/test-lib/Test/Gen/Marconi/ChainIndex/Mockchain.hs
+++ b/marconi-chain-index/test-lib/Test/Gen/Marconi/ChainIndex/Mockchain.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Gen.Marconi.ChainIndex.Mockchain (
+module Test.Gen.Marconi.ChainIndex.Mockchain (
   Mockchain,
   genMockchain,
   MockBlock (..),
@@ -32,15 +32,15 @@ import Data.Maybe (catMaybes)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Time.Clock.POSIX (POSIXTime)
-import Gen.Marconi.ChainIndex.Types (genHashBlockHeader, genTxOutTxContext, nonEmptySubset)
-import Gen.Marconi.ChainIndex.Types qualified as Gen
 import Hedgehog (Gen)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Internal.Gen qualified as Hedgehog.Gen
 import Hedgehog.Range qualified
 import Hedgehog.Range qualified as Range
-import Helpers (emptyTxBodyContent)
 import Test.Gen.Cardano.Api.Typed qualified as CGen
+import Test.Gen.Marconi.ChainIndex.Types (genHashBlockHeader, genTxOutTxContext, nonEmptySubset)
+import Test.Gen.Marconi.ChainIndex.Types qualified as Gen
+import Test.Helpers (emptyTxBodyContent)
 
 type Mockchain era = [MockBlock era]
 

--- a/marconi-chain-index/test-lib/Test/Gen/Marconi/ChainIndex/Types.hs
+++ b/marconi-chain-index/test-lib/Test/Gen/Marconi/ChainIndex/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE TupleSections #-}
 
-module Gen.Marconi.ChainIndex.Types (
+module Test.Gen.Marconi.ChainIndex.Types (
   nonEmptySubset,
   genBlockHeader,
   genHashBlockHeader,

--- a/marconi-chain-index/test-lib/Test/Helpers.hs
+++ b/marconi-chain-index/test-lib/Test/Helpers.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
 
-module Helpers where
+module Test.Helpers where
 
 import Cardano.Api qualified as C
 import Cardano.Api.Extended.Streaming qualified as C

--- a/marconi-chain-index/test-lib/Test/Helpers.hs
+++ b/marconi-chain-index/test-lib/Test/Helpers.hs
@@ -102,6 +102,7 @@ getAddressTxInsValue con address = do
       values = map (\case C.TxOut _ v _ _ -> C.txOutValueToLovelace v) txOuts
   pure (txIns, sum values)
 
+-- TODO: PLT-8098 use MarconiTrace IO for consistent messages?
 submitTx
   :: (C.IsCardanoEra era, MonadIO m, MonadTest m)
   => C.LocalNodeConnectInfo C.CardanoMode
@@ -115,10 +116,11 @@ submitTx localNodeConnectInfo tx = do
     liftIO $ C.submitTxToNodeLocal localNodeConnectInfo $ C.TxInMode tx eraInMode
   failOnTxSubmitFail submitResult
   where
-    failOnTxSubmitFail :: (Show a, MonadTest m) => SubmitResult a -> m ()
+    failOnTxSubmitFail :: (Show a, MonadTest m, MonadIO m) => SubmitResult a -> m ()
     failOnTxSubmitFail = \case
       SubmitFail reason -> H.failMessage GHC.callStack $ "Transaction failed: " <> show reason
-      SubmitSuccess -> pure ()
+      -- TODO: PLT-8098 convert to logInfo
+      SubmitSuccess -> liftIO $ putStrLn "Transaction submitted successfully"
 
 -- TODO: PLT-8098 delete this if unused
 

--- a/marconi-chain-index/test-lib/Test/Helpers.hs
+++ b/marconi-chain-index/test-lib/Test/Helpers.hs
@@ -314,7 +314,7 @@ unitTestWithTmpDir prefixPath =
     . workspace prefixPath
 
 {- Failure-wrapping functions analogous to those of hedgehog-extras but in MonadIO
- - for easier use of actions in Helpers with async. -}
+ - for greater flexibility. -}
 nothingFail :: (MonadIO m) => String -> Maybe a -> m a
 nothingFail err Nothing = liftIO $ throwIO $ errorCallException err
 nothingFail _ (Just x) = pure x

--- a/marconi-chain-index/test-lib/Test/Helpers.hs
+++ b/marconi-chain-index/test-lib/Test/Helpers.hs
@@ -293,6 +293,8 @@ workspace prefixPath f = GHC.withFrozenCallStack $ do
 setDarwinTmpdir :: IO ()
 setDarwinTmpdir = when (IO.os == "darwin") $ IO.setEnv "TMPDIR" "/tmp"
 
+-- TODO: PLT-8098 clean up and move/delete duplicates as needed
+
 -- * Accessors
 
 bimTxIds :: C.BlockInMode mode -> [C.TxId]

--- a/marconi-chain-index/test-lib/Test/Helpers.hs
+++ b/marconi-chain-index/test-lib/Test/Helpers.hs
@@ -62,7 +62,7 @@ getLedgerProtocolParams
   -> m (C.LedgerProtocolParameters era)
 getLedgerProtocolParams localNodeConnectInfo = do
   eraInMode <-
-    nothingFail "toEraInMode" $
+    nothingFail eraInModeFailMsg $
       C.toEraInMode (C.shelleyBasedToCardanoEra (C.shelleyBasedEra @era)) C.CardanoMode
   fmap C.LedgerProtocolParameters . leftFailM . leftFailM . liftIO $
     C.queryNodeLocalState localNodeConnectInfo Nothing $
@@ -81,7 +81,7 @@ findUTxOByAddress localNodeConnectInfo address = do
             C.QueryUTxOByAddress $
               Set.singleton (C.toAddressAny address)
   eraInMode <-
-    nothingFail "toEraInMode" $
+    nothingFail eraInModeFailMsg $
       C.toEraInMode (C.shelleyBasedToCardanoEra C.shelleyBasedEra) C.CardanoMode
   leftFailM . leftFailM . liftIO $
     C.queryNodeLocalState localNodeConnectInfo Nothing $
@@ -107,7 +107,7 @@ submitTx
   -> m ()
 submitTx localNodeConnectInfo tx = do
   eraInMode <-
-    nothingFail "toEraInMode" $
+    nothingFail eraInModeFailMsg $
       C.toEraInMode C.cardanoEra C.CardanoMode
   submitResult :: SubmitResult (C.TxValidationErrorInMode C.CardanoMode) <-
     liftIO $ C.submitTxToNodeLocal localNodeConnectInfo $ C.TxInMode tx eraInMode
@@ -252,6 +252,9 @@ leftFail (Right x) = pure x
 
 leftFailM :: (MonadIO m, Show e) => m (Either e a) -> m a
 leftFailM f = f >>= leftFail
+
+eraInModeFailMsg :: String
+eraInModeFailMsg = "Inconsistent arguments passed to Cardano.Api.toEraInMode"
 
 {- Miscellaneous accessors -}
 

--- a/marconi-chain-index/test-lib/Test/Integration.hs
+++ b/marconi-chain-index/test-lib/Test/Integration.hs
@@ -111,7 +111,7 @@ unboundedValidityRange = (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.V
 {- Transaction operations -}
 
 validateAndSubmitTx
-  :: (H.MonadTest m, MonadIO m)
+  :: (MonadIO m)
   => C.LocalNodeConnectInfo C.CardanoMode
   -> C.LedgerProtocolParameters C.BabbageEra
   -> C.NetworkId
@@ -123,7 +123,7 @@ validateAndSubmitTx
   -> m ()
 validateAndSubmitTx localNodeConnectInfo ledgerPP networkId address witnessSigningKey txbodyc lovelace = do
   txbodyValid <-
-    H.leftFail $
+    Helpers.leftFail $
       mkValidatedTxBodyWithFee ledgerPP networkId address txbodyc lovelace 1
   let keyWitness = C.makeShelleyKeyWitness txbodyValid witnessSigningKey
   signAndSubmitTx localNodeConnectInfo [keyWitness] txbodyValid
@@ -238,7 +238,7 @@ calculateFee ledgerPP nInputs nOutputs nByronKeyWitnesses nShelleyKeyWitnesses n
 context, and wait for it to be submitted over the protocol.
 -}
 signAndSubmitTx
-  :: (H.MonadTest m, MonadIO m)
+  :: (MonadIO m)
   => C.LocalNodeConnectInfo C.CardanoMode
   -> [C.KeyWitness C.BabbageEra]
   -> C.TxBody C.BabbageEra

--- a/marconi-chain-index/test-lib/Test/Integration.hs
+++ b/marconi-chain-index/test-lib/Test/Integration.hs
@@ -33,6 +33,7 @@ import Test.Helpers qualified as Helpers
 -- TODO: PLT-8098 suppress logging in node emulator? generates lots of noise.
 -- TODO: PLT-8098 keep getting could not connect with node-server.sock does not exist
 -- TODO: PLT-8098 want to run only certain number of slots in emulator
+-- TODO: PLT-8098 need to shut down the node emulator properly when the test is done.
 
 {- Node emulator setup and helpers -}
 

--- a/marconi-chain-index/test-lib/Test/Integration.hs
+++ b/marconi-chain-index/test-lib/Test/Integration.hs
@@ -191,6 +191,7 @@ mkUnbalancedTxBodyContentFromTxMintValue validityRange ledgerPP address txIns tx
     }
 
 {- Indexers and queries -}
+-- H.failMessage GHC.callStack
 
 -- | TODO: PLT-8098 blocks until you get one. use the MarconiTrace and provide a better message.
 queryFirstResultWithRetry :: Int -> Word64 -> H.Integration [a] -> H.Integration a

--- a/marconi-chain-index/test-lib/Test/Integration.hs
+++ b/marconi-chain-index/test-lib/Test/Integration.hs
@@ -1,0 +1,2 @@
+-- | Utilities for integration tests using tools from the `cardano-node-emulator` project.
+module Test.Integration where

--- a/marconi-chain-index/test-lib/Test/Integration.hs
+++ b/marconi-chain-index/test-lib/Test/Integration.hs
@@ -10,20 +10,31 @@ import Cardano.Api.Extended.IPC qualified as C
 import Cardano.Api.Shelley qualified as C
 import Cardano.Node.Emulator.Generators (knownAddresses, knownXPrvs)
 import Cardano.Node.Socket.Emulator qualified as E
+import Control.Concurrent (threadDelay)
 import Control.Monad (replicateM)
 import Control.Monad.IO.Class (liftIO)
 import Data.Bifunctor (first)
 import Data.Map qualified as Map
 import Data.Maybe (listToMaybe)
+import Data.Word (Word64)
 import Hedgehog qualified as H
 import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Gen qualified as H.Gen
 import Hedgehog.Range qualified as Range
 import Ledger.Test (testnet)
+import Marconi.ChainIndex.Types (MarconiTrace)
+import Marconi.Core qualified as Core
 import PlutusLedgerApi.V1 qualified as PlutusV1
 import PlutusLedgerApi.V2 qualified as PlutusV2
 import PlutusTx qualified
+import System.Exit (exitFailure)
 import Test.Helpers qualified as Helpers
+
+-- TODO: PLT-8098 suppress logging in node emulator? generates lots of noise.
+-- TODO: PLT-8098 keep getting could not connect with node-server.sock does not exist
+-- TODO: PLT-8098 want to run only certain number of slots in emulator
+
+{- Node emulator setup and helpers -}
 
 -- | Start a testnet using the node emulator, within the @H.'Integration'@ context.
 startTestnet
@@ -57,12 +68,72 @@ knownWitnessSigningKey = C.WitnessPaymentExtendedKey . C.PaymentExtendedSigningK
 unboundedValidityRange :: (C.TxValidityLowerBound C.BabbageEra, C.TxValidityUpperBound C.BabbageEra)
 unboundedValidityRange = (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInBabbageEra)
 
--- TODO: PLT-8098 confirm that txOuts are not used for fee calculation and modify this
--- and or mkValidatedTxBodyWithFee.
+{- Transaction operations -}
 
-{- | TODO: PLT-8098 docs and annotate inputs. Note lovelace not included yet in txout.
-Does this need to be generalized over  C.IsShelleyBasedEra era?
+validateAndSubmitTx
+  :: C.LocalNodeConnectInfo C.CardanoMode
+  -> C.LedgerProtocolParameters C.BabbageEra
+  -> C.NetworkId
+  -> C.Address C.ShelleyAddr
+  -> C.ShelleyWitnessSigningKey
+  -> C.TxBodyContent C.BuildTx C.BabbageEra
+  -> C.Lovelace
+  -- ^ Lovelace before applying fees
+  -> H.Integration ()
+validateAndSubmitTx localNodeConnectInfo ledgerPP networkId address witnessSigningKey txbodyc lovelace = do
+  txbodyValid <-
+    H.leftFail $
+      mkValidatedTxBodyWithFee ledgerPP networkId address txbodyc lovelace 1
+  let keyWitness = C.makeShelleyKeyWitness txbodyValid witnessSigningKey
+  signAndSubmitTx localNodeConnectInfo [keyWitness] txbodyValid
+
+-- TODO: PLT-8098 did the legacy impl mix up parameter order for number of Byron/Shelley key witnesses?
+-- compare with estimateTransactionFee in cardano-api, where Shelley witness number comes first.
+-- If so, why does it still validate?
+
+-- TODO: PLT-8098 make a note about how this is a shortcut for testing that does not do the
+-- full iterative transaction fee calculation. apparantly there is a utility in cardano-node for
+-- that.
+
+{- | Validate the transaction, calculate the fee and build the transaction body with txOut
+ - and fee adjustments applied.
 -}
+mkValidatedTxBodyWithFee
+  :: C.LedgerProtocolParameters C.BabbageEra
+  -> C.NetworkId
+  -> C.Address C.ShelleyAddr
+  -> C.TxBodyContent C.BuildTx C.BabbageEra
+  -> C.Lovelace
+  -- ^ Lovelace to fix in in TxOut, before applying fees
+  -> Word
+  -- ^ The number of Shelley key witnesses
+  -> Either C.TxBodyError (C.TxBody C.BabbageEra)
+mkValidatedTxBodyWithFee ledgerPP networkid address txbodyc lovelace nKeywitnesses =
+  C.createAndValidateTransactionBody txbodyc
+    >>= C.createAndValidateTransactionBody . updateTxWithFee txbodyc
+  where
+    -- TODO: PLT-8098 need to get address from txbody or somewhere
+    -- Take the txMintValue and add the fee-adjusted lovace to build a single TxOut.
+    rebuildTxOutWithFee
+      :: C.TxBodyContent C.BuildTx C.BabbageEra -> C.Lovelace -> C.TxOut C.CtxTx C.BabbageEra
+    rebuildTxOutWithFee txbodyc' fee =
+      Helpers.mkTxOut address $
+        C.lovelaceToValue (lovelace - fee) <> Helpers.getValueFromTxMintValue (C.txMintValue txbodyc')
+    -- TODO: PLT-8098 this consistently produces a "fee too small" error. the fee is off by < 1k
+    -- It uses cardano-ledger's transaction fee calculation function. does that differ from node
+    -- emulators?
+    -- calculateFee :: C.TxBody C.BabbageEra -> C.Lovelace
+    -- calculateFee txbody' = C.evaluateTransactionFee (C.unLedgerProtocolParameters ledgerPP) txbody' nKeywitnesses 0
+    updateTxWithFee
+      :: C.TxBodyContent C.BuildTx C.BabbageEra
+      -> C.TxBody C.BabbageEra
+      -> C.TxBodyContent C.BuildTx C.BabbageEra
+    updateTxWithFee txbodyc' txbody' =
+      C.setTxOuts [rebuildTxOutWithFee txbodyc' fee] $
+        C.setTxFee (C.TxFeeExplicit C.TxFeesExplicitInBabbageEra fee) txbodyc'
+      where
+        fee = calculateFee ledgerPP (length $ C.txIns txbodyc') 1 0 1 networkid txbody'
+
 mkUnbalancedTxBodyContentFromTxMintValue
   :: (C.TxValidityLowerBound C.BabbageEra, C.TxValidityUpperBound C.BabbageEra)
   -> C.LedgerProtocolParameters C.BabbageEra
@@ -78,60 +149,58 @@ mkUnbalancedTxBodyContentFromTxMintValue validityRange ledgerPP address txIns tx
     , C.txInsCollateral = C.TxInsCollateral C.CollateralInBabbageEra txIns
     }
 
--- TODO: PLT-8098 did the legacy impl mix up parameter order for number of Byron/Shelley key witnesses?
--- compare with estimateTransactionFee in cardano-api, where Shelley witness number comes first.
--- If so, why does it still validate?
+-- | TODO: PLT-8098 blocks until you get one. use the MarconiTrace and provide a better message.
+queryFirstResultWithRetry :: Int -> Word64 -> H.Integration [a] -> H.Integration a
+queryFirstResultWithRetry ntries _ _
+  | ntries <= 0 =
+      liftIO $
+        putStrLn "Max integration test query tries reached" >> exitFailure
+queryFirstResultWithRetry ntries delay action = do
+  res <- listToMaybe <$> action
+  case res of
+    Nothing ->
+      liftIO (threadDelay $ fromIntegral delay)
+        >> queryFirstResultWithRetry (ntries - 1) delay action
+    Just x -> pure x
 
--- TODO: PLT-8098 make a note about how this is a shortcut for testing that does not do the
--- full iterative transaction fee calculation. apparantly there is a utility in cardano-node for
--- that.
+-- TODO: PLT-8098 confirm that txOuts are not used for fee calculation and modify this
+-- and or mkValidatedTxBodyWithFee.
 
-{- | Validate the transaction, calculate the fee and build the transaction body with txOut
- - and fee adjustments applied.
--}
-mkValidatedTxBodyWithFee
-  :: C.LedgerProtocolParameters C.BabbageEra
-  -> C.Address C.ShelleyAddr
-  -> C.TxBodyContent C.BuildTx C.BabbageEra
+-- TODO: PLT-8098 taken from legacy. review and remove if not needed
+calculateFee
+  :: (C.IsShelleyBasedEra era)
+  => C.LedgerProtocolParameters era
+  -> Int
+  -> Int
+  -> Int
+  -> Int
+  -> C.NetworkId
+  -> C.TxBody era
   -> C.Lovelace
-  -- ^ Lovelace to fix in in TxOut, before applying fees
-  -> Word
-  -- ^ The number of Shelley key witnesses
-  -> Either C.TxBodyError (C.TxBody C.BabbageEra)
-mkValidatedTxBodyWithFee ledgerPP address txbodyc lovelace nKeywitnesses =
-  C.createAndValidateTransactionBody txbodyc
-    >>= C.createAndValidateTransactionBody . updateTxWithFee txbodyc
-  where
-    -- TODO: PLT-8098 need to get address from txbody or somewhere
-    -- Take the txMintValue and add the fee-adjusted lovace to build a single TxOut.
-    rebuildTxOutWithFee
-      :: C.TxBodyContent C.BuildTx C.BabbageEra -> C.Lovelace -> C.TxOut C.CtxTx C.BabbageEra
-    rebuildTxOutWithFee txbodyc' fee =
-      Helpers.mkTxOut address $
-        C.lovelaceToValue (lovelace - fee) <> Helpers.getValueFromTxMintValue (C.txMintValue txbodyc')
-    calculateFee :: C.TxBody C.BabbageEra -> C.Lovelace
-    calculateFee txbody' = C.evaluateTransactionFee (C.unLedgerProtocolParameters ledgerPP) txbody' nKeywitnesses 0
-    -- Sets the txFee field as well as the txOuts field to a single TxOut with the fee-adjusted
-    -- lovelace
-    updateTxWithFee
-      :: C.TxBodyContent C.BuildTx C.BabbageEra
-      -> C.TxBody C.BabbageEra
-      -> C.TxBodyContent C.BuildTx C.BabbageEra
-    updateTxWithFee txbodyc' txbody' =
-      C.setTxOuts [rebuildTxOutWithFee txbodyc' (calculateFee txbody')] $
-        C.setTxFee (C.TxFeeExplicit C.TxFeesExplicitInBabbageEra $ calculateFee txbody') txbodyc'
-
---
+calculateFee ledgerPP nInputs nOutputs nByronKeyWitnesses nShelleyKeyWitnesses networkId txBody =
+  let apiPP = C.fromLedgerPParams C.shelleyBasedEra $ C.unLedgerProtocolParameters ledgerPP
+   in C.estimateTransactionFee
+        networkId
+        (C.protocolParamTxFeeFixed apiPP)
+        (C.protocolParamTxFeePerByte apiPP)
+        (C.makeSignedTransaction [] txBody)
+        nInputs
+        nOutputs
+        -- TODO: PLT-8098 note the swap
+        nShelleyKeyWitnesses
+        nByronKeyWitnesses
 
 {- | TODO: PLT-8098 sign the validated tx body and submit to node emulator within H.Integration
-context
+context, and wait for it to be submitted over the protocol.
 -}
 signAndSubmitTx
   :: C.LocalNodeConnectInfo C.CardanoMode
   -> [C.KeyWitness C.BabbageEra]
   -> C.TxBody C.BabbageEra
   -> H.Integration ()
-signAndSubmitTx info witnesses = Helpers.submitTx info . C.makeSignedTransaction witnesses
+signAndSubmitTx info witnesses txbody = Helpers.submitAwaitTx info (tx, txbody)
+  where
+    tx = C.makeSignedTransaction witnesses txbody
 
 -- TODO: PLT-8098 All below copied from legacy. Reevaluate if needed.
 -- They should go in a different module.

--- a/marconi-chain-index/test-lib/Test/Integration.hs
+++ b/marconi-chain-index/test-lib/Test/Integration.hs
@@ -86,6 +86,8 @@ mkLocalNodeInfo tempAbsBasePath slotLength = do
                 }
           , E.Types.nscSocketPath = socketPathAbs
           , E.Types.nscNetworkId = networkId
+          , -- TODO: PLT-8098 default is 100. this is for evaluating interaction with catchup
+            E.Types.nscKeptBlocks = 1_000
           }
   pure (config, localNodeConnectInfo)
 

--- a/marconi-chain-index/test-lib/Test/Integration.hs
+++ b/marconi-chain-index/test-lib/Test/Integration.hs
@@ -1,2 +1,121 @@
+{-# LANGUAGE TupleSections #-}
+
 -- | Utilities for integration tests using tools from the `cardano-node-emulator` project.
 module Test.Integration where
+
+import Cardano.Api.Extended.IPC qualified as C
+import Cardano.Api.Shelley qualified as C
+import Cardano.Node.Emulator.Generators (knownAddresses, knownXPrvs)
+import Cardano.Node.Socket.Emulator qualified as E
+import Control.Monad.IO.Class (liftIO)
+import Data.Maybe (listToMaybe)
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Ledger.Test (testnet)
+import Test.Helpers qualified as Helpers
+
+-- | Start a testnet using the node emulator, within the @H.'Integration'@ context.
+startTestnet
+  :: FilePath
+  -> H.Integration (C.LocalNodeConnectInfo C.CardanoMode, C.NetworkId, FilePath)
+startTestnet tempAbsBasePath = do
+  let socketPathAbs = tempAbsBasePath <> "/node-server.sock"
+      -- TODO: PLT-8098 leftover from legacy code: "any other networkId doesn't work"
+      networkId = testnet
+      -- In milliseconds, shorter than the default to make the tests go faster
+      slotLength = 10
+      localNodeConnectInfo = C.mkLocalNodeConnectInfo networkId socketPathAbs
+  liftIO $ E.startTestnet socketPathAbs slotLength networkId
+  pure (localNodeConnectInfo, networkId, socketPathAbs)
+
+-- | Take the first @C.'ShelleyAddr'@ of @Cardano.Node.Emulator.Generators.'knownAddresses'@.
+knownShelleyAddress :: Maybe (C.Address C.ShelleyAddr)
+knownShelleyAddress = undefined
+
+-- | Take the first @C.'WitnessPaymentExtendedKey'@ from 'knownXPrvs'.
+knownKeyWitness :: Maybe C.ShelleyWitnessSigningKey
+knownKeyWitness = C.WitnessPaymentExtendedKey . C.PaymentExtendedSigningKey <$> listToMaybe knownXPrvs
+
+-- | Unbounded validity range for transaction validation in the Babbage era.
+unboundedValidityRange :: (C.TxValidityLowerBound C.BabbageEra, C.TxValidityUpperBound C.BabbageEra)
+unboundedValidityRange = (C.TxValidityNoLowerBound, C.TxValidityNoUpperBound C.ValidityNoUpperBoundInBabbageEra)
+
+-- TODO: PLT-8098 confirm that txOuts are not used for fee calculation and modify this
+-- and or mkValidatedTxBodyWithFee.
+
+{- | TODO: PLT-8098 docs and annotate inputs. Note lovelace not included yet in txout.
+Does this need to be generalized over  C.IsShelleyBasedEra era?
+-}
+mkUnbalancedTxBodyContentFromTxMintValue
+  :: (C.TxValidityLowerBound C.BabbageEra, C.TxValidityUpperBound C.BabbageEra)
+  -> C.LedgerProtocolParameters C.BabbageEra
+  -> C.Address C.ShelleyAddr
+  -> [C.TxIn]
+  -> C.TxMintValue C.BuildTx C.BabbageEra
+  -> C.TxBodyContent C.BuildTx C.BabbageEra
+mkUnbalancedTxBodyContentFromTxMintValue validityRange ledgerPP address txIns txMintValue =
+  (Helpers.emptyTxBodyContent validityRange ledgerPP)
+    { C.txIns = map (,C.BuildTxWith $ C.KeyWitness C.KeyWitnessForSpending) txIns
+    , C.txOuts = [Helpers.mkTxOut address $ Helpers.getValueFromTxMintValue txMintValue]
+    , C.txMintValue = txMintValue
+    , C.txInsCollateral = C.TxInsCollateral C.CollateralInBabbageEra txIns
+    }
+
+-- TODO: PLT-8098 did the legacy impl mix up parameter order for number of Byron/Shelley key witnesses?
+-- compare with estimateTransactionFee in cardano-api, where Shelley witness number comes first.
+-- If so, why does it still validate?
+
+-- TODO: PLT-8098 make a note about how this is a shortcut for testing that does not do the
+-- full iterative transaction fee calculation. apparantly there is a utility in cardano-node for
+-- that.
+
+{- | Validate the transaction, calculate the fee and build the transaction body with txOut
+ - and fee adjustments applied.
+-}
+mkValidatedTxBodyWithFee
+  :: C.LedgerProtocolParameters C.BabbageEra
+  -> C.Address C.ShelleyAddr
+  -> C.TxBodyContent C.BuildTx C.BabbageEra
+  -> C.Lovelace
+  -- ^ Lovelace to fix in in TxOut, before applying fees
+  -> Word
+  -- ^ The number of Shelley key witnesses
+  -> Either C.TxBodyError (C.TxBody C.BabbageEra)
+mkValidatedTxBodyWithFee ledgerPP address txbodyc lovelace nKeywitnesses =
+  C.createAndValidateTransactionBody txbodyc
+    >>= C.createAndValidateTransactionBody . updateTxWithFee txbodyc
+  where
+    -- TODO: PLT-8098 need to get address from txbody or somewhere
+    -- Take the txMintValue and add the fee-adjusted lovace to build a single TxOut.
+    rebuildTxOutWithFee
+      :: C.TxBodyContent C.BuildTx C.BabbageEra -> C.Lovelace -> C.TxOut C.CtxTx C.BabbageEra
+    rebuildTxOutWithFee txbodyc' fee =
+      Helpers.mkTxOut address $
+        C.lovelaceToValue (lovelace - fee) <> Helpers.getValueFromTxMintValue (C.txMintValue txbodyc')
+    calculateFee :: C.TxBody C.BabbageEra -> C.Lovelace
+    calculateFee txbody' = C.evaluateTransactionFee (C.unLedgerProtocolParameters ledgerPP) txbody' nKeywitnesses 0
+    -- Sets the txFee field as well as the txOuts field to a single TxOut with the fee-adjusted
+    -- lovelace
+    updateTxWithFee
+      :: C.TxBodyContent C.BuildTx C.BabbageEra
+      -> C.TxBody C.BabbageEra
+      -> C.TxBodyContent C.BuildTx C.BabbageEra
+    updateTxWithFee txbodyc' txbody' =
+      C.setTxOuts [rebuildTxOutWithFee txbodyc' (calculateFee txbody')] $
+        C.setTxFee (C.TxFeeExplicit C.TxFeesExplicitInBabbageEra $ calculateFee txbody') txbodyc'
+
+--
+
+{- | TODO: PLT-8098 sign the validated tx body and submit to node emulator within H.Integration
+context
+-}
+signAndSubmitTx
+  :: C.LocalNodeConnectInfo C.CardanoMode
+  -> [C.KeyWitness C.BabbageEra]
+  -> C.TxBody C.BabbageEra
+  -> H.Integration ()
+signAndSubmitTx info witnesses = Helpers.submitTx info . C.makeSignedTransaction witnesses
+
+-- | TODO: PLT-8098 put generators in a Gen submodule as with legacy
+genTxMintValue :: H.Gen (C.TxMintValue C.BuildTx C.BabbageEra)
+genTxMintValue = undefined

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Api/Gen.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Api/Gen.hs
@@ -2,7 +2,6 @@ module Spec.Marconi.ChainIndex.Api.Gen where
 
 import Cardano.Api qualified as C
 import Data.String (fromString)
-import Gen.Marconi.ChainIndex.Types qualified as Gen
 import Hedgehog (
   Gen,
  )
@@ -13,6 +12,7 @@ import Marconi.ChainIndex.Api.JsonRpc.Endpoint.MintBurnToken (
   GetBurnTokenEventsParams (GetBurnTokenEventsParams),
  )
 import Test.Gen.Cardano.Api.Typed qualified as CGen
+import Test.Gen.Marconi.ChainIndex.Types qualified as Gen
 
 genBurnTokenEventResult :: Maybe C.HashableScriptData -> Gen BurnTokenEventResult
 genBurnTokenEventResult hsd =

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers.hs
@@ -31,7 +31,7 @@ propTests =
       , BlockInfo.propTests
       , ChainTip.tests
       , UtxoQuery.tests
-      , MintTokenEvent.tests
+      , MintTokenEvent.propTests
       ]
 
 -- | Tests whose number of runs is set in the test definition, e.g. to 1.
@@ -40,4 +40,5 @@ unitTests =
   testGroup
     "Spec.Marconi.ChainIndex.Indexer.unitTests"
     [ BlockInfo.unitTests
+    , MintTokenEvent.unitTests
     ]

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers.hs
@@ -13,14 +13,31 @@ import Test.Tasty.Hedgehog (HedgehogTestLimit (HedgehogTestLimit))
 
 tests :: TestTree
 tests =
+  testGroup
+    "Spec.Marconi.ChainIndex.Indexer"
+    [ unitTests
+    , propTests
+    ]
+
+-- | Genuine property tests, with an arbitrary number of test runs.
+propTests :: TestTree
+propTests =
   localOption (HedgehogTestLimit $ Just 200) $
     testGroup
-      "Spec.Marconi.ChainIndex.Indexer"
+      "Spec.Marconi.ChainIndex.Indexer.propTests"
       [ Utxo.tests
       , Spent.tests
       , Datum.tests
-      , BlockInfo.tests
+      , BlockInfo.propTests
       , ChainTip.tests
       , UtxoQuery.tests
       , MintTokenEvent.tests
       ]
+
+-- | Tests whose number of runs is set in the test definition, e.g. to 1.
+unitTests :: TestTree
+unitTests =
+  testGroup
+    "Spec.Marconi.ChainIndex.Indexer.unitTests"
+    [ BlockInfo.unitTests
+    ]

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/BlockInfo.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/BlockInfo.hs
@@ -148,7 +148,6 @@ endToEndBlockInfo = Helpers.unitTestWithTmpDir "." $ \tempPath -> do
 
   {- NOTE: PLT-8098
    startTestnet does not shutdown when the test is done.
-   See Cardano.Node.Socket.Emulator.Server.runServerNode.
    As a temporary measure to avoid polluting the test output, Integration.startTestnet squashes all
    SlotAdd log messages.
    -}

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/BlockInfo.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/BlockInfo.hs
@@ -13,8 +13,6 @@ import Control.Lens ((^.))
 import Data.Aeson qualified as Aeson
 import Data.Maybe (mapMaybe)
 import Data.Time qualified as Time
-import Gen.Marconi.ChainIndex.Mockchain qualified as Gen
-import Gen.Marconi.ChainIndex.Types qualified as CGen
 import Hedgehog ((===))
 import Hedgehog qualified
 import Hedgehog.Gen qualified
@@ -22,6 +20,8 @@ import Hedgehog.Range qualified
 import Marconi.ChainIndex.Indexers.BlockInfo (BlockInfo (BlockInfo))
 import Marconi.ChainIndex.Indexers.BlockInfo qualified as BlockInfo
 import Marconi.Core qualified as Core
+import Test.Gen.Marconi.ChainIndex.Mockchain qualified as Gen
+import Test.Gen.Marconi.ChainIndex.Types qualified as CGen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/BlockInfo.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/BlockInfo.hs
@@ -147,14 +147,15 @@ endToEndBlockInfo = Helpers.unitTestWithTmpDir "." $ \tempPath -> do
   -- Start the testnet and indexer, and run the query.
 
   {- NOTE: PLT-8098
-   startTestnet returns immediately but runIndexer runs indefinitely, hence the use of
-   race and leftFail below. startTestnet does not shutdown when the test is done.
+   startTestnet does not shutdown when the test is done.
    See Cardano.Node.Socket.Emulator.Server.runServerNode.
    As a temporary measure to avoid polluting the test output, Integration.startTestnet squashes all
    SlotAdd log messages.
    -}
+  Hedgehog.evalIO $ Integration.startTestnet nscConfig
+
   res <- Hedgehog.evalIO $
-    Async.race (Integration.startTestnet nscConfig >> Runner.runIndexer config coordinator) $
+    Async.race (Runner.runIndexer config coordinator) $
       do
         threadDelay 5_000_000
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/ChainTip.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/ChainTip.hs
@@ -12,13 +12,13 @@ import Control.Exception (throw)
 import Control.Lens qualified as Lens
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Trans.Except (ExceptT, runExceptT)
-import Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Hedgehog ((===))
 import Hedgehog qualified
 import Marconi.ChainIndex.Indexers.ChainTip (ChainTipIndexer)
 import Marconi.ChainIndex.Indexers.ChainTip qualified as ChainTip
 import Marconi.Core qualified as Core
 import System.IO.Temp qualified as Tmp
+import Test.Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Datum.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Datum.hs
@@ -19,11 +19,11 @@ import Control.Lens qualified as Lens
 import Data.Aeson qualified as Aeson
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
-import Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Hedgehog ((===))
 import Hedgehog qualified
 import Hedgehog.Gen qualified
 import Test.Gen.Cardano.Api.Typed qualified as CGen
+import Test.Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintTokenEvent.hs
@@ -11,7 +11,6 @@ module Spec.Marconi.ChainIndex.Indexers.MintTokenEvent (
 import Cardano.Api qualified as C
 import Cardano.Api.Extended.Gen qualified as CEGen
 import Cardano.Api.Extended.Streaming (BlockEvent (BlockEvent), ChainSyncEvent)
-import Control.Concurrent (threadDelay)
 import Control.Concurrent qualified as Concurrent
 import Control.Concurrent.Async qualified as Async
 import Control.Lens (over, toListOf, view, (^.))
@@ -25,7 +24,6 @@ import Data.List qualified as List
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (mapMaybe)
-import Data.Void (Void)
 import Hedgehog (Gen, PropertyT, (===))
 import Hedgehog qualified as H
 import Hedgehog.Extras qualified as H
@@ -55,10 +53,8 @@ import Marconi.ChainIndex.Indexers.Worker (
   StandardWorkerConfig (StandardWorkerConfig),
  )
 import Marconi.ChainIndex.Logger (defaultStdOutLogger, mkMarconiTrace)
-import Marconi.ChainIndex.Node.Client.Retry (withNodeConnectRetry)
 import Marconi.ChainIndex.Runner qualified as Runner
 import Marconi.ChainIndex.Types (RetryConfig (RetryConfig), TxIndexInBlock (TxIndexInBlock))
-import Marconi.ChainIndex.Utils qualified as Utils
 import Marconi.Core qualified as Core
 import Test.Gen.Cardano.Api.Typed qualified as CGen
 import Test.Gen.Marconi.ChainIndex.Types qualified as Gen
@@ -683,6 +679,7 @@ endToEndMintTokenEvent = H.withShrinks 0 $
 
           -- TODO: PLT-8098 this fails to connect even though the indexer seems to sync fine. Why?
           -- could hard-code param from cardano-node (currently 100) but not ideal.
+          -- it is not actually needed here but is puzzling
 
           -- Taken from 'Run.run'
           -- securityParam <-
@@ -696,7 +693,7 @@ endToEndMintTokenEvent = H.withShrinks 0 $
                   marconiTrace
                   mintEventPreprocessor
                   retryConfig
-                  -- TODO: PLT-8098 see todo about security param
+                  -- No rollbacks, so security parameter is arbitrary
                   100
                   networkId
                   C.ChainPointAtGenesis

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintTokenEvent.hs
@@ -5,7 +5,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Spec.Marconi.ChainIndex.Indexers.MintTokenEvent (
-  tests,
+  propTests,
+  unitTests,
 ) where
 
 import Cardano.Api qualified as C
@@ -68,8 +69,11 @@ import Test.Integration qualified as Integration
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 
-tests :: TestTree
-tests =
+{- | Genuine property tests, in which more than one test can be run and
+ - options on the number of tests might be configured by the caller.
+-}
+propTests :: TestTree
+propTests =
   testGroup
     "Spec.Marconi.ChainIndex.Indexers.MintTokenEvent"
     [ testGroup
@@ -137,7 +141,17 @@ tests =
             "propRunnerDoesntTrackUnselectedAssetId"
             propRunnerDoesntTrackUnselectedAssetId
         ]
-    , testGroup
+    ]
+
+{- | Unit tests, defined with the Hedgehog API.
+ - Tests defined @Hedgehog.'propertyOnce'@ or otherwise with
+   a fixed number of test runs that should not be changed.
+-}
+unitTests :: TestTree
+unitTests =
+  testGroup
+    "Spec.Marconi.ChainIndex.Indexers.MintTokenEvent"
+    [ testGroup
         "End-to-end indexer tests with cardano-node-emulator"
         [ testPropertyNamed
             "Indexing a testnet and then submitting a transaction with a mint event to it has the indexer receive that mint event"
@@ -663,9 +677,6 @@ endToEndMintTokenEvent = H.withShrinks 0 $
            SlotAdd log messages.
            -}
 
-          -- TODO: PLT-8098 convert this and the blockinfo one to use the corresponding functions from lifted-async, which
-          -- propertyT implements. that way you can do everything with hedgehog in the race as well
-          -- and clean some things up by putting the tests in there and using race_.
           res <- H.evalIO
             $ Async.race
               (Integration.startTestnet nscConfig >> Runner.runIndexer config coordinator)

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintTokenEvent.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/MintTokenEvent.hs
@@ -21,7 +21,6 @@ import Data.List qualified as List
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (mapMaybe)
-import Gen.Marconi.ChainIndex.Types qualified as Gen
 import Hedgehog (Gen, PropertyT, (===))
 import Hedgehog qualified as H
 import Hedgehog.Gen qualified as H.Gen
@@ -51,6 +50,7 @@ import Marconi.ChainIndex.Indexers.Worker (
 import Marconi.ChainIndex.Types (TxIndexInBlock (TxIndexInBlock))
 import Marconi.Core qualified as Core
 import Test.Gen.Cardano.Api.Typed qualified as CGen
+import Test.Gen.Marconi.ChainIndex.Types qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Spent.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Spent.hs
@@ -15,13 +15,13 @@ import Data.Aeson qualified as Aeson
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (mapMaybe)
-import Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Hedgehog ((===))
 import Hedgehog qualified
 import Hedgehog.Gen qualified
 import Marconi.ChainIndex.Indexers.Spent qualified as Spent
 import Marconi.Core qualified as Core
 import Test.Gen.Cardano.Api.Typed qualified as CGen
+import Test.Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/Utxo.hs
@@ -18,7 +18,6 @@ import Data.List ((\\))
 import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Maybe (mapMaybe)
-import Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Hedgehog ((===))
 import Hedgehog qualified
 import Hedgehog.Gen qualified
@@ -34,6 +33,7 @@ import Marconi.ChainIndex.Logger (nullTracer)
 import Marconi.ChainIndex.Types (TxIndexInBlock (TxIndexInBlock))
 import Marconi.Core qualified as Core
 import Test.Gen.Cardano.Api.Typed qualified as CGen
+import Test.Gen.Marconi.ChainIndex.Mockchain qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/UtxoQuery.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Indexers/UtxoQuery.hs
@@ -27,8 +27,6 @@ import Control.Monad (void)
 import Data.Aeson qualified as Aeson
 import Data.List qualified as List
 import Data.Maybe (fromMaybe)
-import Gen.Marconi.ChainIndex.Mockchain qualified as Gen
-import Gen.Marconi.ChainIndex.Types qualified as CGen
 import Hedgehog (Property)
 import Hedgehog qualified
 import Hedgehog.Gen qualified
@@ -39,6 +37,8 @@ import Spec.Marconi.ChainIndex.Indexers.Datum qualified as Test.Datum
 import Spec.Marconi.ChainIndex.Indexers.Spent qualified as Test.Spent
 import Spec.Marconi.ChainIndex.Indexers.Utxo qualified as Test.Utxo
 import Test.Gen.Cardano.Api.Typed qualified as CGen
+import Test.Gen.Marconi.ChainIndex.Mockchain qualified as Gen
+import Test.Gen.Marconi.ChainIndex.Types qualified as CGen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/marconi-chain-index/test/Spec/Marconi/ChainIndex/Orphans.hs
+++ b/marconi-chain-index/test/Spec/Marconi/ChainIndex/Orphans.hs
@@ -7,11 +7,11 @@ import Data.Aeson qualified as Aeson
 import Database.SQLite.Simple.FromField qualified as SQL
 import Database.SQLite.Simple.Internal qualified as SQL
 import Database.SQLite.Simple.ToField qualified as SQL
-import Gen.Marconi.ChainIndex.Types qualified as Gen
 import Hedgehog (Property, forAll, property, tripping)
 import Hedgehog.Range qualified as Range
 import Marconi.ChainIndex.Orphans ()
 import Test.Gen.Cardano.Api.Typed qualified as CGen
+import Test.Gen.Marconi.ChainIndex.Types qualified as Gen
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)
 

--- a/marconi-starter/test/Spec/Marconi/Starter/AddressCount.hs
+++ b/marconi-starter/test/Spec/Marconi/Starter/AddressCount.hs
@@ -11,7 +11,6 @@ import Data.Map qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Gen.Marconi.ChainIndex.Types (genAddressInEra, genBlockNo, genChainPoint', genSlotNo)
 import Hedgehog (Gen, Property, PropertyT, (===))
 import Hedgehog qualified as H
 import Hedgehog.Gen qualified as Gen
@@ -39,6 +38,7 @@ import Marconi.Starter.Indexers.AddressCount (
   AddressCountQuery (AddressCountQuery),
   mkAddressCountSqliteIndexer,
  )
+import Test.Gen.Marconi.ChainIndex.Types (genAddressInEra, genBlockNo, genChainPoint', genSlotNo)
 
 hprop_generator_preconditions :: Property
 hprop_generator_preconditions = H.property $ do


### PR DESCRIPTION
Adds some end-to-end tests using cardano-node-emulator for simple queries of marconi-chain-index:

* BlockInfo indexer
* MintTokenEvent indexer

To support that, it

* Changes the module structure of test-lib slightly for better organization
* Splits unit and property tests (both run via hedgehog), to avoid unintentionally overriding the 'propertyOnce' configuration for the unit tests.
* Suppresses 'SlotAdd' logging information from the node emulator to avoid polluting test output.

Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [X] Targeting main unless this is a cherry-pick backport
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
