### PR TITLE
Changed first retry time to 1s

### DIFF
--- a/marconi-chain-index/src/Marconi/ChainIndex/CLI.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/CLI.hs
@@ -411,8 +411,8 @@ commonRetryConfigParser =
         Opt.auto
         ( Opt.long "initial-retry-time"
             <> Opt.metavar "NATURAL"
-            <> Opt.help "Initial time (in seconds) before retry after a failed node connection. Defaults to 30s."
-            <> Opt.value 30
+            <> Opt.help "Initial time (in seconds) before a retry after a failed node connection. Defaults to 1s."
+            <> Opt.value 1
         )
 
     noMaxRetryTimeParser :: Opt.Parser (Maybe Word64)

--- a/marconi-chain-index/test/Spec.hs
+++ b/marconi-chain-index/test/Spec.hs
@@ -15,8 +15,8 @@ tests :: TestTree
 tests =
   testGroup
     "Marconi"
-    [ Routes.tests
-    , CLIInput.tests
+    [ CLIInput.tests
     , CLI.tests
+    , Routes.tests
     , Api.Routes.tests
     ]

--- a/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___help.help
+++ b/marconi-chain-index/test/Spec/Golden/Cli/marconi-chain-index___help.help
@@ -35,8 +35,8 @@ Available options:
                            if the target indexers can't resume from arbitrary
                            points.
   --initial-retry-time NATURAL
-                           Initial time (in seconds) before retry after a failed
-                           node connection. Defaults to 30s.
+                           Initial time (in seconds) before a retry after a
+                           failed node connection. Defaults to 1s.
   --no-max-retry-time      Unlimited retries.
   --max-retry-time NATURAL Max time (in seconds) allowed after startup for
                            retries. Defaults to 30min.

--- a/marconi-sidechain-experimental/test/Spec/Golden/Cli/marconi-sidechain___help.help
+++ b/marconi-sidechain-experimental/test/Spec/Golden/Cli/marconi-sidechain___help.help
@@ -38,8 +38,8 @@ Available options:
                            ..." or "--match-asset-id "assetname-1.policy-id-1
                            policy-id-2" ..."
   --initial-retry-time NATURAL
-                           Initial time (in seconds) before retry after a failed
-                           node connection. Defaults to 30s.
+                           Initial time (in seconds) before a retry after a
+                           failed node connection. Defaults to 1s.
   --no-max-retry-time      Unlimited retries.
   --max-retry-time NATURAL Max time (in seconds) allowed after startup for
                            retries. Defaults to 30min.

--- a/marconi-sidechain/test/Spec.hs
+++ b/marconi-sidechain/test/Spec.hs
@@ -43,9 +43,7 @@ tests :: SidechainEnv -> RpcClientAction -> TestTree
 tests env rpcClientAction =
   testGroup
     "marconi-sidechain"
-    [ Integration.tests
-    , CLIInputValidation.tests
-    , localOption (HedgehogTestLimit $ Just 200) $
+    [ localOption (HedgehogTestLimit $ Just 200) $
         testGroup
           "marconi-sidechain"
           [ Env.tests env
@@ -54,6 +52,8 @@ tests env rpcClientAction =
           , Api.Query.Indexers.Utxo.tests rpcClientAction
           , Api.Query.Indexers.MintBurn.tests rpcClientAction
           ]
+    , CLIInputValidation.tests
+    , Integration.tests
     ]
 
 mkCliArgs :: FilePath -> IO CLI.CliArgs


### PR DESCRIPTION
New log output:

```
$ cabal run marconi-sidechain-experimental:exe:marconi-sidechain-experimental -- --testnet-magic 1 -s test.socket -d test --node-config-path faef
[marconi-sidechain-experimental:Info:19] [2023-11-28 15:44:00.03 UTC] marconi-sidechain-1.2.0.0-544bba08c5075a7b68f784b980bdfc9960f520ac
[marconi-sidechain-experimental:Info:19] [2023-11-28 15:44:00.03 UTC] CliArgs
    { socketFilePath = "test.socket"
    , nodeConfigPath = "faef"
    , dbDir = "test"
    , httpPort = 3000
    , networkId = Testnet
        ( NetworkMagic
            { unNetworkMagic = 1 }
        )
    , targetAddresses = Nothing
    , targetAssets = Nothing
    , optionsRetryConfig = RetryConfig
        { baseTimeBeforeNextRetry = 1
        , maybeMaxWaitTime = Just 1800
        }
    , optionsChainPoint = StartFromLastSyncPoint
    }
[marconi-sidechain-experimental:Warning:19] [2023-11-28 15:44:00.03 UTC] Could not connect to Cardano node: socket file test.socket does not exist. Retrying in 1s ...
[marconi-sidechain-experimental:Warning:19] [2023-11-28 15:44:01.03 UTC] Could not connect to Cardano node: socket file test.socket does not exist. Retrying in 2s ...
[marconi-sidechain-experimental:Warning:19] [2023-11-28 15:44:03.04 UTC] Could not connect to Cardano node: socket file test.socket does not exist. Retrying in 4s ...
[marconi-sidechain-experimental:Warning:19] [2023-11-28 15:44:07.04 UTC] Could not connect to Cardano node: socket file test.socket does not exist. Retrying in 8s ...
^C⏎                                                   
```

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
