### PR TITLE
PLT-8769 - Add, rather than overwrite the current metrics

### DIFF
--- a/marconi-cardano-core/src/Marconi/Cardano/Core/Transformer/WithSyncStats/Backend/Prometheus.hs
+++ b/marconi-cardano-core/src/Marconi/Cardano/Core/Transformer/WithSyncStats/Backend/Prometheus.hs
@@ -31,6 +31,6 @@ mkPrometheusBackend timeBetween = do
   where
     updateMetrics :: P.Gauge -> P.Gauge -> LastSyncStats -> IO ()
     updateMetrics rollforwards rollbacks (LastSyncStats fw bw _ _ _) = do
-      _ <- P.setGauge rollforwards (fromInteger . toInteger $ fw)
-      _ <- P.setGauge rollbacks (fromInteger . toInteger $ bw)
+      _ <- P.addGauge rollforwards (fromInteger . toInteger $ fw)
+      _ <- P.addGauge rollbacks (fromInteger . toInteger $ bw)
       pure ()

--- a/marconi-cardano-core/src/Marconi/Cardano/Core/Transformer/WithSyncStats/Backend/Prometheus.hs
+++ b/marconi-cardano-core/src/Marconi/Cardano/Core/Transformer/WithSyncStats/Backend/Prometheus.hs
@@ -19,18 +19,18 @@ mkPrometheusBackend :: NominalDiffTime -> IO StatsBackend
 mkPrometheusBackend timeBetween = do
   processedBlocksCounter <-
     P.register $
-      P.gauge (P.Info "processed_blocks_counter" "Number of processed blocks")
+      P.counter (P.Info "processed_blocks_counter" "Number of processed blocks")
   processedRollbacksCounter <-
     P.register $
-      P.gauge (P.Info "processed_rollbacks_counter" "Number of processed rollbacks")
+      P.counter (P.Info "processed_rollbacks_counter" "Number of processed rollbacks")
   pure $
     StatsBackend
       (updateMetrics processedBlocksCounter processedRollbacksCounter)
       timeBetween
       emptyLastSyncStats
   where
-    updateMetrics :: P.Gauge -> P.Gauge -> LastSyncStats -> IO ()
+    updateMetrics :: P.Counter -> P.Counter -> LastSyncStats -> IO ()
     updateMetrics rollforwards rollbacks (LastSyncStats fw bw _ _ _) = do
-      _ <- P.addGauge rollforwards (fromInteger . toInteger $ fw)
-      _ <- P.addGauge rollbacks (fromInteger . toInteger $ bw)
+      _ <- P.addCounter rollforwards (fromInteger . toInteger $ fw)
+      _ <- P.addCounter rollbacks (fromInteger . toInteger $ bw)
       pure ()


### PR DESCRIPTION
I've used `addGauge` instead of `setGauge`, which will accumulate rather than overwrite.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
