### PR TITLE
PLT-8935 Typo in UtxoQuery SQL statement

### DIFF
--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/UtxoQuery.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/UtxoQuery.hs
@@ -304,7 +304,7 @@ instance
           Nothing -> mempty
           Just lo -> (["u.slotNo >= :lowerBound"], [":lowerBound" := lo])
         upperBoundFilter = case q ^. upperBound <|> C.chainPointToSlotNo point of
-          Nothing -> (["s.slotNo IS NULL"], [])
+          Nothing -> (["futureSpent.slotNo IS NULL"], [])
           Just hi ->
             ( -- created before the upperBound
 


### PR DESCRIPTION
Fixes a typo in the `UtxoQuery` aggregate's `Queryable` instance, whose SQL statement contained an alias that did not exist.

Pre-submit checklist:
- Branch
    - [X] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [X] Targeting main unless this is a cherry-pick backport
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [X] Reviewer requested
