### PR TITLE
Update source-dep commit for quickcheck-contractmodel

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -57,8 +57,8 @@ package cardano-crypto-praos
 source-repository-package
     type: git
     location: https://github.com/input-output-hk/quickcheck-contractmodel
-    tag: 6b0e3e3259fcf522df33dfc21138a41837b9ac16
-    --sha256: sha256-k7waj5qbAcbsyRvkKKdkKLu21GqRWv679QYTFGjV0bQ=
+    tag: 45f75c3ffa3b6ac08f7ba6b9678552bf58e2e005
+    --sha256: sha256-APWe5EDBuWzPGtfgNLB9GfU2n4XTxh+a1OZR7sdIREA=
     subdir:
       quickcheck-contractmodel
       quickcheck-threatmodel


### PR DESCRIPTION
This fixes recent CI failures in the GitHub workflow that builds haddocks