### PR TITLE
Update nix documentation the README

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,19 +14,15 @@ If you _really_ cannot use Nix and still want to contribute to Marconi, then xre
 
 === Installing and setting up Nix
 
-This repository uses nix to provide the development and build environment.
+This repository uses Nix to provide the development and build environment.
 
-If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
-the flake config values to enable access to our binary caches.   
+For instructions on how to install and configure nix (including how to enable access to our binary caches), refer to link:https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md[this document]. 
 
-The nix code is based on a template from the 
-link:https://github.com/input-output-hk/iogx/[IOGX flake]
-For instructions on how to install and configure nix (including how to enable 
-access to our binary caches), and how keep the flake inputs up to date, refer to 
-link:https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix[this section]
-of the IOGX manual.
+If you already have Nix installed and configured, you may enter the development shell by running `nix develop`.
 
-If you are committing code outside nix develop, you will get this error:
+=== Note on pre-commit hooks
+
+If you are committing code outside `nix develop`, you will get this error:
 
 ----
 pre-commit not found. Did you forget to activate your virtualenv?

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -16,7 +16,7 @@ If you _really_ cannot use Nix and still want to contribute to Marconi, then xre
 
 This repository uses Nix to provide the development and build environment.
 
-For instructions on how to install and configure nix (including how to enable access to our binary caches), refer to link:https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md[this document]. 
+For instructions on how to install and configure Nix (including how to enable access to our binary caches), refer to link:https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md[this document]. 
 
 If you already have Nix installed and configured, you may enter the development shell by running `nix develop`.
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -14,88 +14,17 @@ If you _really_ cannot use Nix and still want to contribute to Marconi, then xre
 
 === Installing and setting up Nix
 
-This project uses Flakes, so you must have Nix version `>= 2.4` installed.
+This repository uses nix to provide the development and build environment.
 
-Either upgrade or install https://nixos.org/[Nix] following the instructions on https://nixos.org/download.html[its website].
+If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
+the flake config values to enable access to our binary caches.   
 
