### PR TITLE
PLT-8794 - Specified marconi-chain-index:lib to avoid pulling in tests

### DIFF
--- a/.github/workflows/haddock.yml
+++ b/.github/workflows/haddock.yml
@@ -25,7 +25,7 @@ jobs:
           nix develop --command bash -c '
               cabal update
               cabal haddock marconi-core
-              cabal haddock marconi-chain-index
+              cabal haddock marconi-chain-index:lib:marconi-chain-index
               cabal haddock marconi-core-json-rpc
             '
           mkdir dist


### PR DESCRIPTION
The problem was: 

`Error: cabal: Failed to build documentation for plutus-script-utils-1.2.0.0
(which is required by lib:marconi-chain-index-test-lib from
marconi-chain-index-1.2.0.0).`

I've specified `marconi-chain-index:lib:marconi-chain-index` because that's all we care about here I believe, but I'm still a bit unsure as to why docs would fail to build for `plutus-script-utils`.

Note that I've not actually tested this end-to-end as it's a bit awkward and I'm essentially certain this'll work (and if it doesn't, it won't harm anything since it's already broken). The part I tested was that `cabal haddock marconi-chain-index` fails, and `cabal haddock marconi-chain-index:lib:marconi-chain-index` succeeds.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
