### PR TITLE
Improve build and test instructions in marconi-sidechain README

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,10 +20,12 @@ packages: legacy/marconi-core-legacy
           marconi-chain-index
           marconi-core
           marconi-core-json-rpc
-          doc/read-the-docs-site
           marconi-sidechain
           marconi-sidechain-experimental
           marconi-starter
+if(!os(darwin) || impl(ghc >= 9.4))
+  packages:
+          doc/read-the-docs-site
 
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/marconi-sidechain/README.md
+++ b/marconi-sidechain/README.md
@@ -1,18 +1,29 @@
 # marconi-sidechain
 
-`marconi-sidechain` is a lightweight chain follower application for the Sidechain project to index and query specific information from the Cardano blockchain.
+`marconi-sidechain` is a lightweight chain-follower application for the Sidechain project to index and query specific information from the Cardano blockchain.
 The interface for querying the indexed information uses [JSON-RPC](https://www.jsonrpc.org/specification) over HTTP.
 
-See the [architecture documentation](./doc/ARCHITECTURE.adoc) for more information on how this application was build.
+See the [architecture documentation](./doc/ARCHITECTURE.adoc) for more information on how this application was built.
 
 ## Prerequisites
 
-If using `Nix`:
+If using **Nix**:
 
 * [Nix](https://nixos.org/download.html) (`>=2.5.1`)
-  * Enable IOHK's binary cache or else you will build the world! Refer to [this section](../CONTRIBUTING.adoc#how-to-get-a-shell-environment-with-tools) on how to achieve this.
+* Ensure you have the following configuration (eg in `~/.config/nix/nix.conf`):
 
-If *not* using `Nix`:
+```
+experimental-features = nix-command flakes
+accept-flake-config = true
+```
+
+If using **Docker**:
+
+```
+docker pull nixos/nix:2.18.1
+```
+
+If *not* using **Nix** or **Docker**:
 
 * [GHC](https://www.haskell.org/downloads/) (`==8.10.7`)
 * [Cabal](https://www.haskell.org/cabal/download.html) (`>=3.4.0.0`)
@@ -20,18 +31,35 @@ If *not* using `Nix`:
 
 ## How to build from source
 
-### Cabal build
+### Nix build
 
-TBD
+The `marconi-sidechain` executable is available as a nix flake.
 
-### Cabal+Nix build
+If inside the `marconi` repository, you can run from the top-level:
+
+```
+$ nix build .#marconi-sidechain
+```
+
+Or you may run from anywhere (with or without a clone of the repo):
+
+```
+$ nix build github:input-output-hk/marconi#marconi-sidechain
+```
+
+Both commands will produce a `result` directory containing the executable
+`result/bin/marconi-sidechain`.
+
+### Nix+Cabal build
 
 To build `marconi-sidechain` from the source files, use the following commands:
 
 ```sh
 git clone git@github.com:input-output-hk/marconi.git
+cd marconi
 nix develop
-cabal clean && cabal update # Optional, but makes sure you start clean
+cabal update # Important: updates the index-state for the cardano-haskell-packages repository (CHaP)
+cabal clean # Optional, but makes sure you start clean
 cabal build marconi-sidechain
 ```
 
@@ -47,24 +75,24 @@ Or you can run the executable directly with:
 cabal run marconi-sidechain:exe:marconi-sidechain -- --help
 ```
 
-### Nix build
+### Docker build
 
-The `marconi-sidechain` executable is available as a nix flake.
-
-If inside the `marconi` repository, you can run from the top-level:
+Start a container and add some nix configuration:
 
 ```
-$ nix build .#marconi-sidechain
+$ docker run -it --name marconi nixos/nix:2.18.1
+bash-5.2# mkdir -p ~/.config/nix/
+bash-5.2# cat >>~/.config/nix/nix.conf <<EOF
+experimental-features = nix-command flakes
+accept-flake-config = true
+EOF
 ```
 
-Or you may run from anywhere:
+Then follow the instructions for the Nix+Cabal build above.
 
-```
-$ nix build github:input-output-hk/marconi#marconi-sidechain
-```
+### Cabal build
 
-Both commands will produce a `result` directory containing the executable
-`result/bin/marconi-sidechain`.
+TBD
 
 ## Command line summary
 
@@ -128,6 +156,8 @@ The `id` field should be a random ID representing your request. The response wil
 ### JSON-RPC API method examples
 
 All of the following example are actual results from the Cardano pre-production testnet.
+
+A script that runs these examples is in `marconi-sidechain/examples/run-pre-prod-queries`.
 
 #### echo
 

--- a/marconi-sidechain/README.md
+++ b/marconi-sidechain/README.md
@@ -51,6 +51,8 @@ Both commands will produce a `result` directory containing the executable
 `result/bin/marconi-sidechain`.
 
 Note that Nix builds work on Mac as well as Linux.
+However, building native binaries (`aarch64-darwin`) for Apple Silicon is currently broken
+so it's necessary to force an x86 build with the `--system x86_64-darwin` Nix command-line option.
 
 ### Nix+Cabal build
 
@@ -78,6 +80,8 @@ cabal run marconi-sidechain:exe:marconi-sidechain -- --help
 ```
 
 Note that Nix+Cabal builds work on Mac as well as Linux.
+However, building native binaries (`aarch64-darwin`) for Apple Silicon is currently broken
+so it's necessary to force an x86 build with the `--system x86_64-darwin` Nix command-line option.
 
 ### Docker build
 

--- a/marconi-sidechain/README.md
+++ b/marconi-sidechain/README.md
@@ -50,6 +50,8 @@ $ nix build github:input-output-hk/marconi#marconi-sidechain
 Both commands will produce a `result` directory containing the executable
 `result/bin/marconi-sidechain`.
 
+Note that Nix builds work on Mac as well as Linux.
+
 ### Nix+Cabal build
 
 To build `marconi-sidechain` from the source files, use the following commands:
@@ -74,6 +76,8 @@ Or you can run the executable directly with:
 ```sh
 cabal run marconi-sidechain:exe:marconi-sidechain -- --help
 ```
+
+Note that Nix+Cabal builds work on Mac as well as Linux.
 
 ### Docker build
 

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -104,7 +104,7 @@ let
     includeMingwW64HydraJobs = false;
     shellArgs = repoRoot.nix.shell;
     readTheDocs = {
-      enable = !pkgs.stdenv.isDarwin;
+      enable = true;
       siteFolder = "doc/read-the-docs-site";
     };
   };


### PR DESCRIPTION
* Update Nix prerequisites
* Put Nix first
* Add Docker instructions
* Mention `marconi-sidechain/examples/run-pre-prod-queries` for testing RPC
* Mention that Nix works on Mac