### PR TITLE
Add support for running marconi-sidechain as a NixOS module

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1423,11 +1423,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1700649178,
-        "narHash": "sha256-ltH0ssweTOAV+q6klGl01PP/hceVkj6sh3SfgB44Ql4=",
+        "lastModified": 1702325668,
+        "narHash": "sha256-b1A1VtMsoOYW6KuMXORF9kZmplgMqiSef7IANnbsejU=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "af1f870fd0a3ddbd7af70ce18c4bed1f1cb1ccc3",
+        "rev": "50adb7cb0b9dc4e97a69922dac645451f1ca0b8a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,9 @@
     repoRoot = ./.;
     systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
     outputs = import ./nix/outputs.nix;
+    flake = {
+      nixosModules = import ./nix/nixosModules;
+    };
   };
 
 

--- a/nix/nixosModules/default.nix
+++ b/nix/nixosModules/default.nix
@@ -1,0 +1,3 @@
+{
+  marconi-sidechain = import ./marconi-sidechain-service.nix;
+}

--- a/nix/nixosModules/marconi-dashboard.json
+++ b/nix/nixosModules/marconi-dashboard.json
@@ -18,10 +18,32 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "marconi-prometheus-datasource"
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "marconi-prometheus-datasource"
+          },
+          "refId": "A"
+        }
+      ],
+      "type": "welcome"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -83,7 +105,283 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 3
+      },
+      "id": 123129,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "marconi-prometheus-datasource"
+          },
+          "editorMode": "code",
+          "expr": "(node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / 1000000000",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory (GB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "marconi-prometheus-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "id": 123126,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "marconi-prometheus-datasource"
+          },
+          "editorMode": "code",
+          "expr": "100 - (100 * (node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Memory usage (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "marconi-prometheus-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 123124,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "marconi-prometheus-datasource"
+          },
+          "editorMode": "builder",
+          "expr": "processed_blocks_counter",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total number of processed blocks",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "marconi-prometheus-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
       },
       "id": 123128,
       "options": {
@@ -174,10 +472,10 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 0
+        "x": 0,
+        "y": 19
       },
-      "id": 123126,
+      "id": 123130,
       "options": {
         "legend": {
           "calcs": [],
@@ -197,105 +495,13 @@
             "uid": "marconi-prometheus-datasource"
           },
           "editorMode": "code",
-          "expr": "100 - (100 * (node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes)",
+          "expr": "(node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"rootfs\"} - node_filesystem_avail_bytes{mountpoint=\"/\",fstype!=\"rootfs\"}) / 1000000000",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Memory usage",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "marconi-prometheus-datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 8
-      },
-      "id": 123124,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "marconi-prometheus-datasource"
-          },
-          "editorMode": "builder",
-          "expr": "processed_blocks_counter",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Number of processed blocks",
+      "title": "Available disk space (GB)",
       "type": "timeseries"
     },
     {
@@ -359,7 +565,291 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 19
+      },
+      "id": 123125,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "marconi-prometheus-datasource"
+          },
+          "editorMode": "code",
+          "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"rootfs\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Available disk space (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "marconi-prometheus-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 123132,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "marconi-prometheus-datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg (sum by(cpu) (irate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average CPU usage (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "marconi-prometheus-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 123131,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "marconi-prometheus-datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum by(cpu) (irate(node_cpu_seconds_total{ mode!=\"idle\"}[$__rate_interval]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Single CPU usage (%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "marconi-prometheus-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
       },
       "id": 123127,
       "options": {
@@ -389,210 +879,6 @@
       ],
       "title": "Number of processed rollbacks",
       "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "marconi-prometheus-datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "id": 123125,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "marconi-prometheus-datasource"
-          },
-          "editorMode": "code",
-          "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=\"/\",fstype!=\"rootfs\"} * 100) / node_filesystem_size_bytes{mountpoint=\"/\",fstype!=\"rootfs\"})",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Available disk space",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "marconi-prometheus-datasource"
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 24
-      },
-      "id": 1,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "marconi-prometheus-datasource"
-          },
-          "refId": "A"
-        }
-      ],
-      "type": "welcome"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "marconi-prometheus-datasource"
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 123123,
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "marconi-prometheus-datasource"
-          },
-          "refId": "A"
-        }
-      ],
-      "type": "gettingstarted"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "marconi-prometheus-datasource"
-      },
-      "gridPos": {
-        "h": 15,
-        "w": 12,
-        "x": 0,
-        "y": 36
-      },
-      "id": 3,
-      "links": [],
-      "options": {
-        "folderId": 0,
-        "maxItems": 30,
-        "query": "",
-        "showHeadings": true,
-        "showRecentlyViewed": true,
-        "showSearch": false,
-        "showStarred": true,
-        "tags": []
-      },
-      "pluginVersion": "9.5.2",
-      "tags": [],
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "marconi-prometheus-datasource"
-          },
-          "refId": "A"
-        }
-      ],
-      "title": "Dashboards",
-      "type": "dashlist"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "marconi-prometheus-datasource"
-      },
-      "gridPos": {
-        "h": 15,
-        "w": 12,
-        "x": 12,
-        "y": 36
-      },
-      "id": 4,
-      "links": [],
-      "options": {
-        "feedUrl": "https://grafana.com/blog/news.xml",
-        "showImage": true
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "marconi-prometheus-datasource"
-          },
-          "refId": "A"
-        }
-      ],
-      "title": "Latest from the blog",
-      "type": "news"
     }
   ],
   "refresh": "5s",
