### PR TITLE
Disable the `marconi-doc` Haskell example on Darwin

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,10 +20,12 @@ packages: legacy/marconi-core-legacy
           marconi-chain-index
           marconi-core
           marconi-core-json-rpc
-          doc/read-the-docs-site
           marconi-sidechain
           marconi-sidechain-experimental
           marconi-starter
+if(!os(darwin) || impl(ghc >= 9.4))
+  packages:
+          doc/read-the-docs-site
 
 -- We never, ever, want this.
 write-ghc-environment-files: never

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -104,7 +104,7 @@ let
     includeMingwW64HydraJobs = false;
     shellArgs = repoRoot.nix.shell;
     readTheDocs = {
-      enable = !pkgs.stdenv.isDarwin;
+      enable = true;
       siteFolder = "doc/read-the-docs-site";
     };
   };


### PR DESCRIPTION
It's been failing in CI with a segfault on Darwin for some time now even though it builds successfully on Linux. This is almost certainly a GHC bug. Ideally we would ensure that this example builds on all platforms, but we don't have time to investigate this GHC bug at the moment. Hopefully it will go away when we upgrade to a later version of GHC.