-On Linux this command should suffice: `sh <(curl -L https://nixos.org/nix/install) --daemon`
-
-=== How to get a shell environment with tools
-
-To enter the development shell run the following command in the root directory:
-
-`nix develop`
-
-If you receive this message:
-
-`error: experimental Nix feature 'nix-command' is disabled; use '--extra-experimental-features nix-command' to override`
-
-Then try this:
-
-`nix develop --extra-experimental-features 'nix-command flakes'`
-
-You may now choose to edit your `/etc/nix/nix.conf` (global) or `~/.config/nix/nix.conf` (you must be a https://nixos.org/nix/manual/#ssec-multi-user[trusted user] to do this) by appending the following line:
-
-`extra-experimental-features = nix-command flakes`
-
-If you do so you will be able to enter the development shell by running `nix develop`.
-
-If you are a VSCode user, you may want to start your development session by running:
-
-`nix develop --command code`
-
-If this is your first time running `nix develop`, you may be asked the following:
-```
-do you want to allow configuration setting 'allow-import-from-derivation' to be set to 'true' (y/N)? y
-do you want to permanently mark this value as trusted (y/N)? y
-```
-Please type `y` to this and all subsequent prompts to make life easy for yourself.
-
-IMPORTANT: *It is particularly important to accept the `extra-substituters` and `extra-trusted-public-keys` settings, which will grant access to our Nix binary cache.*
-
-At this point and if this is your first time running `nix develop` then Nix will download, build and install a copious amout of dependencies.
-
-It is not uncommon for this process to take a couple of hours and to write tens of GBs to the `/nix/store`.
-
-*Rest assured that this only happens the very first time you run `nix develop`.*
-
-However you should pay attention to the output of `nix develop`: if you notice that you are _building_ GHC, it is likely that your caches have not been configured correctly.
-
-Accepting the configuration settings as outlined above should be sufficient to avoid this, however if your caches are still broken, you may try to append the following lines to `/etc/nix/nix.conf` and/or `~/.config/nix/nix.conf`:
-
-----
-substituters = https://cache.iog.io https://cache.nixos.org/
-trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-extra-experimental-features = nix-command flakes
-----
-
-On NixOS, set the following NixOS options:
-----
-nix = {
-  binaryCaches          = [ "https://cache.iog.io" ];
-  binaryCachePublicKeys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
-};
-----
-
-You will need to restart the nix-daemon on non-NixOS for the changes to take effect, or just restart your machine.
-
-IMPORTANT: If you are on NixOS or otherwise using a multi-user Nix install, you **must** be a trusted user to set substituters. If you are not a trusted user, enabling the options prompted by the flake will have no effect (non-trusted users are disallowed from doing this).
-
-On non-NixOS systems, add the following to the system-wide configuration (`/etc/nix/nix.conf`):
-
-```
-trusted-users = <username> root
-```
-
-You can also use a group name by prefixing it with `@`, e.g. to add all members of the `wheel` group:
-
-```
-trusted-users = @wheel root
-```
-
-On NixOS, add the user/group name to the list under [`nix.settings.trusted-users`](https://search.nixos.org/options?show=nix.settings.trusted-users).
-
-=== Note on pre-commit hooks
+The nix code is based on a template from the 
+link:https://github.com/input-output-hk/iogx/[IOGX flake]
+For instructions on how to install and configure nix (including how to enable 
+access to our binary caches), and how keep the flake inputs up to date, refer to 
+link:https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix[this section]
+of the IOGX manual.
 
 If you are committing code outside nix develop, you will get this error:
 

--- a/doc/read-the-docs-site/README.md
+++ b/doc/read-the-docs-site/README.md
@@ -1,4 +1,4 @@
-# Plutus documentation site
+# Marconi documentation site
 
 This is a sphinx site.
 
@@ -6,11 +6,13 @@ Run `nix develop` to enter a development shell with `sphinx-build` and `sphinx-a
 
 The following commands are also available:
 
-- `build-readthedocs-site`
-  Build the docs locally in `_build/index.html`
-- `serve-readthedocs-site`
+- `develop-rtd-site`          
   Start a development server with live reload on `http://localhost:8000`
+- `build-rtd-site`             
+  Build the docs locally in `_build/index.html`
+- `serve-rtd-site`   
+  Build the full site with nix (including Haddock) and serve it on `http://localhost:8002`
 
-The doc site from main is built automatically and hosted [here](https://marconi.readthedocs.io).
+The doc site from main is built automatically and hosted [here](https://marconi.readthedocs.io/en/latest).
 
 Additionally, the site is built for all PRs, and a link to a preview can be found in the PR statuses.

--- a/flake.lock
+++ b/flake.lock
@@ -1418,15 +1418,16 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "nixpkgs-stable": "nixpkgs-stable",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1698052499,
-        "narHash": "sha256-FoXYUaknObBfNoYaWt06Aq4pV+QvI0h1EXdzK4yutEg=",
+        "lastModified": 1699460731,
+        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "98685364d646db5e7cb64bcbe9d455e8f2bb99d7",
+        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
         "type": "github"
       },
       "original": {
@@ -2076,6 +2077,22 @@
     },
     "nixpkgs-stable": {
       "locked": {
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
@@ -2549,7 +2566,7 @@
         "flake-utils": "flake-utils_10",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_11",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
         "lastModified": 1696846637,

--- a/flake.lock
+++ b/flake.lock
@@ -1423,11 +1423,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1699460731,
-        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
+        "lastModified": 1699537966,
+        "narHash": "sha256-MGGza+vZDRjKj31WhQJDt7CqVVdrFkgkXIcqr0gDiU8=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
+        "rev": "c6ce7f034717ed0c0e9c6dd8fa2f898a15439627",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Instructions on how to install & upgrade nix and how to setup the binary caches are now included in the [relevant section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix) of the IOGX manual. 
This PR updates various files and documents that reference nix. 