@@ -636,6 +922,6 @@
   "timezone": "browser",
   "title": "Home",
   "uid": "cff12384-a384-490c-b3b2-c2dc7c102a3e",
-  "version": 11,
+  "version": 3,
   "weekStart": ""
 }

--- a/nix/nixosModules/marconi-sidechain-service.nix
+++ b/nix/nixosModules/marconi-sidechain-service.nix
@@ -1,0 +1,160 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.marconi-sidechain;
+
+  networkMagicOpt =
+    if cfg.network == "mainnet"
+    then "--mainnet"
+    else if cfg.network == "preprod"
+    then "--testnet-magic 1"
+    else if cfg.network == "preview"
+    then "--testnet-magic 2"
+    else if cfg.network == "sanchonet"
+    then "--testnet-magic 4"
+    else "--testnet-magic ${builtins.toString cfg.network}";
+
+  cmd = builtins.toString (builtins.filter (x: x != "") [
+    "${cfg.executable} "
+    # Mandatory CLI params
+    "--socket-path ${cfg.nodeSocketPath}"
+    "${networkMagicOpt}"
+    "--node-config-path ${cfg.nodeConfigFile}"
+    "--db-dir ${cfg.databaseDir}"
+    # Optional  CLI params
+    "--initial-retry-time ${builtins.toString cfg.initialRetryTime}"
+    "--max-retry-time ${builtins.toString cfg.maxRetryTime}"
+    "--http-port ${builtins.toString cfg.port}"
+  ]);
+in
+{
+  options = {
+    services.marconi-sidechain = {
+      enable = lib.mkEnableOption "marconi-sidechain";
+
+      executable = lib.mkOption {
+        type = lib.types.str;
+        default = "marconi-sidechain";
+        example = [ "marconi-sidechain" "nix run github:input-output-hk/marconi#marconi-sidechain-experimental --" ];
+        description = "The marconi-sidechain executable invocation to use";
+      };
+
+      nodeSocketPath = lib.mkOption {
+        type = lib.types.str;
+        example = "/var/lib/cardano-node/mainnet/cardano-node.socket";
+        description = "Local Cardano node communication socket path";
+      };
+
+      network = lib.mkOption {
+        type = lib.types.either (lib.types.enum [ "mainnet" "preprod" "preview" "sanchonet" ]) lib.types.int;
+        example = [ "mainnet" 1 2 ];
+        description = "The Cardano network we want to connect to";
+      };
+
+      nodeConfigFile = lib.mkOption {
+        type = lib.types.str;
+        example = "/var/lib/cardano-node/mainnet/config.json";
+        description = "Node configuration file. Mainly used by the EpochState indexer.";
+      };
+
+      databaseDir = lib.mkOption {
+        type = lib.types.str;
+        example = "/var/lib/cardano-node/mainnet/marconi-sidechain";
+        description = "Directory containing the SQLite databases created by marconi-sidechain";
+      };
+
+      port = lib.mkOption {
+        type = lib.types.int;
+        default = 8090;
+        example = 8090;
+        description = "The port number of marconi-sidechain's HTTP interface";
+      };
+
+      initialRetryTime = lib.mkOption {
+        type = lib.types.int;
+        default = 5;
+        example = 5;
+        description = "Initial time (in seconds) before retry after failing to connect to local node.";
+      };
+
+      maxRetryTime = lib.mkOption {
+        type = lib.types.int;
+        default = 300;
+        example = 300;
+        description = "Max time (in seconds) allowed after startup for retries. If omitted, then it will retry indefinetely.";
+      };
+
+      monitoring = {
+        enable = lib.mkEnableOption "marconi-sidechain monitoring";
+      };
+    };
+  };
+
+  config =
+    let
+      marconiSidechainConfig =
+        lib.mkIf cfg.enable (
+          {
+            systemd.services.marconi-sidechain = {
+              description = "Runs marconi-sidechain";
+
+              serviceConfig = {
+                User = "root";
+                Group = "root";
+                ExecStart = "${cmd}";
+                Restart = "always";
+              };
+
+              wants = [ "network-online.target" ];
+              wantedBy = [ "multi-user.target" ];
+            };
+          });
+      monitoringConfig =
+        lib.mkIf cfg.monitoring.enable ({
+          services.prometheus = {
+            scrapeConfigs = [
+              {
+                job_name = "marconi-sidechain";
+                static_configs = [{
+                  targets = [ "127.0.0.1:${toString config.services.marconi-sidechain.port}" ];
+                }];
+              }
+            ];
+          };
+
+          services.grafana = {
+            provision = {
+              datasources.settings.datasources = [
+                {
+                  name = "marconi-sidechain";
+                  type = "prometheus";
+                  access = "proxy";
+                  url = "http://127.0.0.1:${toString config.services.prometheus.port}";
+                  uid = "marconi-sidechain-prometheus-datasource";
+                }
+              ];
+              dashboards.settings.providers = [
+                {
+                  name = "default";
+                  type = "file";
+                  folder = "";
+                  updateIntervalSeconds = 30;
+                  options = {
+                    path = "/etc/grafana-dashboards";
+                  };
+                }
+              ];
+            };
+          };
+
+          environment.etc = {
+            "grafana-dashboards/marconi-dashboard.json" = {
+              source = ./marconi-dashboard.json;
+              group = "root";
+              user = "root";
+            };
+          };
+        });
+    in
+    lib.mkMerge [ marconiSidechainConfig monitoringConfig ];
+}

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -4,9 +4,7 @@ let
   project = repoRoot.nix.project;
 in
 [
-  (
-    project.flake
-  )
+  (project.flake)
   {
     devShells.profiled = project.variants.profiled.devShell;
   }

--- a/nix/scripts/start-benchmarking-machine.nix
+++ b/nix/scripts/start-benchmarking-machine.nix
@@ -156,6 +156,10 @@ let
         { from = "host"; host.port = 10022; guest.port = 22; }
       ];
     };
