### PR TITLE
PLT-8932 - Darwin test instability fix attempt

### DIFF
--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -148,7 +148,6 @@ test-suite marconi-core-test
     , comonad
     , containers
     , contra-tracer
-    , directory
     , lens
     , marconi-core:{marconi-core, marconi-core-test-lib}
     , mtl

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -148,6 +148,7 @@ test-suite marconi-core-test
     , comonad
     , containers
     , contra-tracer
+    , filepath
     , lens
     , marconi-core:{marconi-core, marconi-core-test-lib}
     , mtl

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -148,7 +148,6 @@ test-suite marconi-core-test
     , comonad
     , containers
     , contra-tracer
-    , filepath
     , lens
     , marconi-core:{marconi-core, marconi-core-test-lib}
     , mtl

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1730,13 +1730,19 @@ propWithStreamTBQueue = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabil
 propWithStreamSocket :: Property
 propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstability $ \args -> do
   guid <- liftIO nextRandom
-  (_, (actual, expected)) <- liftIO $ Tmp.withSystemTempDirectory (show guid) $ \dir -> do
-    let chainSubset = take (chainSizeSubset args) (eventGenerator args)
-        fileName = dir </> "file.sock"
-    serverStarted <- newQSem 1
-    concurrently
-      (server fileName chainSubset serverStarted)
-      (client fileName chainSubset serverStarted)
+  (_, (actual, expected)) <- liftIO
+    $ Tmp.withSystemTempDirectory
+      ( take 20 $
+          filter ('-' /=) $
+            show guid
+      )
+    $ \dir -> do
+      let chainSubset = take (chainSizeSubset args) (eventGenerator args)
+          fileName = dir </> "file"
+      serverStarted <- newQSem 1
+      concurrently
+        (server fileName chainSubset serverStarted)
+        (client fileName chainSubset serverStarted)
 
   GenM.stop (actual == expected)
   where

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -198,7 +198,6 @@ import Network.Socket.ByteString (sendAll)
 import Streaming (Of, Stream)
 import Streaming.Prelude qualified as S
 import System.FilePath ((</>))
-import System.IO.Temp (withSystemTempDirectory)
 import System.IO.Temp qualified as Tmp
 import Test.Marconi.Core.ModelBased qualified as Model
 import Test.QuickCheck (Arbitrary, Gen, Property, (===), (==>))
@@ -1731,7 +1730,7 @@ propWithStreamTBQueue = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabil
 propWithStreamSocket :: Property
 propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstability $ \args -> do
   guid <- liftIO nextRandom
-  (_, (actual, expected)) <- liftIO $ withSystemTempDirectory (show guid) $ \dir -> do
+  (_, (actual, expected)) <- liftIO $ Tmp.withSystemTempDirectory (show guid) $ \dir -> do
     let chainSubset = take (chainSizeSubset args) (eventGenerator args)
         fileName = dir </> "file.sock"
     serverStarted <- newQSem 1

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1733,6 +1733,8 @@ propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabili
       mempty
     $ \dir -> do
       let chainSubset = take (chainSizeSubset args) (eventGenerator args)
+          -- We need to make the filename as short as possible, because we're very limited by path
+          -- length
           fileName = dir </> "f"
       serverStarted <- newQSem 1
       concurrently

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -196,6 +196,7 @@ import Network.Socket (
 import Network.Socket.ByteString (sendAll)
 import Streaming (Of, Stream)
 import Streaming.Prelude qualified as S
+import System.FilePath ((</>))
 import System.IO.Temp qualified as Tmp
 import Test.Marconi.Core.ModelBased qualified as Model
 import Test.QuickCheck (Arbitrary, Gen, Property, (===), (==>))
@@ -1728,14 +1729,15 @@ propWithStreamTBQueue = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabil
 propWithStreamSocket :: Property
 propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstability $ \args -> do
   (_, (actual, expected)) <- liftIO
-    $ Tmp.withSystemTempFile
-      "stream-socket"
-    $ \path _ -> do
+    $ Tmp.withSystemTempDirectory
+      "stream"
+    $ \dir -> do
       let chainSubset = take (chainSizeSubset args) (eventGenerator args)
+          fileName = dir </> "socket"
       serverStarted <- newQSem 1
       concurrently
-        (server path chainSubset serverStarted)
-        (client path chainSubset serverStarted)
+        (server fileName chainSubset serverStarted)
+        (client fileName chainSubset serverStarted)
 
   GenM.stop (actual == expected)
   where

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -131,7 +131,7 @@ import Control.Concurrent.STM (
   TBQueue,
   newTBQueueIO,
  )
-import Control.Exception (bracket, finally)
+import Control.Exception (bracket)
 import Control.Lens (
   Getter,
   Lens',
@@ -169,7 +169,6 @@ import Data.Sequence (Seq ((:<|), (:|>)))
 import Data.Sequence qualified as Seq
 import Data.UUID (UUID)
 import Data.UUID qualified as UUID
-import Data.UUID.V4 (nextRandom)
 import Data.Word (Word64)
 import Database.SQLite.Simple qualified as SQL
 import Database.SQLite.Simple.FromField (FromField)
@@ -197,7 +196,7 @@ import Network.Socket (
 import Network.Socket.ByteString (sendAll)
 import Streaming (Of, Stream)
 import Streaming.Prelude qualified as S
-import System.Directory (removeFile)
+import System.IO.Temp (withSystemTempFile)
 import System.IO.Temp qualified as Tmp
 import Test.Marconi.Core.ModelBased qualified as Model
 import Test.QuickCheck (Arbitrary, Gen, Property, (===), (==>))
@@ -1729,20 +1728,12 @@ propWithStreamTBQueue = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabil
 -}
 propWithStreamSocket :: Property
 propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstability $ \args -> do
-  let chainSubset = take (chainSizeSubset args) (eventGenerator args)
-
-  serverStarted <- liftIO $ newQSem 1
-  guid <- liftIO nextRandom
-
-  let socketPath = "/tmp/prop-with-stream-socket:" ++ show guid ++ ".sock"
-
-  (_, (actual, expected)) <-
-    liftIO
-      ( concurrently
-          (server socketPath chainSubset serverStarted)
-          (client socketPath chainSubset serverStarted)
-          `finally` removeFile socketPath
-      )
+  (_, (actual, expected)) <- liftIO $ withSystemTempFile "prop-with-stream-socket" $ \socketPath _ -> do
+    let chainSubset = take (chainSizeSubset args) (eventGenerator args)
+    serverStarted <- newQSem 1
+    concurrently
+      (server socketPath chainSubset serverStarted)
+      (client socketPath chainSubset serverStarted)
 
   GenM.stop (actual == expected)
   where

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1730,10 +1730,10 @@ propWithStreamSocket :: Property
 propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstability $ \args -> do
   (_, (actual, expected)) <- liftIO
     $ Tmp.withSystemTempDirectory
-      "stream"
+      mempty
     $ \dir -> do
       let chainSubset = take (chainSizeSubset args) (eventGenerator args)
-          fileName = dir </> "socket"
+          fileName = dir </> "f"
       serverStarted <- newQSem 1
       concurrently
         (server fileName chainSubset serverStarted)


### PR DESCRIPTION
An attempt at fixing an unstable test on Darwin, using Neil's suggestion in https://input-output.atlassian.net/browse/PLT-8932

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [x] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [x] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
