### PR TITLE
Fix rollbacks and memory issues due to accumulation of ExtLedgerStates

### DIFF
--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/ExtLedgerStateCoordinator.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/ExtLedgerStateCoordinator.hs
@@ -362,13 +362,10 @@ instance
             then blockIndexer (Core.index $ Core.Timed point $ Just blockInMode')
             else pure
     indexer'' <-
-      if snapshotTime || isNewEpoch
-        then
-          pure . resetOnSnapshot
-            <=< snapshotLedgerState
-            <=< snapshotBlock
-            $ indexer'
-        else pure indexer'
+      pure . resetOnSnapshot
+        <=< snapshotLedgerState
+        <=< snapshotBlock
+        $ indexer'
     Core.indexVia coordinator timedEvent indexer''
 
   rollback point =
@@ -593,7 +590,7 @@ buildExtLedgerStateEventIndexer codecConfig securityParam' path = do
           _ -> init immutableEvents
   Core.mkFileIndexer
     path
-    (Just 180_000_000) -- Wait 180s for files to finish writing before terminating
+    Nothing -- (Just 180_000_000) -- Wait 180s for files to finish writing before terminating
     (Core.FileStorageConfig False immutableEpochs (comparing (Down . metadataBlockNo)))
     (Core.FileBuilder "epochState" "cbor" metadataAsText serialiseLedgerState serialisePoint)
     ( Core.EventBuilder
@@ -663,7 +660,7 @@ buildBlockIndexer codecConfig securityParam' path = do
     Just v -> pure v
   Core.mkFileIndexer
     path
-    (Just 60_000_000) -- Wait 60s for files to finish writing before terminating
+    Nothing -- (Just 60_000_000) -- Wait 60s for files to finish writing before terminating
     (Core.FileStorageConfig False immutableBlocks (comparing metadataBlockNo))
     ( Core.FileBuilder
         "block"

--- a/marconi-chain-index/src/Marconi/ChainIndex/Run.hs
+++ b/marconi-chain-index/src/Marconi/ChainIndex/Run.hs
@@ -21,7 +21,7 @@ import Data.Void (Void)
 import Marconi.Cardano.Core.Logger (defaultStdOutLogger, mkMarconiTrace)
 import Marconi.Cardano.Core.Node.Client.Retry (withNodeConnectRetry)
 import Marconi.Cardano.Core.Runner qualified as Runner
-import Marconi.Cardano.Core.Types (TargetAddresses)
+import Marconi.Cardano.Core.Types (SecurityParam (SecurityParam), TargetAddresses)
 import Marconi.Cardano.Indexers (buildIndexers)
 import Marconi.Cardano.Indexers.MintTokenEvent qualified as MintTokenEvent
 import Marconi.Cardano.Indexers.Utxo qualified as Utxo
@@ -69,8 +69,7 @@ run appName = withGracefulTermination_ $ do
   createDirectoryIfMissing True (Cli.optionsDbPath o)
 
   let batchSize = 5000
-      stopCatchupDistance = 100
-      volatileEpochStateSnapshotInterval = 100
+      volatileEpochStateSnapshotInterval = 1000
       filteredAddresses = shelleyAddressesToAddressAny $ Cli.optionsTargetAddresses o
       filteredAssetIds = Cli.optionsTargetAssets o
       includeScript = not $ Cli.optionsDisableScript o
@@ -110,6 +109,8 @@ run appName = withGracefulTermination_ $ do
     withNodeConnectRetry marconiTrace retryConfig socketPath $
       Utils.toException $
         Utils.querySecurityParam @Void networkId socketPath
+
+  let SecurityParam stopCatchupDistance = securityParam
 
   mindexers <-
     runExceptT $


### PR DESCRIPTION
Two main fixes and a change.

Fixes:
- Stop relying on asynchronous saves of the ledger, as it leads to the accumulation of ledger states in memory
- Save correctly the volatile blocks 

Change:
- Catchup now stops when we reach volatile events.

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
