### PR TITLE
Upgrade cabal files to 3.8

### DIFF
--- a/doc/read-the-docs-site/marconi-doc.cabal
+++ b/doc/read-the-docs-site/marconi-doc.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-doc
 version:       1.2.0.0
 license:       Apache-2.0

--- a/legacy/marconi-chain-index-legacy/marconi-chain-index-legacy.cabal
+++ b/legacy/marconi-chain-index-legacy/marconi-chain-index-legacy.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-chain-index-legacy
 version:       1.2.0.0
 license:       Apache-2.0
@@ -88,7 +88,7 @@ library
   -- Local components
   --------------------
   build-depends:
-    , cardano-api-extended-legacy
+    , marconi-chain-index-legacy:cardano-api-extended-legacy
     , marconi-core-legacy
 
   --------------------------
@@ -223,8 +223,7 @@ library marconi-chain-index-legacy-test-lib
   -- Local components
   --------------------
   build-depends:
-    , cardano-api-extended-legacy
-    , marconi-chain-index-legacy
+    , marconi-chain-index-legacy:{marconi-chain-index-legacy, cardano-api-extended-legacy}
     , marconi-core-legacy
 
   --------------------------
@@ -329,9 +328,7 @@ test-suite marconi-chain-index-legacy-test
   -- Local components
   --------------------
   build-depends:
-    , cardano-api-extended-legacy
-    , marconi-chain-index-legacy
-    , marconi-chain-index-legacy-test-lib
+    , marconi-chain-index-legacy:{marconi-chain-index-legacy, cardano-api-extended-legacy, marconi-chain-index-legacy-test-lib}
     , marconi-core-legacy
 
   --------------------------
@@ -401,9 +398,8 @@ test-suite marconi-chain-index-legacy-test-compare-cardano-db-sync
   -- Local components
   --------------------
   build-depends:
-    , marconi-chain-index-legacy           >=1.2.0
-    , marconi-chain-index-legacy-test-lib  >=1.2.0
-    , marconi-core-legacy                  >=1.2.0
+    , marconi-chain-index-legacy:{marconi-chain-index-legacy, marconi-chain-index-legacy-test-lib}  >=1.2.0
+    , marconi-core-legacy                                                                           >=1.2.0
 
   --------------------------
   -- Other IOG dependencies

--- a/legacy/marconi-core-legacy/marconi-core-legacy.cabal
+++ b/legacy/marconi-core-legacy/marconi-core-legacy.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-core-legacy
 version:       1.2.0.0
 synopsis:      Indexers that can rewind the state to a previous version.

--- a/marconi-cardano-core/marconi-cardano-core.cabal
+++ b/marconi-cardano-core/marconi-cardano-core.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-cardano-core
 version:       1.2.0.0
 license:       Apache-2.0
@@ -69,7 +69,7 @@ library
   -- Local components
   --------------------
   build-depends:
-    , cardano-api-extended
+    , marconi-cardano-core:cardano-api-extended
     , marconi-core
 
   --------------------------
@@ -166,8 +166,7 @@ library marconi-cardano-core-test-lib
   -- Local components
   --------------------
   build-depends:
-    , cardano-api-extended
-    , marconi-cardano-core
+    marconi-cardano-core:{marconi-cardano-core, cardano-api-extended}
 
   --------------------------
   -- Other IOG dependencies
@@ -223,9 +222,7 @@ test-suite marconi-cardano-core-test
   -- Local components
   --------------------
   build-depends:
-    , cardano-api-extended
-    , marconi-cardano-core
-    , marconi-cardano-core-test-lib
+    marconi-cardano-core:{marconi-cardano-core, cardano-api-extended, marconi-cardano-core-test-lib}
 
   --------------------------
   -- Other IOG dependencies

--- a/marconi-cardano-indexers/marconi-cardano-indexers.cabal
+++ b/marconi-cardano-indexers/marconi-cardano-indexers.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-cardano-indexers
 version:       1.2.0.0
 license:       Apache-2.0
@@ -138,8 +138,7 @@ test-suite marconi-cardano-indexers-test
   --------------------
   build-depends:
     , marconi-cardano-core:{marconi-cardano-core, cardano-api-extended, marconi-cardano-core-test-lib}
-    , marconi-cardano-indexers
-    , marconi-cardano-indexers-test-lib
+    , marconi-cardano-indexers:{marconi-cardano-indexers, marconi-cardano-indexers-test-lib}
     , marconi-core:{marconi-core, marconi-core-test-lib}
 
   --------------------------

--- a/marconi-chain-index/marconi-chain-index.cabal
+++ b/marconi-chain-index/marconi-chain-index.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-chain-index
 version:       1.2.0.0
 license:       Apache-2.0

--- a/marconi-core-json-rpc/marconi-core-json-rpc.cabal
+++ b/marconi-core-json-rpc/marconi-core-json-rpc.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-core-json-rpc
 version:       1.2.0.0
 synopsis:

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-core
 version:       1.2.0.0
 synopsis:      Modular indexing for rewindable ledger
@@ -143,20 +143,19 @@ test-suite marconi-core-test
   hs-source-dirs: test
   build-depends:
     , async
-    , base                   >=4.7    && <5
+    , base                                                >=4.7    && <5
     , bytestring
     , comonad
     , containers
     , contra-tracer
     , directory
     , lens
-    , marconi-core
-    , marconi-core-test-lib
+    , marconi-core:{marconi-core, marconi-core-test-lib}
     , mtl
     , network
     , QuickCheck
     , quickcheck-instances
-    , sqlite-simple          >=0.4.18
+    , sqlite-simple                                       >=0.4.18
     , stm
     , streaming
     , tasty

--- a/marconi-sidechain-experimental/marconi-sidechain-experimental.cabal
+++ b/marconi-sidechain-experimental/marconi-sidechain-experimental.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-sidechain-experimental
 version:       1.2.0.0
 license:       Apache-2.0

--- a/marconi-sidechain/marconi-sidechain.cabal
+++ b/marconi-sidechain/marconi-sidechain.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-sidechain
 version:       1.2.0.0
 license:       Apache-2.0
@@ -174,7 +174,7 @@ executable db-utils-exe
   --------------------
   -- Local components
   --------------------
-  build-depends:  db-utils
+  build-depends:  marconi-sidechain:db-utils
 
   ------------------------
   -- Non-IOG dependencies

--- a/marconi-starter/marconi-starter.cabal
+++ b/marconi-starter/marconi-starter.cabal
@@ -1,4 +1,4 @@
-cabal-version: 3.0
+cabal-version: 3.8
 name:          marconi-starter
 version:       1.2.0.0
 license:       Apache-2.0


### PR DESCRIPTION
I did this while trying to fix dependency problems in `marconi-sidechain-node` but I thought it was worth keeping anyway.

[Since 3.4](https://cabal.readthedocs.io/en/stable/file-format-changelog.html#cabal-version-3-4) the file format requires that sublibraries be fully qualified even in the project they're defined in, just like they have to be in other other projects.

There's no particular connection between the version of cabal you're using and the file format version, other than cabal has to be newer than the file format. We're using cabal 3.10.