### PR TITLE
Disable the read-the-docs nix build on Darwin

### DIFF
--- a/nix/project.nix
+++ b/nix/project.nix
@@ -96,7 +96,7 @@ let
     includeMingwW64HydraJobs = false;
     shellArgs = repoRoot.nix.shell;
     readTheDocs = {
-      enable = true;
+      enable = !pkgs.stdenv.isDarwin;
       siteFolder = "doc/read-the-docs-site";
     };
   };


### PR DESCRIPTION
It's been failing randomly but frequently with a segfault recently, and in any case we don't need to check that it builds on Darwin since the copy that's deployed to the site will always be built on Linux.