+
+    imports = [
+      inputs.self.nixosModules.marconi-sidechain
+    ];
   };
 
   # TODO Doesn't work yet. Need to complete in the future.
@@ -218,7 +222,7 @@ let
         ExecStartPre = ''
           ${pkgs.bash}/bin/bash -c "mkdir -p /var/lib/cardano-node/preprod/marconi-sidechain"
         '';
-        ExecStart = ''${pkgs.bash}/bin/bash -c "${inputs.self.marconi-sidechain}/bin/marconi-sidechain --testnet-magic 1 -s ${config.services.cardano-node.socketPath 0} --node-config-path ${config.services.cardano-node.stateDir 0}/config-0-0.json -d ${config.services.cardano-node.stateDir 0}/preprod/marconi-sidechain --http-port 8080 --max-indexing-depth"'';
+        ExecStart = ''${pkgs.bash}/bin/bash -c "${inputs.self.packages.marconi-sidechain}/bin/marconi-sidechain --testnet-magic 1 -s ${config.services.cardano-node.socketPath 0} --node-config-path ${config.services.cardano-node.stateDir 0}/config-0-0.json -d ${config.services.cardano-node.stateDir 0}/preprod/marconi-sidechain --http-port 8080 --max-indexing-depth"'';
         ConditionPathExists = config.services.cardano-node.socketPath 0;
       };
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -22,7 +22,7 @@ in
     start-benchmark-machine = {
       enable = false;
       group = "benchmarking";
-      exec = repoRoot.scripts.start-benchmarking-machine;
+      exec = repoRoot.nix.scripts.start-benchmarking-machine;
       description = ''
         Start the benchmarking NixOS VM exposing Grafana dashboards and Prometheus metrics for Marconi.
       '';


### PR DESCRIPTION
* Added NixOS module in the `flake.nix` in order to easily run Marconi, Grafana and Prometheus in a NixOS machine.

* Also fixed the `start-benchmarking-machine` script which was failing following changes to IOGX

* Upgraded IOGX flake following a bug fix related to nixosModules

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
