### PR TITLE
Faster ledger state

### DIFF
--- a/legacy/marconi-chain-index-legacy/test-lib/Gen/Marconi/ChainIndex/Legacy/Types.hs
+++ b/legacy/marconi-chain-index-legacy/test-lib/Gen/Marconi/ChainIndex/Legacy/Types.hs
@@ -10,7 +10,7 @@ module Gen.Marconi.ChainIndex.Legacy.Types (
   genChainPoints,
   genChainPoint,
   genChainPoint',
-  genExecutionUnits,
+  CGen.genExecutionUnits,
   genSlotNo,
   genTxBodyContentWithTxInsCollateral,
   genTxBodyContentForPlutusScripts,
@@ -280,7 +280,7 @@ genWitnessAndHashInEra era = do
     C.ScriptWitness C.ScriptWitnessForSpending <$> case script of
       C.PlutusScript version plutusScript -> do
         scriptData <- CGen.genHashableScriptData
-        executionUnits <- genExecutionUnits
+        executionUnits <- CGen.genExecutionUnits
         pure $
           C.PlutusScriptWitness
             scriptLanguageInEra
@@ -292,15 +292,6 @@ genWitnessAndHashInEra era = do
       C.SimpleScript simpleScript ->
         pure $ C.SimpleScriptWitness scriptLanguageInEra (C.SScript simpleScript)
   pure (witness, C.hashScript script)
-
-{- | TODO Copy-paste from cardano-node: cardano-api/gen/Gen/Cardano/Api/Typed.hs
- Copied from cardano-api. Delete when this function is reexported
--}
-genExecutionUnits :: Gen C.ExecutionUnits
-genExecutionUnits =
-  C.ExecutionUnits
-    <$> Gen.integral (Range.constant 0 1000)
-    <*> Gen.integral (Range.constant 0 1000)
 
 genTxOutTxContext :: C.CardanoEra era -> Gen (C.TxOut C.CtxTx era)
 genTxOutTxContext era =
@@ -446,8 +437,8 @@ genProtocolParametersForPlutusScripts =
           ]
       )
     <*> (Just <$> genExecutionUnitPrices)
-    <*> (Just <$> genExecutionUnits)
-    <*> (Just <$> genExecutionUnits)
+    <*> (Just <$> CGen.genExecutionUnits)
+    <*> (Just <$> CGen.genExecutionUnits)
     <*> (Just <$> genNat)
     <*> (Just <$> genNat)
     <*> (Just <$> genNat)

--- a/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/CLI.hs
+++ b/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/CLI.hs
@@ -175,6 +175,7 @@ data CommonOptions = CommonOptions
   , optionsRetryConfig :: !RetryConfig
   -- ^ set up retry configuration when the node socket is unavailable
   , batchSizeConfig :: !Word64
+  -- ^ Size of the batches sent to the indexers
   }
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -366,7 +367,7 @@ commonBatchSizeParser =
     $ Opt.long "batch-size"
       <> Opt.metavar "INT"
       <> Opt.value 3000
-      <> Opt.help "Number of blocks send as a batch to the indexers"
+      <> Opt.help "Number of blocks sent as a batch to the indexers"
       <> Opt.showDefault
 
 {- | Parse the addresses to index. Addresses should be given in Bech32 format

--- a/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/CLI.hs
+++ b/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/CLI.hs
@@ -174,6 +174,7 @@ data CommonOptions = CommonOptions
   -- ^ The starting point of the indexers
   , optionsRetryConfig :: !RetryConfig
   -- ^ set up retry configuration when the node socket is unavailable
+  , batchSizeConfig :: !Word64
   }
   deriving stock (Show, Generic)
   deriving anyclass (FromJSON, ToJSON)
@@ -236,6 +237,7 @@ commonOptionsParser =
     <*> commonNetworkIdParser
     <*> commonStartFromParser
     <*> commonRetryConfigParser
+    <*> commonBatchSizeParser
 
 optionsParser :: Opt.Parser Options
 optionsParser =
@@ -355,6 +357,16 @@ commonPortParser =
       <> Opt.metavar "INT"
       <> Opt.value 3000
       <> Opt.help "JSON-RPC http port number"
+      <> Opt.showDefault
+
+commonBatchSizeParser :: Opt.Parser Word64
+commonBatchSizeParser =
+  Opt.option
+    Opt.auto
+    $ Opt.long "batch-size"
+      <> Opt.metavar "INT"
+      <> Opt.value 3000
+      <> Opt.help "Number of blocks send as a batch to the indexers"
       <> Opt.showDefault
 
 {- | Parse the addresses to index. Addresses should be given in Bech32 format

--- a/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Indexers.hs
+++ b/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Indexers.hs
@@ -17,7 +17,6 @@ import Control.Lens qualified as Lens
 import Control.Monad.Cont (MonadIO)
 import Control.Monad.Except (ExceptT, MonadError, MonadTrans (lift))
 import Data.List.NonEmpty (NonEmpty)
-import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Traversable (for)
@@ -67,8 +66,6 @@ import Marconi.Cardano.Indexers.Spent qualified as Spent
 import Marconi.Cardano.Indexers.Utxo qualified as Utxo
 import Marconi.Cardano.Indexers.UtxoQuery qualified as UtxoQuery
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
-import Marconi.Core.Preprocessor qualified as Core
 import System.FilePath ((</>))
 
 -- Point instances used only in this module
@@ -91,6 +88,13 @@ type CurrentSyncPointIndexer =
 type EpochNonceIndexer = Core.WithTrace IO Core.SQLiteIndexer Nonce.EpochNonce
 type EpochSDDIndexer = Core.WithTrace IO Core.SQLiteIndexer (NonEmpty SDD.EpochSDD)
 
+data EpochEvent = EpochEvent
+  { epochNo :: C.EpochNo
+  , epochSDD :: Maybe (NonEmpty SDD.EpochSDD)
+  , epochNonce :: Maybe Nonce.EpochNonce
+  }
+type instance Core.Point EpochEvent = C.ChainPoint
+
 -- | Container for all the queryable indexers.
 data MarconiCardanoQueryables = MarconiCardanoQueryables
   { _queryableEpochNonce :: !(MVar EpochNonceIndexer)
@@ -110,7 +114,7 @@ buildIndexers
   -> Core.CatchupConfig
   -> Utxo.UtxoIndexerConfig
   -> MintTokenEvent.MintTokenEventConfig
-  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig IO (WithDistance BlockEvent)
+  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig IO EpochEvent (WithDistance BlockEvent)
   -> BM.Trace IO Text
   -> MarconiTrace IO
   -> FilePath
@@ -126,7 +130,7 @@ buildIndexers
   catchupConfig
   utxoConfig
   mintEventConfig
-  epochStateConfig
+  ledgerStateConfig
   textLogger
   prettyLogger
   path = do
@@ -135,20 +139,18 @@ buildIndexers
         blockEventTextLogger = BM.appendName "blockEvent" textLogger
         blockEventLogger = BM.appendName "blockEvent" mainLogger
         txBodyCoordinatorLogger = BM.appendName "txBody" blockEventTextLogger
-        epochStateTextLogger = BM.appendName "epochState" blockEventTextLogger
-        epochSDDTextLogger = BM.appendName "epochSDD" epochStateTextLogger
-        epochNonceTextLogger = BM.appendName "epochNonce" epochStateTextLogger
+        ledgerStateTextLogger = BM.appendName "ledgerState" blockEventTextLogger
 
     StandardWorker blockInfoMVar blockInfoWorker <-
       BlockInfo.blockInfoBuilder securityParam catchupConfig blockEventTextLogger path
 
     Core.WorkerIndexer epochSDDMVar epochSDDWorker <-
-      epochSDDBuilder securityParam catchupConfig epochSDDTextLogger path
+      epochSDDBuilder securityParam catchupConfig ledgerStateTextLogger path
     Core.WorkerIndexer epochNonceMVar epochNonceWorker <-
-      epochNonceBuilder securityParam catchupConfig epochNonceTextLogger path
-    Core.WorkerIndexer _epochStateMVar epochStateWorker <-
+      epochNonceBuilder securityParam catchupConfig ledgerStateTextLogger path
+    Core.WorkerIndexer _ledgerStateMVar ledgerStateWorker <-
       ExtLedgerStateCoordinator.extLedgerStateWorker
-        epochStateConfig
+        ledgerStateConfig
         [epochSDDWorker, epochNonceWorker]
         path
 
@@ -189,7 +191,7 @@ buildIndexers
       lift $
         buildBlockEventCoordinator
           blockEventLogger
-          [blockInfoWorker, epochStateWorker, coordinatorTxBodyWorkers]
+          [blockInfoWorker, ledgerStateWorker, coordinatorTxBodyWorkers]
 
     Core.WorkerIndexer chainTipMVar chainTipWorker <-
       ChainTip.chainTipBuilder mainLogger path
@@ -251,7 +253,7 @@ epochNonceBuilder
   -> n
       ( Core.WorkerIndexer
           m
-          (ExtLedgerStateCoordinator.ExtLedgerStateEvent, WithDistance BlockEvent)
+          EpochEvent
           Nonce.EpochNonce
           (Core.WithTrace m Core.SQLiteIndexer)
       )
@@ -263,12 +265,11 @@ epochNonceBuilder securityParam catchupConfig textLogger path =
           indexerName
           securityParam
           catchupConfig
-          (pure . Nonce.getEpochNonce . fst)
+          (pure . epochNonce)
           (BM.appendName indexerName indexerEventLogger)
-      getEpochNo (ExtLedgerStateCoordinator.ExtLedgerStateEvent ledgerState _) = Nonce.getEpochNo ledgerState
    in Nonce.epochNonceWorker
         epochNonceWorkerConfig
-        (Nonce.EpochNonceWorkerConfig $ fromMaybe 0 . getEpochNo . fst)
+        (Nonce.EpochNonceWorkerConfig epochNo)
         (Core.parseDBLocation (path </> "epochNonce.db"))
 
 -- | Configure and start the @EpochSDD@ indexer
@@ -281,7 +282,7 @@ epochSDDBuilder
   -> n
       ( Core.WorkerIndexer
           m
-          (ExtLedgerStateCoordinator.ExtLedgerStateEvent, WithDistance BlockEvent)
+          EpochEvent
           (NonEmpty SDD.EpochSDD)
           (Core.WithTrace m Core.SQLiteIndexer)
       )
@@ -293,12 +294,11 @@ epochSDDBuilder securityParam catchupConfig textLogger path =
           indexerName
           securityParam
           catchupConfig
-          (pure . SDD.getEpochSDD . fst)
+          (pure . epochSDD)
           (BM.appendName indexerName indexerEventLogger)
-      getEpochNo (ExtLedgerStateCoordinator.ExtLedgerStateEvent ledgerState _) = Nonce.getEpochNo ledgerState
    in SDD.epochSDDWorker
         epochSDDWorkerConfig
-        (SDD.EpochSDDWorkerConfig $ fromMaybe 0 . getEpochNo . fst)
+        (SDD.EpochSDDWorkerConfig epochNo)
         (Core.parseDBLocation (path </> "epochSDD.db"))
 
 -- | Configure and start the @SnapshotBlockEvent@ indexer
@@ -346,7 +346,10 @@ extractSnapshotBlockEvent =
 buildIndexersForSnapshot
   :: SecurityParam
   -> Core.CatchupConfig
-  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig IO (WithDistance BlockEvent)
+  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig
+      IO
+      (ExtLedgerStateEvent, WithDistance BlockEvent)
+      (WithDistance BlockEvent)
   -> BM.Trace IO Text
   -> MarconiTrace IO
   -> FilePath
@@ -359,7 +362,7 @@ buildIndexersForSnapshot
 buildIndexersForSnapshot
   securityParam
   catchupConfig
-  epochStateConfig
+  ledgerStateConfig
   textLogger
   prettyLogger
   path
@@ -390,11 +393,11 @@ buildIndexersForSnapshot
             (path </> show no)
             blockRange'
             nodeConfig
-        return [snapshotExtLedgerStateWorker, snapshotBlockEventWorker]
+        pure [snapshotExtLedgerStateWorker, snapshotBlockEventWorker]
 
-    Core.WorkerIndexer _epochStateMVar snapshotWorker <-
+    Core.WorkerIndexer _ledgerStateMVar snapshotWorker <-
       ExtLedgerStateCoordinator.extLedgerStateWorker
-        epochStateConfig
+        ledgerStateConfig
         (concat snapshotWorkers)
         path
 
@@ -439,7 +442,6 @@ snapshotExtLedgerStateEventBuilder securityParam catchupConfig textLogger path b
           (pure . Just . fst)
           (BM.appendName indexerName indexerEventLogger)
    in snapshotExtLedgerStateEventWorker
-        securityParam
         standardWorkerConfig
         (SnapshotWorkerConfig (ExtLedgerStateCoordinator.blockNo . fst) blockRange' nodeConfig)
         path
@@ -447,8 +449,7 @@ snapshotExtLedgerStateEventBuilder securityParam catchupConfig textLogger path b
 snapshotExtLedgerStateEventWorker
   :: forall input m n
    . (MonadIO m, MonadError Core.IndexerError m, MonadIO n)
-  => SecurityParam
-  -> StandardWorkerConfig n input ExtLedgerStateEvent
+  => StandardWorkerConfig n input ExtLedgerStateEvent
   -> SnapshotWorkerConfig input
   -> FilePath
   -> m
@@ -458,11 +459,11 @@ snapshotExtLedgerStateEventWorker
           ExtLedgerStateEvent
           (Core.WithTrace n (Core.FileIndexer EpochMetadata))
       )
-snapshotExtLedgerStateEventWorker securityParam standardWorkerConfig snapshotBlockEventWorkerConfig path = do
+snapshotExtLedgerStateEventWorker standardWorkerConfig snapshotBlockEventWorkerConfig path = do
   codecConfig <- getConfigCodec (SnapshotBlockEvent.nodeConfig snapshotBlockEventWorkerConfig)
   indexer <-
     Core.withTrace (logger standardWorkerConfig)
-      <$> buildExtLedgerStateEventIndexer codecConfig securityParam path
+      <$> buildExtLedgerStateEventIndexer codecConfig path
   let preprocessor =
         Core.traverseMaybeEvent (lift . eventExtractor standardWorkerConfig)
           <<< justBeforeBlockRangePreprocessor

--- a/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Indexers.hs
+++ b/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Indexers.hs
@@ -114,7 +114,7 @@ buildIndexers
   -> Core.CatchupConfig
   -> Utxo.UtxoIndexerConfig
   -> MintTokenEvent.MintTokenEventConfig
-  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig IO EpochEvent (WithDistance BlockEvent)
+  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig EpochEvent (WithDistance BlockEvent)
   -> BM.Trace IO Text
   -> MarconiTrace IO
   -> FilePath
@@ -151,6 +151,7 @@ buildIndexers
     Core.WorkerIndexer _ledgerStateMVar ledgerStateWorker <-
       ExtLedgerStateCoordinator.extLedgerStateWorker
         ledgerStateConfig
+        ledgerStateTextLogger
         [epochSDDWorker, epochNonceWorker]
         path
 
@@ -347,7 +348,6 @@ buildIndexersForSnapshot
   :: SecurityParam
   -> Core.CatchupConfig
   -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig
-      IO
       (ExtLedgerStateEvent, WithDistance BlockEvent)
       (WithDistance BlockEvent)
   -> BM.Trace IO Text
@@ -372,6 +372,7 @@ buildIndexersForSnapshot
         mainLogger = BM.contramap (fmap (fmap $ Text.pack . show)) textLogger
         blockEventTextLogger = BM.appendName "blockEvent" textLogger
         blockEventLogger = BM.appendName "blockEvent" mainLogger
+        ledgerStateTextLogger = BM.appendName "ledgerState" blockEventTextLogger
         snapshotBlockEventTextLogger = BM.appendName "snapshotBlockEvent" blockEventTextLogger
         snapshotExtLedgerStateTextLogger = BM.appendName "snapshotBlockEvent" blockEventTextLogger
 
@@ -398,6 +399,7 @@ buildIndexersForSnapshot
     Core.WorkerIndexer _ledgerStateMVar snapshotWorker <-
       ExtLedgerStateCoordinator.extLedgerStateWorker
         ledgerStateConfig
+        ledgerStateTextLogger
         (concat snapshotWorkers)
         path
 

--- a/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Run.hs
+++ b/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Run.hs
@@ -139,7 +139,6 @@ run appName = withGracefulTermination_ $ do
         ( ExtLedgerState.ExtLedgerStateWorkerConfig
             Distance.getEvent
             Distance.chainDistance
-            trace
             nodeConfigPath
             epochStateSnapshotInterval
             securityParam

--- a/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Run.hs
+++ b/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Run.hs
@@ -9,7 +9,7 @@ import Cardano.BM.Trace (logError, logInfo)
 import Cardano.BM.Tracing qualified as BM
 import Control.Concurrent.Async (race_)
 import Control.Exception (finally)
-import Control.Monad (unless)
+import Control.Monad (guard, unless)
 import Control.Monad.Except (runExceptT)
 import Control.Monad.Reader (runReaderT)
 import Data.Aeson (toJSON)
@@ -55,6 +55,10 @@ import System.Posix.Signals (
  )
 import qualified Marconi.Cardano.Indexers.ExtLedgerStateCoordinator as ExtLedgerState
 import qualified Marconi.Cardano.Core.Extract.WithDistance as Distance
+import qualified Marconi.Cardano.Indexers.EpochSDD as EpochSDD
+import qualified Marconi.Cardano.Indexers.EpochNonce as EpochNonce
+import qualified Marconi.Cardano.ChainIndex.Indexers as Indexers
+import Marconi.Cardano.Indexers.ExtLedgerStateCoordinator (ExtLedgerStateEvent(extLedgerState))
 #endif
 
 run :: Text -> IO ()
@@ -74,8 +78,8 @@ run appName = withGracefulTermination_ $ do
 
   createDirectoryIfMissing True (Cli.optionsDbPath o)
 
-  let batchSize = 5000
-      volatileEpochStateSnapshotInterval = 1000
+  let batchSize = Cli.batchSizeConfig $ Cli.commonOptions o
+      epochStateSnapshotInterval = 100000
       filteredAddresses = shelleyAddressesToAddressAny $ Cli.optionsTargetAddresses o
       filteredAssetIds = Cli.optionsTargetAssets o
       includeScript = not $ Cli.optionsDisableScript o
@@ -117,6 +121,13 @@ run appName = withGracefulTermination_ $ do
         Utils.querySecurityParam @Void networkId socketPath
 
   let SecurityParam stopCatchupDistance = securityParam
+      extLedgerStateAsEvent previousLedgerStateEvent ledgerStateEvent _blockEvent = do
+        previousEpochNo <- ExtLedgerState.getEpochNo $ extLedgerState previousLedgerStateEvent
+        epochNo <- ExtLedgerState.getEpochNo $ extLedgerState ledgerStateEvent
+        guard $ epochNo /= previousEpochNo
+        let sdd = EpochSDD.getEpochSDD ledgerStateEvent
+            nonce = EpochNonce.getEpochNonce ledgerStateEvent
+        pure $ Indexers.EpochEvent epochNo sdd nonce
 
   mindexers <-
     runExceptT $
@@ -127,10 +138,12 @@ run appName = withGracefulTermination_ $ do
         (MintTokenEvent.MintTokenEventConfig filteredAssetIds)
         ( ExtLedgerState.ExtLedgerStateWorkerConfig
             Distance.getEvent
+            Distance.chainDistance
             trace
             nodeConfigPath
-            volatileEpochStateSnapshotInterval
+            epochStateSnapshotInterval
             securityParam
+            extLedgerStateAsEvent
         )
         trace
         marconiTrace
@@ -176,6 +189,10 @@ shelleyAddressesToAddressAny :: Maybe TargetAddresses -> [C.AddressAny]
 shelleyAddressesToAddressAny Nothing = []
 shelleyAddressesToAddressAny (Just targetAddresses) =
   fmap C.AddressShelley $ NEList.toList $ NESet.toList targetAddresses
+
+getBlockNo :: C.BlockInMode C.CardanoMode -> C.BlockNo
+getBlockNo (C.BlockInMode block _eraInMode) =
+  case C.getBlockHeader block of C.BlockHeader _ _ b -> b
 
 getStartingPoint :: Cli.StartingPoint -> C.ChainPoint -> C.ChainPoint
 getStartingPoint preferredStartingPoint indexerLastSyncPoint =

--- a/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Snapshot/Run.hs
+++ b/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Snapshot/Run.hs
@@ -65,10 +65,12 @@ run = do
   let extLedgerStateConfig =
         ExtLedgerStateWorkerConfig
           Distance.getEvent
+          Distance.chainDistance
           trace
           nodeConfigPath
           volatileEpochStateSnapshotInterval
           securityParam
+          (const $ curry Just)
       snapshotConfig =
         RunIndexerConfig
           marconiTrace

--- a/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Snapshot/Run.hs
+++ b/marconi-cardano-chain-index/src/Marconi/Cardano/ChainIndex/Snapshot/Run.hs
@@ -66,7 +66,6 @@ run = do
         ExtLedgerStateWorkerConfig
           Distance.getEvent
           Distance.chainDistance
-          trace
           nodeConfigPath
           volatileEpochStateSnapshotInterval
           securityParam

--- a/marconi-cardano-chain-index/test-lib/Test/Marconi/Cardano/ChainIndex/Indexers.hs
+++ b/marconi-cardano-chain-index/test-lib/Test/Marconi/Cardano/ChainIndex/Indexers.hs
@@ -145,7 +145,7 @@ buildIndexers
   -> Core.CatchupConfig
   -> Utxo.UtxoIndexerConfig
   -> MintTokenEvent.MintTokenEventConfig
-  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig IO EpochEvent (WithDistance BlockEvent)
+  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig EpochEvent (WithDistance BlockEvent)
   -> BM.Trace IO Text
   -> MarconiTrace IO
   -> FilePath
@@ -181,6 +181,7 @@ buildIndexers
     Core.WorkerIndexer _epochStateMVar epochStateWorker <-
       ExtLedgerStateCoordinator.extLedgerStateWorker
         epochStateConfig
+        epochStateTextLogger
         [epochSDDWorker, epochNonceWorker]
         path
 

--- a/marconi-cardano-chain-index/test-lib/Test/Marconi/Cardano/ChainIndex/Indexers.hs
+++ b/marconi-cardano-chain-index/test-lib/Test/Marconi/Cardano/ChainIndex/Indexers.hs
@@ -17,6 +17,7 @@ import Control.Monad.Trans (lift)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Marconi.Cardano.ChainIndex.Indexers (EpochEvent)
 import Marconi.Cardano.ChainIndex.Indexers qualified as Indexers
 import Marconi.Cardano.Core.Extract.WithDistance (WithDistance)
 import Marconi.Cardano.Core.Indexer.Worker (
@@ -144,7 +145,7 @@ buildIndexers
   -> Core.CatchupConfig
   -> Utxo.UtxoIndexerConfig
   -> MintTokenEvent.MintTokenEventConfig
-  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig IO (WithDistance BlockEvent)
+  -> ExtLedgerStateCoordinator.ExtLedgerStateWorkerConfig IO EpochEvent (WithDistance BlockEvent)
   -> BM.Trace IO Text
   -> MarconiTrace IO
   -> FilePath

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddress-MissingBech32Prefix.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddress-MissingBech32Prefix.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddress-badFormat.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddress-badFormat.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddressPrefix-stake1.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddressPrefix-stake1.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddressPrefix-stake_test.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddressPrefix-stake_test.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddress_1CharShort.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAddress_1CharShort.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-invalidBase16Format.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-invalidBase16Format.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-invalidBase16Length.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-invalidBase16Length.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-tooLong.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-tooLong.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1ByteLong.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1ByteLong.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1ByteShort.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1ByteShort.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1HexCharLong.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1HexCharLong.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1HexCharShort.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1HexCharShort.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-badBase16Format.golden
+++ b/marconi-cardano-chain-index/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-badBase16Format.golden
@@ -8,7 +8,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/Cli/marconi-cardano-chain-index___disable_address_data.help
+++ b/marconi-cardano-chain-index/test/Spec/Golden/Cli/marconi-cardano-chain-index___disable_address_data.help
@@ -11,7 +11,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 

--- a/marconi-cardano-chain-index/test/Spec/Golden/Cli/marconi-cardano-chain-index___help.help
+++ b/marconi-cardano-chain-index/test/Spec/Golden/Cli/marconi-cardano-chain-index___help.help
@@ -9,7 +9,8 @@ Usage: marconi-cardano-chain-index [--version] [--debug]
                                      --start-from SLOT-NO:BLOCK-HEADER-HASH] 
                                    [--initial-retry-time NATURAL] 
                                    [--no-max-retry-time | 
-                                     --max-retry-time NATURAL] (-d|--db-dir DIR)
+                                     --max-retry-time NATURAL] 
+                                   [--batch-size INT] (-d|--db-dir DIR) 
                                    [--enable-txoutref] [--disable-utxo] 
                                    [--disable-address-datum] 
                                    [--disable-script-tx] 
@@ -43,6 +44,8 @@ Available options:
   --no-max-retry-time      Unlimited retries.
   --max-retry-time NATURAL Max time (in seconds) allowed after startup for
                            retries. Defaults to 30min.
+  --batch-size INT         Number of blocks send as a batch to the indexers
+                           (default: 3000)
   -d,--db-dir DIR          Directory path where all Marconi-related SQLite
                            databases are located.
   --enable-txoutref        enable txout ref storage.

--- a/marconi-cardano-chain-index/test/Spec/Golden/Cli/marconi-cardano-chain-index___help.help
+++ b/marconi-cardano-chain-index/test/Spec/Golden/Cli/marconi-cardano-chain-index___help.help
@@ -44,7 +44,7 @@ Available options:
   --no-max-retry-time      Unlimited retries.
   --max-retry-time NATURAL Max time (in seconds) allowed after startup for
                            retries. Defaults to 30min.
-  --batch-size INT         Number of blocks send as a batch to the indexers
+  --batch-size INT         Number of blocks sent as a batch to the indexers
                            (default: 3000)
   -d,--db-dir DIR          Directory path where all Marconi-related SQLite
                            databases are located.

--- a/marconi-cardano-core/test-lib/Test/Gen/Marconi/Cardano/Core/Types.hs
+++ b/marconi-cardano-core/test-lib/Test/Gen/Marconi/Cardano/Core/Types.hs
@@ -11,7 +11,7 @@ module Test.Gen.Marconi.Cardano.Core.Types (
   genChainPoints,
   genChainPoint,
   genChainPoint',
-  genExecutionUnits,
+  CGen.genExecutionUnits,
   genSlotNo,
   genTxBodyContentWithTxInsCollateral,
   genTxBodyContentForPlutusScripts,
@@ -28,7 +28,7 @@ module Test.Gen.Marconi.Cardano.Core.Types (
   genHashScriptData,
   genAssetId,
   genPolicyId,
-  genQuantity,
+  CGen.genQuantity,
   CGen.genEpochNo,
   genPoolId,
 ) where
@@ -60,7 +60,6 @@ import Data.Word (Word64)
 import GHC.Natural (Natural)
 import Hedgehog (Gen, MonadGen)
 import Hedgehog.Gen qualified as Gen
-import Hedgehog.Range (Range)
 import Hedgehog.Range qualified as Range
 import Marconi.Cardano.Core.Types (TargetAddresses)
 import PlutusCore.Evaluation.Machine.ExBudgetingDefaults (defaultCostModelParams)
@@ -290,7 +289,7 @@ genWitnessAndHashInEra era = do
     C.ScriptWitness C.ScriptWitnessForSpending <$> case script of
       C.PlutusScript version plutusScript -> do
         scriptData <- CGen.genHashableScriptData
-        executionUnits <- genExecutionUnits
+        executionUnits <- CGen.genExecutionUnits
         pure $
           C.PlutusScriptWitness
             scriptLanguageInEra
@@ -302,15 +301,6 @@ genWitnessAndHashInEra era = do
       C.SimpleScript simpleScript ->
         pure $ C.SimpleScriptWitness scriptLanguageInEra (C.SScript simpleScript)
   pure (witness, C.hashScript script)
-
-{- | TODO Copy-paste from cardano-node: cardano-api/gen/Gen/Cardano/Api/Typed.hs
- Copied from cardano-api. Delete when this function is reexported
--}
-genExecutionUnits :: Gen C.ExecutionUnits
-genExecutionUnits =
-  C.ExecutionUnits
-    <$> Gen.integral (Range.constant 0 1000)
-    <*> Gen.integral (Range.constant 0 1000)
 
 {- | Generate a @C.'TxOut'@ in the given era. It can contain Shelley or Byron addresses.
 For a version that only gives Shelley addresses, see 'genShelleyTxOutTxContext'.
@@ -474,8 +464,8 @@ genProtocolParametersForPlutusScripts =
           ]
       )
     <*> (Just <$> genExecutionUnitPrices)
-    <*> (Just <$> genExecutionUnits)
-    <*> (Just <$> genExecutionUnits)
+    <*> (Just <$> CGen.genExecutionUnits)
+    <*> (Just <$> CGen.genExecutionUnits)
     <*> (Just <$> genNat)
     <*> (Just <$> genNat)
     <*> (Just <$> genNat)
@@ -517,10 +507,6 @@ genPolicyId =
     , -- and some from the full range of the type
       (1, C.PolicyId <$> CGen.genScriptHash)
     ]
-
--- TODO Copied from cardano-api. Delete once reexported
-genQuantity :: Range Integer -> Gen C.Quantity
-genQuantity range = fromInteger <$> Gen.integral range
 
 genPoolId :: Gen (C.Hash C.StakePoolKey)
 genPoolId = C.StakePoolKeyHash . KeyHash . mkDummyHash <$> Gen.int (Range.linear 0 10)

--- a/marconi-cardano-indexers/marconi-cardano-indexers.cabal
+++ b/marconi-cardano-indexers/marconi-cardano-indexers.cabal
@@ -109,11 +109,9 @@ library
     , filepath
     , lens
     , mtl
-    , prettyprinter
     , sqlite-simple
     , text
     , time
-    , transformers
     , vector-map
 
 test-suite marconi-cardano-indexers-test

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/BlockInfo.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/BlockInfo.hs
@@ -66,7 +66,6 @@ import Marconi.Cardano.Core.Types (BlockEvent (BlockEvent), SecurityParam)
 import Marconi.Cardano.Indexers.SyncHelper (mkSingleInsertSyncedSqliteIndexer)
 import Marconi.Core qualified as Core
 import Marconi.Core.Indexer.SQLiteIndexer (SQLiteDBLocation)
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import System.FilePath ((</>))
 
 data BlockInfo = BlockInfo

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Datum.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Datum.hs
@@ -64,9 +64,8 @@ import Marconi.Cardano.Core.Types (
   SecurityParam,
  )
 import Marconi.Cardano.Indexers.SyncHelper qualified as Sync
+import Marconi.Core (SQLiteDBLocation)
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer (SQLiteDBLocation)
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import System.FilePath ((</>))
 
 data DatumInfo = DatumInfo

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/EpochNonce.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/EpochNonce.hs
@@ -96,8 +96,8 @@ mkEpochNonceIndexer path = do
               ( epochNo INT NOT NULL
               , nonce BLOB NOT NULL
               , blockNo INT NOT NULL
-              , slotNo INT
-              , blockHeaderHash BLOB
+              , slotNo INT NOT NULL
+              , blockHeaderHash BLOB NOT NULL
               )|]
       nonceInsertQuery =
         [sql|INSERT INTO epoch_nonce

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/EpochNonce.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/EpochNonce.hs
@@ -96,8 +96,8 @@ mkEpochNonceIndexer path = do
               ( epochNo INT NOT NULL
               , nonce BLOB NOT NULL
               , blockNo INT NOT NULL
-              , slotNo INT NOT NULL
-              , blockHeaderHash BLOB NOT NULL
+              , slotNo INT
+              , blockHeaderHash BLOB
               )|]
       nonceInsertQuery =
         [sql|INSERT INTO epoch_nonce

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/EpochSDD.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/EpochSDD.hs
@@ -57,6 +57,7 @@ import Marconi.Cardano.Core.Indexer.Worker (
 import Marconi.Cardano.Core.Orphans ()
 import Marconi.Cardano.Indexers.ExtLedgerStateCoordinator (
   ExtLedgerStateEvent (ExtLedgerStateEvent),
+  getEpochNo,
   newEpochPreprocessor,
  )
 import Marconi.Cardano.Indexers.SyncHelper qualified as Sync
@@ -165,20 +166,6 @@ getEpochSDD (ExtLedgerStateEvent ledgerState blockNo) = NonEmpty.nonEmpty $ do
   epochNo <- toList $ getEpochNo ledgerState
   (poolId, lovelace) <- Map.toList $ getStakeMap ledgerState
   pure $ EpochSDD epochNo poolId lovelace blockNo
-
-getEpochNo
-  :: O.ExtLedgerState (O.CardanoBlock O.StandardCrypto)
-  -> Maybe C.EpochNo
-getEpochNo extLedgerState' = case O.ledgerState extLedgerState' of
-  O.LedgerStateByron _st -> Nothing
-  O.LedgerStateShelley st -> getEpochNoFromShelleyBlock st
-  O.LedgerStateAllegra st -> getEpochNoFromShelleyBlock st
-  O.LedgerStateMary st -> getEpochNoFromShelleyBlock st
-  O.LedgerStateAlonzo st -> getEpochNoFromShelleyBlock st
-  O.LedgerStateBabbage st -> getEpochNoFromShelleyBlock st
-  O.LedgerStateConway st -> getEpochNoFromShelleyBlock st
-  where
-    getEpochNoFromShelleyBlock = Just . Ledger.nesEL . O.shelleyLedgerState
 
 {- | From LedgerState, get epoch stake pool delegation: a mapping of pool ID to amount staked in
  lovelace. We do this by getting the 'ssStakeMark stake snapshot and then use 'ssDelegations' and

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/ExtLedgerStateCoordinator.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/ExtLedgerStateCoordinator.hs
@@ -4,13 +4,23 @@
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
--- | A coordinator that also maintains the @ExtLedgerState@.
+{- | A coordinator that also maintains the @ExtLedgerState@.
+
+* It takes an @input@ computes the @ExtLedgerState@ out of it
+  (in a preprocessor, we don't want to pass the ledger state if it isn't needed)
+* volatile @ExtLedgerState@s are stored in memory
+  (in a preprocessor as well).
+* Compute the @output@ from there
+* pass the @output@ to the underlying coordinator
+* saves the last known stable ledger state systematically on close
+-}
 module Marconi.Cardano.Indexers.ExtLedgerStateCoordinator (
   -- * Types
   ExtLedgerState,
@@ -27,9 +37,9 @@ module Marconi.Cardano.Indexers.ExtLedgerStateCoordinator (
   buildExtLedgerStateEventIndexer,
 
   -- * Utils
+  getEpochNo,
   newEpochPreprocessor,
   readGenesisFile,
-  extractBlockEvent,
 
   -- * For testing
   deserialiseLedgerState,
@@ -48,42 +58,36 @@ import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Write qualified as CBOR
 import Control.Arrow ((<<<))
 import Control.Concurrent qualified as Con
-import Control.Exception (throw)
-import Control.Lens (Lens', (%~), (&), (-~), (.=), (.~), (^.))
+import Control.Lens ((%=), (+=), (-=), (.=), (^.))
 import Control.Lens qualified as Lens
-import Control.Monad (foldM, (<=<))
+import Control.Monad (guard, when)
 import Control.Monad.Except (ExceptT, MonadError (throwError), runExceptT)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.State.Strict (MonadState (put), gets)
-import Control.Monad.Trans (lift)
-import Control.Monad.Trans.Maybe (MaybeT (runMaybeT))
 import Data.Bifunctor (Bifunctor (bimap))
-import Data.ByteString qualified as BS
 import Data.ByteString.Base16 qualified as Base16
-import Data.ByteString.Lazy qualified as BS.Lazy
+import Data.ByteString.Builder (Builder)
+import Data.ByteString.Lazy qualified as BS
 import Data.ByteString.Short qualified as BS.Short
 import Data.Data (Proxy (Proxy))
-import Data.List (sortOn)
-import Data.Map qualified as Map
-import Data.Maybe (fromMaybe, listToMaybe)
+import Data.Foldable (foldrM)
+import Data.Functor (($>))
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Ord (Down (Down), comparing)
+import Data.Sequence (Seq)
+import Data.Sequence qualified as Seq
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
-import Marconi.Cardano.Core.Extract.WithDistance (WithDistance, chainDistance)
+import Data.Word (Word64)
 import Marconi.Cardano.Core.Orphans ()
 import Marconi.Cardano.Core.Types (BlockEvent, SecurityParam (SecurityParam), blockInMode)
-import Marconi.Core (IsSync (lastStablePoint))
 import Marconi.Core qualified as Core
-import Marconi.Core.Preprocessor qualified as Core
 import Ouroboros.Consensus.Cardano.Block qualified as O
 import Ouroboros.Consensus.Config qualified as O
 import Ouroboros.Consensus.Ledger.Extended qualified as O
-import Ouroboros.Consensus.Node.NetworkProtocolVersion qualified as O
-import Ouroboros.Consensus.Node.Serialisation qualified as O
 import Ouroboros.Consensus.Shelley.Ledger qualified as O
 import Ouroboros.Consensus.Storage.Serialisation qualified as O
-import Prettyprinter (Pretty (pretty))
 import System.Directory (createDirectoryIfMissing)
 import System.FilePath ((</>))
 import Text.Read qualified as Text
@@ -95,20 +99,6 @@ type CodecConfig = O.CodecConfig (O.HardForkBlock (O.CardanoEras O.StandardCrypt
 type instance Core.Point ExtLedgerState = C.ChainPoint
 type instance Core.Point (C.BlockInMode C.CardanoMode) = C.ChainPoint
 
-data ExtLedgerStateCoordinatorConfig input = ExtLedgerStateCoordinatorConfig
-  { _configExtractBlockEvent :: input -> BlockEvent
-  -- ^ extract block event from the input
-  , _configGenesisConfig :: C.GenesisConfig
-  -- ^ used to bootstrap the ledger state
-  , _configSnapshotInterval :: Word
-  -- ^ how often we save the ledger state saving often is expensive but make rollbacks faster
-  , _configSecurityParam :: SecurityParam
-  -- ^ we use the security param to decide when we trigger the saves, on stable data, we save at
-  -- each epoch only
-  }
-
-Lens.makeLenses ''ExtLedgerStateCoordinatorConfig
-
 -- | Base event used to store the 'ExtLedgerState'
 data ExtLedgerStateEvent = ExtLedgerStateEvent
   { extLedgerState :: ExtLedgerState
@@ -118,16 +108,10 @@ data ExtLedgerStateEvent = ExtLedgerStateEvent
 
 type instance Core.Point ExtLedgerStateEvent = C.ChainPoint
 
-data ExtLedgerStateCoordinatorState = ExtLedgerStateCoordinatorState
-  { _stateBlocksToNextSnapshot :: Word
-  -- ^ Number of block before the next snapshot
-  , _stateEpochNo :: Maybe C.EpochNo
-  -- ^ LastEpochNo saved
-  , _stateSnapshots :: [C.ChainPoint]
-  -- ^ Track the previous snapshot, used for resuming
+newtype ExtLedgerStateCoordinatorConfig = ExtLedgerStateCoordinatorConfig
+  { _configGenesisConfig :: C.GenesisConfig
+  -- ^ used to bootstrap the ledger state
   }
-
-Lens.makeLenses ''ExtLedgerStateCoordinatorState
 
 -- | Metadata used to create 'ExtLedgerStateEventIndexer' filenames
 data EpochMetadata = EpochMetadata
@@ -138,193 +122,251 @@ data EpochMetadata = EpochMetadata
 
 type ExtLedgerStateFileIndexer = Core.FileIndexer EpochMetadata ExtLedgerStateEvent
 
-type BlockFileIndexer = Core.FileIndexer EpochMetadata (C.BlockInMode C.CardanoMode)
-
-data ExtLedgerStateCoordinator input = ExtLedgerStateCoordinator
-  { _extLedgerStateCoordinatorConfig :: ExtLedgerStateCoordinatorConfig input
-  -- ^ The configuration of the coordinator
-  , _extLedgerStateCoordinatorState :: ExtLedgerStateCoordinatorState
-  -- ^ The current state of the coordinator
-  , _extLedgerStateIndexer :: ExtLedgerStateFileIndexer
-  -- ^ The indexer that manage the ledger state snapshot to handle backup and resuming
-  , _blockIndexer :: BlockFileIndexer
-  -- ^ The indexer that serialise blocks to handle resuming
-  , _coordinator :: Core.Coordinator input
+newtype ExtLedgerStateCoordinator output input = ExtLedgerStateCoordinator
+  { _coordinator :: Core.Coordinator output
   -- ^ A standard coordinator, which handles the workers
   }
 
 Lens.makeLenses ''ExtLedgerStateCoordinator
 
--- | The state maintained by the indexer to decide how to handle incoming events
-data WorkerState input = WorkerState
-  { _lastLedgerState :: ExtLedgerStateEvent
+data ExtLedgerStatePersistConfig = ExtLedgerStatePersistConfig
+  { _blocksToNextSnapshot :: Word64
+  -- ^ Number of block before the next snapshot
+  , _snapshotInterval :: Word64
+  -- ^ Track the previous snapshot, used for resuming
+  , _ledgerStateIndexer :: ExtLedgerStateFileIndexer
+  }
+
+Lens.makeLenses ''ExtLedgerStatePersistConfig
+
+-- | The state maintained by the preprocessor of the indexer to decide how to handle incoming events
+data PreprocessorState output input = PreprocessorState
+  { _ledgerStates :: Seq (Core.Timed C.ChainPoint ExtLedgerStateEvent)
   -- ^ The last computed ledger state
-  , _accessToIndexer
-      :: Con.MVar
-          ( Core.WithTrace
-              IO
-              ExtLedgerStateCoordinator
-              (ExtLedgerStateEvent, WithDistance input)
-          )
-  -- ^ allow query to the indexer
+  , _lastLedgerState :: Core.Timed C.ChainPoint ExtLedgerStateEvent
+  , _currentLength :: Word64
+  -- ^ stored ledger state
+  , _maxLength :: Word64
+  -- ^ how many of them do we keep in memory
+  , _persistConfig :: ExtLedgerStatePersistConfig
+  -- ^ the indexer that saves snapshots
   }
 
-Lens.makeLenses ''WorkerState
+Lens.makeLenses ''PreprocessorState
 
-genesisConfig :: Lens.Getter (ExtLedgerStateCoordinator input) C.GenesisConfig
-genesisConfig = extLedgerStateCoordinatorConfig . configGenesisConfig
+{- | Used to maintain a list of `maxLength` ledger states in memory.
+  When full, the oldest stored ledger state is pushed out of the queue
+  and we check if it should be saved (we save every `snapshotInterval + 1` time)
+-}
+updateLatestLedgerState
+  :: (MonadIO io, MonadState (PreprocessorState output input) io, MonadError Core.IndexerError io)
+  => Bool
+  -> Core.Timed C.ChainPoint ExtLedgerStateEvent
+  -> io (Maybe C.ChainPoint)
+updateLatestLedgerState isVolatile' event = do
+  ledgerStates' <- Lens.use ledgerStates
+  snapshotCandidate <- case ledgerStates' of
+    -- If we didn't start volatile event yet
+    Seq.Empty -> do
+      eventToSave <- Lens.use lastLedgerState
+      if isVolatile'
+        then -- We save the last stable event before we reach volatile ones
+        do
+          persistConfig . blocksToNextSnapshot .= 0
+          ledgerStates %= (event Seq.<|)
+        else do
+          persistConfig . blocksToNextSnapshot -= 1
+      timeToNextSnapshot <- Lens.use $ persistConfig . blocksToNextSnapshot
+      pure $ guard (timeToNextSnapshot == 0) $> eventToSave
+    xs Seq.:|> oldestLedgerState -> do
+      max' <- Lens.use maxLength
+      current <- Lens.use currentLength
+      let bufferIsFull = max' <= current
+      when isVolatile' $ do
+        if bufferIsFull
+          then ledgerStates .= (event Seq.<| xs)
+          else do
+            ledgerStates %= (event Seq.<|)
+            currentLength += 1
+      timeToNextSnapshot <- Lens.use $ persistConfig . blocksToNextSnapshot
+      pure $ guard (timeToNextSnapshot == 0 && bufferIsFull) $> oldestLedgerState
+  lastLedgerState .= event
+  case snapshotCandidate of
+    Nothing -> pure Nothing
+    Just eventToSave -> do
+      snapshotInterval' <- Lens.use $ persistConfig . snapshotInterval
+      persistConfig . blocksToNextSnapshot .= snapshotInterval'
+      let savePoint = eventToSave ^. Core.point
+      indexer <- Lens.use $ persistConfig . ledgerStateIndexer
+      indexer' <- Core.setLastStablePoint savePoint =<< Core.index (Just <$> eventToSave) indexer
+      persistConfig . ledgerStateIndexer .= indexer'
+      pure $ Just savePoint
 
-extLedgerConfig :: Lens.Getter (ExtLedgerStateCoordinator input) ExtLedgerConfig
-extLedgerConfig = genesisConfig . Lens.to CE.mkExtLedgerConfig
-
-snapshotInterval :: Lens.Getter (ExtLedgerStateCoordinator input) Word
-snapshotInterval = extLedgerStateCoordinatorConfig . configSnapshotInterval
-
-securityParam :: Lens.Getter (ExtLedgerStateCoordinator input) SecurityParam
-securityParam = extLedgerStateCoordinatorConfig . configSecurityParam
-
-extractBlockEvent :: Lens.Getter (ExtLedgerStateCoordinator input) (input -> BlockEvent)
-extractBlockEvent = extLedgerStateCoordinatorConfig . configExtractBlockEvent
-
-blocksToNextSnapshot :: Lens' (ExtLedgerStateCoordinator input) Word
-blocksToNextSnapshot = extLedgerStateCoordinatorState . stateBlocksToNextSnapshot
-
-snapshots :: Lens' (ExtLedgerStateCoordinator input) [C.ChainPoint]
-snapshots = extLedgerStateCoordinatorState . stateSnapshots
-
-lastEpochNo :: Lens' (ExtLedgerStateCoordinator input) (Maybe C.EpochNo)
-lastEpochNo = extLedgerStateCoordinatorState . stateEpochNo
-
-mkExtLedgerStateCoordinator
-  :: (MonadIO m, MonadError Core.IndexerError m, Core.Point (ExtLedgerStateEvent, input) ~ C.ChainPoint)
-  => ExtLedgerStateCoordinatorConfig (ExtLedgerStateEvent, input)
-  -> FilePath
-  -> [Core.Worker (ExtLedgerStateEvent, input) C.ChainPoint]
-  -> m (ExtLedgerStateCoordinator (ExtLedgerStateEvent, input))
-mkExtLedgerStateCoordinator config rootDir workers = do
-  let genesisCfg = config ^. configGenesisConfig
-      securityParam' = config ^. configSecurityParam
-      extLedgerCfg = CE.mkExtLedgerConfig genesisCfg
-      configCodec = O.configCodec . O.getExtLedgerCfg $ extLedgerCfg
-  liftIO $ createDirectoryIfMissing True rootDir
-  epochStateIndexer' <-
-    buildExtLedgerStateEventIndexer
-      configCodec
-      securityParam'
-      (rootDir </> "epochState")
-  epochBlocksIndexer <-
-    buildBlockIndexer
-      configCodec
-      securityParam'
-      (rootDir </> "epochBlocks")
-  coordinator' <- liftIO $ Core.mkCoordinator workers
-  let extLedgerStateCoordinatorState' =
-        ExtLedgerStateCoordinatorState
-          (config ^. configSnapshotInterval)
-          Nothing
-          []
-  pure $
-    ExtLedgerStateCoordinator
-      config
-      extLedgerStateCoordinatorState'
-      epochStateIndexer'
-      epochBlocksIndexer
-      coordinator'
-
-data ExtLedgerStateWorkerConfig m input = ExtLedgerStateWorkerConfig
+-- | Configuration of the worker
+data ExtLedgerStateWorkerConfig m output input = ExtLedgerStateWorkerConfig
   { workerEventExtractor :: input -> BlockEvent
+  -- ^ Get the blockEvent (required to compute the ledger state) from the event
+  , workerDistanceExtractor :: input -> Word64
+  -- ^ Get the distance to the tip
   , workerLogger :: BM.Trace m Text
+  -- ^ The logger
   , workerNodeConfigPath :: FilePath
-  , workerSnapshotInterval :: Word
+  -- ^ Location of the node config, used to initialise the ledger state
+  , workerSnapshotInterval :: Word64
+  -- ^ Number of blocks before two snapshots of the ledger state
   , workerSecurityParam :: SecurityParam
+  -- ^ Number of volatile blocks
+  , workerOutputBuilder :: ExtLedgerStateEvent -> ExtLedgerStateEvent -> input -> Maybe output
+  -- ^ How to create an @output@ from the previous ledger state, the current one and the current input
   }
 
+{- | The preprocessor maintain the ledger state and pass the processed ledger state to the
+coordinator.
+-}
+extLedgerStatePreprocessor
+  :: C.GenesisConfig
+  -> ExtLedgerStateWorkerConfig m output input
+  -> PreprocessorState input output
+  -> Core.Preprocessor (ExceptT Core.IndexerError IO) C.ChainPoint input output
+extLedgerStatePreprocessor genesisCfg config initialState =
+  let extLedgerCfg = CE.mkExtLedgerConfig genesisCfg
+      extract = workerEventExtractor config
+      applyBlock = CE.applyBlockExtLedgerState extLedgerCfg C.QuickValidation
+   in flip Core.preprocessorM (pure initialState) $ \case
+        Core.Rollback p -> do
+          -- Remove the invalid ledger state from the list of ledger states
+          (dropped, kept) <- Lens.uses ledgerStates (Seq.spanl ((p <) . Lens.view Core.point))
+          ledgerStates .= kept
+          case kept of
+            Seq.Empty -> pure ()
+            latest Seq.:<| _ -> lastLedgerState .= latest
+          currentLength -= fromIntegral (length dropped)
+          pure [Core.Rollback p]
+        Core.Index (Core.Timed p Nothing) -> pure [Core.Index $ Core.Timed p Nothing]
+        Core.Index (Core.Timed p (Just evt)) -> do
+          currentLedgerState <- Lens.use $ lastLedgerState . Core.event
+          let block = extract evt
+              blockInMode' = blockInMode block
+          case applyBlock blockInMode' (extLedgerState currentLedgerState) of
+            Left err -> throwError . Core.IndexerInternalError . Text.pack . show $ err
+            Right ledgerStateEvent -> do
+              let ledgerState = ExtLedgerStateEvent ledgerStateEvent (getBlockNo blockInMode')
+                  timedLedgerState = Core.Timed p ledgerState
+                  distance = workerDistanceExtractor config evt
+                  SecurityParam security = workerSecurityParam config
+                  isVolatile' = distance <= security
+                  outputEvent = workerOutputBuilder config currentLedgerState ledgerState evt
+                  timedOutput = Core.Timed p outputEvent
+              lastStablePoint' <- updateLatestLedgerState isVolatile' timedLedgerState
+              let stableAtInput = case lastStablePoint' of
+                    Nothing -> []
+                    Just C.ChainPointAtGenesis -> []
+                    Just p' -> [Core.StableAt p']
+              pure $ Core.Index timedOutput : stableAtInput
+        Core.IndexAllDescending evts -> do
+          currentLedgerState <- Lens.use (lastLedgerState . Core.event)
+          let go (Core.Timed _ Nothing) (l, acc) = pure (l, acc)
+              go (Core.Timed p (Just evt)) (l, acc) = do
+                let block = extract evt
+                    blockInMode' = blockInMode block
+                case applyBlock blockInMode' (extLedgerState l) of
+                  Left err -> throwError . Core.IndexerInternalError . Text.pack . show $ err
+                  Right ledgerStateEvent -> do
+                    let ledgerState = ExtLedgerStateEvent ledgerStateEvent (getBlockNo blockInMode')
+                        timedLedgerState = Core.Timed p ledgerState
+                        distance = workerDistanceExtractor config evt
+                        SecurityParam security = workerSecurityParam config
+                        isVolatile' = distance <= security
+                        outputEvent = workerOutputBuilder config currentLedgerState ledgerState evt
+                        timedOutput = Core.Timed p outputEvent
+                    lastStablePoint' <- updateLatestLedgerState isVolatile' timedLedgerState
+                    pure (ledgerState, maybe id ((:) . Core.StableAt) lastStablePoint' $ Core.Index timedOutput : acc)
+          outputs <- snd <$> foldrM go (currentLedgerState, []) (NonEmpty.toList evts)
+          pure $ reverse outputs
+        -- These are swallows as stability correspond to ledger state savepoints
+        Core.StableAt _p -> pure []
+        Core.Stop -> do
+          -- TODO close the indexer in a separateThread
+          indexer <- saveLastStable
+          Core.close indexer
+          pure [Core.Stop]
+
+saveLastStable
+  :: (MonadIO io, MonadState (PreprocessorState output input) io, MonadError Core.IndexerError io)
+  => io ExtLedgerStateFileIndexer
+saveLastStable = do
+  ledgerStates' <- Lens.use ledgerStates
+  eventToSave <- case ledgerStates' of
+    Seq.Empty ->
+      Just <$> Lens.use lastLedgerState
+    _xs Seq.:|> oldestLedgerState -> do
+      max' <- Lens.use maxLength
+      current <- Lens.use currentLength
+      let bufferIsFull = max' <= current
+      if bufferIsFull
+        then pure $ Just oldestLedgerState
+        else pure Nothing
+  indexer <- Lens.use (persistConfig . ledgerStateIndexer)
+  case eventToSave of
+    Nothing -> pure indexer
+    Just timedEvent ->
+      Core.setLastStablePoint (timedEvent ^. Core.point) =<< Core.index (Just <$> timedEvent) indexer
+
+{- | Create a naked coordinator.
+| You would usually prefer to use a worker, as it will maintain the
+| ledger state before sending it to the coordinator.
+-}
+mkExtLedgerStateCoordinator
+  :: (MonadIO m, MonadError Core.IndexerError m, Core.Point output ~ C.ChainPoint)
+  => [Core.Worker output C.ChainPoint]
+  -> m (ExtLedgerStateCoordinator output input)
+mkExtLedgerStateCoordinator workers = do
+  coordinator' <- liftIO $ Core.mkCoordinator workers
+  pure $ ExtLedgerStateCoordinator coordinator'
+
+-- | Create a worker for the extLedgerState coordinator
 extLedgerStateWorker
-  :: forall m input
+  :: forall m output input
    . ( MonadIO m
      , MonadError Core.IndexerError m
-     , Core.Point (ExtLedgerStateEvent, WithDistance input) ~ C.ChainPoint
+     , Core.Point output ~ C.ChainPoint
+     , Core.Point input ~ C.ChainPoint
      )
-  => ExtLedgerStateWorkerConfig IO (WithDistance input)
-  -> [Core.Worker (ExtLedgerStateEvent, WithDistance input) C.ChainPoint]
+  => ExtLedgerStateWorkerConfig IO output input
+  -> [Core.Worker output C.ChainPoint]
   -> FilePath
   -> m
       ( Core.WorkerIndexer
           IO
-          (WithDistance input)
-          (ExtLedgerStateEvent, WithDistance input)
-          (Core.WithTrace IO ExtLedgerStateCoordinator)
+          input
+          output
+          (Core.WithTrace IO (ExtLedgerStateCoordinator output))
       )
 extLedgerStateWorker config workers path = do
   genesisCfg <- readGenesisFile $ workerNodeConfigPath config
-  let extLedgerCfg = CE.mkExtLedgerConfig genesisCfg
-      extract = workerEventExtractor config
+  let SecurityParam securityParam' = workerSecurityParam config
       indexerName = "ExtLedgerStateEvent"
       indexerEventLogger = BM.contramap (fmap $ fmap $ Text.pack . show) $ workerLogger config
-      cfg =
-        ExtLedgerStateCoordinatorConfig
-          (extract . snd)
-          genesisCfg
-          (workerSnapshotInterval config)
-          (workerSecurityParam config)
-
-      mapOneEvent
-        :: (MonadState (WorkerState input) n, MonadError Core.IndexerError n, MonadIO n)
-        => Maybe (WithDistance input)
-        -> n (Maybe (ExtLedgerStateEvent, WithDistance input))
-      mapOneEvent Nothing = pure Nothing
-      mapOneEvent (Just evt) = runMaybeT $ do
-        let applyBlock = CE.applyBlockExtLedgerState extLedgerCfg C.QuickValidation
-            block = extract evt
-            blockInMode' = blockInMode block
-        let newBlockNo = getBlockNo blockInMode'
-        ExtLedgerStateEvent currentLedgerState' _block <- Lens.use lastLedgerState
-        case applyBlock blockInMode' currentLedgerState' of
-          Left err -> throwError . Core.IndexerInternalError . Text.pack . show $ err
-          Right res -> do
-            let ledgerStateEvent = ExtLedgerStateEvent res newBlockNo
-            lastLedgerState .= ledgerStateEvent
-            seq ledgerStateEvent $ pure (ledgerStateEvent, evt)
-
-      processAsEpochState
-        :: ExceptT Core.IndexerError IO (WorkerState input)
-        -> Core.Preprocessor
-            (ExceptT Core.IndexerError IO)
-            C.ChainPoint
-            (WithDistance input)
-            (ExtLedgerStateEvent, WithDistance input)
-      processAsEpochState = do
-        Core.preprocessorM $ \case
-          Core.Index x -> pure . Core.Index <$> traverse mapOneEvent x
-          Core.IndexAllDescending xs -> pure . Core.IndexAllDescending <$> traverse (traverse mapOneEvent) xs
-          Core.Rollback p -> do
-            lastIndexerM <- Lens.use accessToIndexer
-            lastIndexer <- liftIO $ Con.readMVar lastIndexerM
-            queryResult <- lift $ runExceptT $ Core.query p Core.EventAtQuery lastIndexer
-            case queryResult of
-              Left (Core.IndexerQueryError err) ->
-                throwError $
-                  Core.IndexerInternalError $
-                    "Can't rollback to the given epoch:" <> Text.pack (show err)
-              Left _err -> throwError $ Core.IndexerInternalError "Can't rollback to the given epoch"
-              Right Nothing -> throwError $ Core.IndexerInternalError "Can't rollback to the given epoch: no event found"
-              Right (Just res) -> do
-                lastLedgerState .= res
-                pure . pure $ Core.Rollback p
-          Core.StableAt p -> pure . pure $ Core.StableAt p
-          Core.Stop -> pure $ pure Core.Stop
-
+      rootDir = path </> "ledgerState"
+      initialExtLedgerStateEvent' = initialExtLedgerStateEvent genesisCfg
+      extLedgerCfg = CE.mkExtLedgerConfig genesisCfg
+      configCodec = O.configCodec . O.getExtLedgerCfg $ extLedgerCfg
+  liftIO $ createDirectoryIfMissing True rootDir
+  ledgerStateIndexer' <- buildExtLedgerStateEventIndexer configCodec rootDir
+  let snapshotInterval' = workerSnapshotInterval config
+      persistConfig' = ExtLedgerStatePersistConfig snapshotInterval' snapshotInterval' ledgerStateIndexer'
   coordinator' <-
     Core.withTrace indexerEventLogger
-      <$> mkExtLedgerStateCoordinator cfg (path </> "epochState") workers
+      <$> mkExtLedgerStateCoordinator workers
   workerState <- liftIO $ Con.newMVar coordinator'
-  lastStable <- Core.lastStablePoint coordinator'
-  ledgerStateE <- runExceptT $ restoreLedgerState (Just lastStable) (coordinator' ^. Core.unwrap)
+  ledgerStateE <- runExceptT $ restoreLedgerState initialExtLedgerStateEvent' ledgerStateIndexer'
   extLedgerState' <- case ledgerStateE of
     Left _err -> throwError $ Core.IndexerInternalError "can't restore ledger state"
     Right res -> pure res
-  let initialState = pure $ WorkerState extLedgerState' workerState
-      eventPreprocessing = processAsEpochState initialState <<< Core.withResume lastStable
+  let initialState = PreprocessorState Seq.empty extLedgerState' 0 securityParam' persistConfig'
+      eventPreprocessing =
+        extLedgerStatePreprocessor genesisCfg config initialState
+          <<< Core.withResume (extLedgerState' ^. Core.point)
   pure $
     Core.WorkerIndexer workerState $
       Core.Worker indexerName workerState eventPreprocessing id
@@ -332,58 +374,62 @@ extLedgerStateWorker config workers path = do
 instance
   ( MonadIO m
   , MonadError Core.IndexerError m
-  , Core.Point (ExtLedgerStateEvent, WithDistance input) ~ C.ChainPoint
+  , Core.Point output ~ C.ChainPoint
   )
-  => Core.IsIndex m (ExtLedgerStateEvent, WithDistance input) ExtLedgerStateCoordinator
+  => Core.IsIndex m output (ExtLedgerStateCoordinator output)
   where
-  index (Core.Timed _point Nothing) indexer = pure indexer
-  index timedEvent@(Core.Timed point (Just input@(newExtLedgerStateEvent, evt))) indexer = do
-    let indexer' = indexer & blocksToNextSnapshot -~ 1
-        extract = indexer ^. extractBlockEvent
-        block = extract input
-        blockInMode' = blockInMode block
-        snapshotTime = (indexer' ^. blocksToNextSnapshot) == 0
-        thisEpochNo = getEpochNo (extLedgerState newExtLedgerStateEvent)
-        isNewEpoch = thisEpochNo /= indexer ^. lastEpochNo
-        isVolatile = SecurityParam (chainDistance evt) < (indexer' ^. securityParam)
-        snapshotEpoch = (snapshotTime && isVolatile) || isNewEpoch
-        resetOnSnapshot =
-          if snapshotTime || isNewEpoch
-            then
-              (blocksToNextSnapshot .~ indexer' ^. snapshotInterval)
-                . (lastEpochNo .~ thisEpochNo)
-            else id
-        snapshotLedgerState =
-          if snapshotEpoch
-            then
-              fmap (snapshots %~ (point :))
-                . Core.indexVia extLedgerStateIndexer (Core.Timed point $ Just newExtLedgerStateEvent)
-            else pure
-        snapshotBlock =
-          if isVolatile
-            then blockIndexer (Core.index $ Core.Timed point $ Just blockInMode')
-            else pure
-    indexer'' <-
-      pure . resetOnSnapshot
-        <=< snapshotLedgerState
-        <=< snapshotBlock
-        $ indexer'
-    Core.indexVia coordinator timedEvent indexer''
+  index = Core.indexVia coordinator
+  rollback = Core.rollbackVia coordinator
+  setLastStablePoint = Core.setLastStablePointVia coordinator
 
-  rollback point =
-    extLedgerStateIndexer (Core.rollback point)
-      <=< blockIndexer (Core.rollback point)
-      <=< coordinator (Core.rollback point)
+-- Restoration of the LedgerState
 
-  setLastStablePoint point indexer =
-    let (volatile, immutable) = span (> point) $ indexer ^. snapshots
-        p' = listToMaybe immutable
-        indexer' = indexer & snapshots .~ volatile
-        setStablePointOnIndexers p =
-          Core.setLastStablePointVia extLedgerStateIndexer p
-            <=< Core.setLastStablePointVia blockIndexer p
-            <=< Core.setLastStablePointVia coordinator p
-     in maybe pure setStablePointOnIndexers p' indexer'
+restoreLedgerState
+  :: (MonadIO m, MonadError (Core.QueryError (Core.EventAtQuery ExtLedgerStateEvent)) m)
+  => ExtLedgerStateEvent
+  -> ExtLedgerStateFileIndexer
+  -> m (Core.Timed C.ChainPoint ExtLedgerStateEvent)
+restoreLedgerState firstExtLedgerStateEvent indexer = do
+  let getLatest [] = Core.Timed Core.genesis firstExtLedgerStateEvent
+      getLatest (x : _) = x
+  result <- runExceptT $ Core.queryLatest Core.latestEvent indexer
+  case result of
+    Right xs -> pure $ getLatest xs
+    Left (Core.AheadOfLastSync partialResult) -> case partialResult of
+      Nothing ->
+        throwError $
+          Core.IndexerQueryError "Cant resolve last ledgerState: No previous result"
+      Just _ ->
+        throwError $
+          Core.IndexerQueryError "Wrong ledger state is stored"
+    Left (Core.IndexerQueryError err) ->
+      throwError $
+        Core.IndexerQueryError $
+          "Cant resolve last ledgerState: " <> Text.pack (show err)
+    Left Core.NotStoredAnymore ->
+      throwError $
+        Core.IndexerQueryError
+          "Cant resolve last ledgerState: Not stored anymore"
+    Left (Core.SlotNoBoundsInvalid _) ->
+      throwError $ Core.IndexerQueryError "Invalid bounds"
+
+instance
+  ( MonadIO m
+  , MonadError Core.IndexerError m
+  , Core.Point event ~ Core.Point output
+  , Core.Point output ~ C.ChainPoint
+  , Ord (Core.Point output)
+  )
+  => Core.IsSync m event (ExtLedgerStateCoordinator output)
+  where
+  lastSyncPoint = Core.lastSyncPointVia coordinator
+  lastStablePoint = Core.lastStablePointVia coordinator
+
+instance
+  (MonadIO m, MonadError Core.IndexerError m)
+  => Core.Closeable m (ExtLedgerStateCoordinator output)
+  where
+  close = Core.closeVia coordinator
 
 -- | A preprocessor that filters in events when they are the first of their epoch
 newEpochPreprocessor :: (Monad m) => (a -> C.EpochNo) -> Core.Preprocessor m C.ChainPoint a a
@@ -398,168 +444,18 @@ newEpochPreprocessor f =
           else pure Nothing
    in Core.scanMaybeEvent filterNewEpoch Nothing
 
-instance
-  ( MonadIO m
-  , MonadError Core.IndexerError m
-  , Core.Point event ~ C.ChainPoint
-  )
-  => Core.IsSync m event ExtLedgerStateCoordinator
-  where
-  lastSyncPoint indexer = do
-    lastBlock <- Core.lastSyncPointVia blockIndexer indexer
-    lastLedgerState' <- Core.lastSyncPointVia extLedgerStateIndexer indexer
-    lastCoordinator <- Core.lastSyncPointVia coordinator indexer
-    pure $ minimum [lastBlock, lastLedgerState', lastCoordinator]
-  lastStablePoint = Core.lastStablePointVia extLedgerStateIndexer
-
-instance
-  (MonadIO m, MonadError Core.IndexerError m)
-  => Core.Closeable m ExtLedgerStateCoordinator
-  where
-  close indexer = do
-    Core.closeVia blockIndexer indexer
-    Core.closeVia extLedgerStateIndexer indexer
-    Core.closeVia coordinator indexer
-
-instance
-  ( MonadIO m
-  , MonadError (Core.QueryError (Core.EventAtQuery ExtLedgerStateEvent)) m
-  , Core.Point event ~ C.ChainPoint
-  , Core.Point (ExtLedgerStateEvent, event) ~ C.ChainPoint
-  )
-  => Core.Queryable
-      m
-      (ExtLedgerStateEvent, event)
-      (Core.EventAtQuery ExtLedgerStateEvent)
-      ExtLedgerStateCoordinator
-  where
-  query point = const $ fmap Just . restoreLedgerState (Just point)
-
--- Restoration of the LedgerState
-
-restoreLedgerState
-  :: ( MonadIO m
-     , MonadError (Core.QueryError (Core.EventAtQuery ExtLedgerStateEvent)) m
-     , Core.Point (ExtLedgerStateEvent, event) ~ C.ChainPoint
-     , Core.Point event ~ C.ChainPoint
-     )
-  => Maybe C.ChainPoint
-  -> ExtLedgerStateCoordinator (ExtLedgerStateEvent, event)
-  -> m ExtLedgerStateEvent
-restoreLedgerState p indexer = do
-  let applyBlocksUpToGivenSlot epochStatePoint closestLedgerState = do
-        blocks <- getBlocksFrom epochStatePoint p (indexer ^. blockIndexer)
-        liftIO $
-          foldM
-            (buildNextExtLedgerStateEvent $ indexer ^. extLedgerConfig)
-            closestLedgerState
-            blocks
-  Core.Timed epochStatePoint closestLedgerState <-
-    getLatestNonEmpty
-      p
-      (Lens.views genesisConfig initialExtLedgerStateEvent indexer)
-      (indexer ^. extLedgerStateIndexer)
-  mlast <- runExceptT @Core.IndexerError $ Core.lastSyncPoint indexer
-  last' <- either (const $ throwError $ Core.IndexerQueryError "can't find lastpoint") pure mlast
-  if epochStatePoint == fromMaybe last' p
-    then pure closestLedgerState
-    else applyBlocksUpToGivenSlot epochStatePoint closestLedgerState
-
-getLatestNonEmpty
-  :: (MonadIO m, MonadError (Core.QueryError (Core.EventAtQuery ExtLedgerStateEvent)) m)
-  => Maybe C.ChainPoint
-  -> ExtLedgerStateEvent
-  -> ExtLedgerStateFileIndexer
-  -> m (Core.Timed C.ChainPoint ExtLedgerStateEvent)
-getLatestNonEmpty p firstExtLedgerStateEvent indexer = do
-  let query = maybe Core.queryLatest Core.query
-      getLatest [] = Core.Timed Core.genesis firstExtLedgerStateEvent
-      getLatest (x : _) = x
-  result <- runExceptT $ query p Core.latestEvent indexer
-  case result of
-    Right xs -> pure $ getLatest xs
-    Left (Core.AheadOfLastSync partialResult) -> case partialResult of
-      Nothing ->
-        throwError $
-          Core.IndexerQueryError $
-            "Cant resolve last epochState: No previous result: " <> Text.pack (show $ pretty p)
-      Just xs -> pure $ getLatest xs
-    Left (Core.IndexerQueryError err) ->
-      throwError $
-        Core.IndexerQueryError $
-          "Cant resolve last epochState: " <> Text.pack (show err)
-    Left Core.NotStoredAnymore ->
-      throwError $
-        Core.IndexerQueryError
-          "Cant resolve last epochState: Not stored anymore"
-    Left (Core.SlotNoBoundsInvalid _) ->
-      throwError $ Core.IndexerQueryError "Invalid bounds"
-
-getBlocksFrom
-  :: (MonadIO m, MonadError (Core.QueryError (Core.EventAtQuery ExtLedgerStateEvent)) m)
-  => C.ChainPoint
-  -> Maybe C.ChainPoint
-  -> BlockFileIndexer
-  -> m [C.BlockInMode C.CardanoMode]
-getBlocksFrom from to indexer = do
-  let query = maybe Core.queryLatest Core.query
-      extractResult = fmap $ Lens.view Core.event
-  result <- runExceptT $ query to (Core.EventsFromQuery from) indexer
-  case result of
-    Right xs -> pure $ extractResult xs
-    Left (Core.AheadOfLastSync partialResult) -> case partialResult of
-      Nothing -> do
-        lastSync <- Core.lastSyncPoint indexer
-        throwError $
-          Core.IndexerQueryError $
-            "Cant resolve last blocks: No result - ahead of sync - No previous result: "
-              <> Text.pack (show $ pretty to)
-              <> " head is: "
-              <> Text.pack (show $ pretty lastSync)
-      Just xs -> do
-        lastSync <- Core.lastSyncPoint indexer
-        throwError $
-          Core.IndexerQueryError $
-            "Cant resolve last blocks: No result - ahead of sync - Latest results: "
-              <> Text.pack (show (Lens.view Core.point <$> xs))
-              <> " Head is: "
-              <> Text.pack (show $ pretty lastSync)
-              <> " Expecting: "
-              <> Text.pack (show to)
-    Left (Core.IndexerQueryError err) ->
-      throwError $
-        Core.IndexerQueryError $
-          "Cant resolve last blocks: " <> Text.pack (show err)
-    Left Core.NotStoredAnymore ->
-      throwError $
-        Core.IndexerQueryError
-          "Cant resolve last blocks: Not stored anymore"
-    Left (Core.SlotNoBoundsInvalid _) ->
-      throwError $ Core.IndexerQueryError "Invalid bounds"
-
 initialExtLedgerStateEvent :: C.GenesisConfig -> ExtLedgerStateEvent
 initialExtLedgerStateEvent = flip ExtLedgerStateEvent 0 . CE.mkInitExtLedgerState
-
-buildNextExtLedgerStateEvent
-  :: ExtLedgerConfig -> ExtLedgerStateEvent -> C.BlockInMode C.CardanoMode -> IO ExtLedgerStateEvent
-buildNextExtLedgerStateEvent extLedgerCfg currentState block =
-  let currentLedgerState' = extLedgerState currentState
-      applyBlock = CE.applyBlockExtLedgerState extLedgerCfg C.QuickValidation
-   in do
-        case applyBlock block currentLedgerState' of
-          Left err -> throw . Core.IndexerInternalError . Text.pack . show $ err
-          Right res -> pure $ ExtLedgerStateEvent res (getBlockNo block)
 
 -- | File Indexer to save the @ExtLedgerState@
 buildExtLedgerStateEventIndexer
   :: (MonadIO m, MonadError Core.IndexerError m)
   => O.CodecConfig (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
-  -> SecurityParam
   -> FilePath
   -> m (Core.FileIndexer EpochMetadata ExtLedgerStateEvent)
-buildExtLedgerStateEventIndexer codecConfig securityParam' path = do
+buildExtLedgerStateEventIndexer codecConfig path = do
   let serialiseLedgerState =
-        CBOR.toStrictByteString
+        CBOR.toBuilder
           . O.encodeExtLedgerState
             (O.encodeDisk codecConfig)
             (O.encodeDisk codecConfig)
@@ -573,28 +469,17 @@ buildExtLedgerStateEventIndexer codecConfig securityParam' path = do
               C.ChainPoint (C.SlotNo slotNo) blockHeaderHash ->
                 [Text.pack $ show slotNo, C.serialiseToRawBytesHexText blockHeaderHash]
          in blockNoAsText evt : chainPointTexts
-      immutableEpochs
-        :: Core.Timed (Core.Point ExtLedgerStateEvent) (Maybe ExtLedgerStateEvent)
-        -> [Core.EventInfo EpochMetadata]
-        -> [Core.EventInfo EpochMetadata]
-      immutableEpochs (Core.Timed _ Nothing) _eventsInfo = []
-      immutableEpochs (Core.Timed _ (Just event)) eventsInfo = do
-        let sortedEvents = sortOn (metadataBlockNo . Core.fileMetadata) eventsInfo
-            lastBlockNo = blockNo event
-            blockDepth = (\(C.BlockNo b) -> b) . (lastBlockNo -)
-            isImmutable =
-              maybe True ((> securityParam') . fromIntegral . blockDepth)
-                . metadataBlockNo
-                . Core.fileMetadata
-            immutableEvents = takeWhile isImmutable sortedEvents
-        case immutableEvents of
-          [] -> []
-          _ -> init immutableEvents
+      keepLast [] = ([], [])
+      keepLast (x : xs) = ([x], xs)
   Core.mkFileIndexer
     path
     Nothing -- (Just 180_000_000) -- Wait 180s for files to finish writing before terminating
-    (Core.FileStorageConfig False immutableEpochs (comparing (Down . metadataBlockNo)))
-    (Core.FileBuilder "epochState" "cbor" metadataAsText serialiseLedgerState serialisePoint)
+    ( Core.FileStorageConfig
+        False
+        (Core.withPartition $ const keepLast)
+        (comparing (Down . metadataBlockNo))
+    )
+    (Core.FileBuilder "ledgerState" "cbor" metadataAsText serialiseLedgerState serialisePoint)
     ( Core.EventBuilder
         deserialiseMetadata
         metadataChainpoint
@@ -618,73 +503,14 @@ deserialiseLedgerState codecConfig (EpochMetadata (Just blockNo') _) =
           (O.decodeDisk codecConfig)
           (O.decodeDisk codecConfig)
       )
-    . BS.fromStrict
 
--- | File Indexer to save the @BlockInMode@
-buildBlockIndexer
-  :: (MonadIO m, MonadError Core.IndexerError m)
-  => O.CodecConfig (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
-  -> SecurityParam
-  -> FilePath
-  -> m (Core.FileIndexer EpochMetadata (C.BlockInMode C.CardanoMode))
-buildBlockIndexer codecConfig securityParam' path = do
-  let blockNoAsText = maybe "" (Text.pack . show . (\(C.BlockNo b) -> b) . getBlockNo)
-      metadataAsText :: Core.Timed C.ChainPoint (Maybe (C.BlockInMode C.CardanoMode)) -> [Text]
-      metadataAsText (Core.Timed C.ChainPointAtGenesis evt) = [blockNoAsText evt]
-      metadataAsText (Core.Timed chainPoint evt) =
-        let chainPointTexts = case chainPoint of
-              C.ChainPoint (C.SlotNo slotNo) blockHeaderHash ->
-                [Text.pack $ show slotNo, C.serialiseToRawBytesHexText blockHeaderHash]
-         in blockNoAsText evt : chainPointTexts
-      immutableBlocks
-        :: Core.Timed (Core.Point ExtLedgerStateEvent) (Maybe (C.BlockInMode C.CardanoMode))
-        -> [Core.EventInfo EpochMetadata]
-        -> [Core.EventInfo EpochMetadata]
-      immutableBlocks (Core.Timed _ Nothing) _eventsInfo = []
-      immutableBlocks (Core.Timed _ (Just event)) eventsInfo = do
-        let sortedEvents = sortOn (metadataBlockNo . Core.fileMetadata) eventsInfo
-            lastBlockNo = getBlockNo event
-            blockDepth = (\(C.BlockNo b) -> b) . (lastBlockNo -)
-            isImmutable =
-              maybe True ((> securityParam') . fromIntegral . blockDepth)
-                . metadataBlockNo
-                . Core.fileMetadata
-            immutableEvents = takeWhile isImmutable sortedEvents
-        case immutableEvents of
-          [] -> []
-          _ -> init immutableEvents
-      blockNodeToNodeVersionM = do
-        nodeToClientVersion <- snd $ O.latestReleasedNodeVersion (Proxy @(O.CardanoBlock O.StandardCrypto))
-        Map.lookup nodeToClientVersion $
-          O.supportedNodeToClientVersions (Proxy @(O.CardanoBlock O.StandardCrypto))
-  blockNodeToNodeVersion <- case blockNodeToNodeVersionM of
-    Nothing -> throwError $ Core.IndexerInternalError "Can't finde block to Node version"
-    Just v -> pure v
-  Core.mkFileIndexer
-    path
-    Nothing -- (Just 60_000_000) -- Wait 60s for files to finish writing before terminating
-    (Core.FileStorageConfig False immutableBlocks (comparing metadataBlockNo))
-    ( Core.FileBuilder
-        "block"
-        "cbor"
-        metadataAsText
-        (serialiseBlock codecConfig blockNodeToNodeVersion)
-        serialisePoint
-    )
-    ( Core.EventBuilder
-        deserialiseMetadata
-        metadataChainpoint
-        (deserialiseBlock codecConfig blockNodeToNodeVersion)
-        deserialisePoint
-    )
-
-serialisePoint :: C.ChainPoint -> BS.ByteString
+serialisePoint :: C.ChainPoint -> Builder
 serialisePoint =
   let pointEncoding :: C.ChainPoint -> CBOR.Encoding
       pointEncoding C.ChainPointAtGenesis = CBOR.encodeBool False
       pointEncoding (C.ChainPoint (C.SlotNo s) (C.HeaderHash bhh)) =
         CBOR.encodeBool True <> CBOR.encodeWord64 s <> CBOR.encodeBytes (BS.Short.fromShort bhh)
-   in CBOR.toStrictByteString . pointEncoding
+   in CBOR.toBuilder . pointEncoding
 
 deserialisePoint :: BS.ByteString -> Either Text C.ChainPoint
 deserialisePoint bs =
@@ -696,8 +522,8 @@ deserialisePoint bs =
             bhh <- C.HeaderHash . BS.Short.toShort <$> CBOR.decodeBytes
             pure $ C.ChainPoint s bhh
           else pure C.ChainPointAtGenesis
-   in case CBOR.deserialiseFromBytes pointDecoding . BS.fromStrict $ bs of
-        Right (remain, res) | BS.Lazy.null remain -> Right res
+   in case CBOR.deserialiseFromBytes pointDecoding bs of
+        Right (remain, res) | BS.null remain -> Right res
         _other -> Left "Can't read chainpoint"
 
 deserialiseMetadata :: [Text] -> Maybe EpochMetadata
@@ -713,28 +539,6 @@ deserialiseMetadata [blockNoStr, slotNoStr, bhhStr] = do
     parseBlockNo "" = pure Nothing
     parseBlockNo bno = Just . C.BlockNo <$> Text.readMaybe (Text.unpack bno)
 deserialiseMetadata _ = Nothing
-
-serialiseBlock
-  :: O.CodecConfig (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
-  -> O.BlockNodeToClientVersion (O.CardanoBlock O.StandardCrypto)
-  -> C.BlockInMode C.CardanoMode
-  -> BS.ByteString
-serialiseBlock codecConfig blockToNode =
-  CBOR.toStrictByteString . O.encodeNodeToClient codecConfig blockToNode . C.toConsensusBlock
-
-deserialiseBlock
-  :: O.CodecConfig (O.HardForkBlock (O.CardanoEras O.StandardCrypto))
-  -> O.BlockNodeToClientVersion (O.CardanoBlock O.StandardCrypto)
-  -> EpochMetadata
-  -> BS.ByteString
-  -> Either Text (Maybe (C.BlockInMode C.CardanoMode))
-deserialiseBlock _codecConfig _blockToNode (EpochMetadata Nothing _) = const (Right Nothing)
-deserialiseBlock codecConfig blockToNode _metadata =
-  bimap
-    (Text.pack . show)
-    (Just . C.fromConsensusBlock C.CardanoMode . snd)
-    . CBOR.deserialiseFromBytes (O.decodeNodeToClient codecConfig blockToNode)
-    . BS.fromStrict
 
 -- Data extraction
 

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/MintTokenEvent.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/MintTokenEvent.hs
@@ -144,9 +144,8 @@ import Marconi.Cardano.Core.Types (
   TxIndexInBlock,
  )
 import Marconi.Cardano.Indexers.SyncHelper qualified as Sync
+import Marconi.Core (SQLiteDBLocation)
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer (SQLiteDBLocation)
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import System.FilePath ((</>))
 
 -- | A raw SQLite indexer for 'MintTokenBlockEvents'

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Spent.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Spent.hs
@@ -54,9 +54,8 @@ import Marconi.Cardano.Core.Indexer.Worker (
 import Marconi.Cardano.Core.Orphans ()
 import Marconi.Cardano.Core.Types (AnyTxBody (AnyTxBody), SecurityParam)
 import Marconi.Cardano.Indexers.SyncHelper qualified as Sync
+import Marconi.Core (SQLiteDBLocation)
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer (SQLiteDBLocation)
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import System.FilePath ((</>))
 
 data SpentInfo = SpentInfo

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Utxo.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Utxo.hs
@@ -92,9 +92,8 @@ import Marconi.Cardano.Core.Types (
   pattern CurrentEra,
  )
 import Marconi.Cardano.Indexers.SyncHelper qualified as Sync
+import Marconi.Core (SQLiteDBLocation)
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer (SQLiteDBLocation)
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import System.FilePath ((</>))
 
 -- | Indexer representation of an UTxO

--- a/marconi-cardano-indexers/test-lib/Test/Gen/Marconi/Cardano/Indexers/UtxoQuery.hs
+++ b/marconi-cardano-indexers/test-lib/Test/Gen/Marconi/Cardano/Indexers/UtxoQuery.hs
@@ -18,7 +18,6 @@ import Marconi.Cardano.Indexers.Utxo qualified as Utxo
 import Marconi.Cardano.Indexers.UtxoQuery (UtxoQueryEvent)
 import Marconi.Cardano.Indexers.UtxoQuery qualified as UtxoQuery
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import System.FilePath ((</>))
 import System.IO.Temp qualified as Tmp
 import Test.Gen.Cardano.Api.Typed qualified as CGen

--- a/marconi-cardano-indexers/test-lib/Test/Marconi/Cardano/Chain/Snapshot.hs
+++ b/marconi-cardano-indexers/test-lib/Test/Marconi/Cardano/Chain/Snapshot.hs
@@ -11,7 +11,7 @@ import Cardano.Api qualified as C
 import Cardano.Api.Extended.Streaming (BlockEvent)
 import Control.Monad (when, (<=<))
 import Control.Monad.Except (runExceptT)
-import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as BS
 import Data.List (find, isPrefixOf, sortOn)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)

--- a/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/BlockInfo.hs
+++ b/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/BlockInfo.hs
@@ -27,7 +27,6 @@ import Marconi.Cardano.Core.Logger (defaultStdOutLogger, mkMarconiTrace)
 import Marconi.Cardano.Core.Runner qualified as Runner
 import Marconi.Cardano.Indexers.BlockInfo qualified as BlockInfo
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import Test.Gen.Marconi.Cardano.Indexers.BlockInfo qualified as Test.BlockInfo
 import Test.Helpers qualified as Helpers
 import Test.Integration qualified as Integration

--- a/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/Datum.hs
+++ b/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/Datum.hs
@@ -17,7 +17,6 @@ import Hedgehog qualified
 import Hedgehog.Gen qualified
 import Marconi.Cardano.Indexers.Datum qualified as Datum
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import Test.Gen.Marconi.Cardano.Indexers.Datum qualified as Test.Datum
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)

--- a/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/MintTokenEvent.hs
+++ b/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/MintTokenEvent.hs
@@ -69,8 +69,6 @@ import Marconi.Cardano.Indexers.MintTokenEvent (
 import Marconi.Cardano.Indexers.MintTokenEvent qualified as MintTokenEvent
 import Marconi.Cardano.Indexers.MintTokenEventQuery qualified as MintTokenEventQuery
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer (inMemoryDB)
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import System.FilePath ((</>))
 import System.IO.Temp qualified as Tmp
 import Test.Gen.Cardano.Api.Typed qualified as CGen
@@ -633,7 +631,7 @@ indexWithRunner trackedAssetIds events = do
       MintTokenEvent.mintTokenEventWorker
         (StandardWorkerConfig "MintTokenEventWorker" 1 (Core.mkCatchupConfig 4 2) pure nullTracer)
         (MintTokenEventConfig trackedAssetIds)
-        inMemoryDB
+        Core.inMemoryDB
 
   -- We create a coordinator to perform indexing through the worker
   coordinator <- liftIO $ Core.mkCoordinator [worker]

--- a/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/Spent.hs
+++ b/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/Spent.hs
@@ -16,7 +16,6 @@ import Hedgehog qualified
 import Hedgehog.Gen qualified
 import Marconi.Cardano.Indexers.Spent qualified as Spent
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import Test.Gen.Marconi.Cardano.Indexers.Spent qualified as Test.Spent
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testPropertyNamed)

--- a/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/Utxo.hs
+++ b/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/Utxo.hs
@@ -28,7 +28,6 @@ import Marconi.Cardano.Core.Indexer.Worker (
 import Marconi.Cardano.Core.Logger (nullTracer)
 import Marconi.Cardano.Indexers.Utxo qualified as Utxo
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import Test.Gen.Marconi.Cardano.Core.Mockchain qualified as Gen
 import Test.Gen.Marconi.Cardano.Indexers.Utxo qualified as Gen
 import Test.Tasty (TestTree, testGroup)

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -109,6 +109,7 @@ library
     , lens
     , mtl
     , network
+    , prettyprinter
     , sqlite-simple
     , stm
     , streaming

--- a/marconi-core/src/Marconi/Core.hs
+++ b/marconi-core/src/Marconi/Core.hs
@@ -612,9 +612,9 @@ import Marconi.Core.Indexer.SQLiteAggregateQuery (
 import Marconi.Core.Indexer.SQLiteIndexer (
   GetLastStablePointQuery (GetLastStablePointQuery, getLastStablePointQuery),
   InsertPointQuery (InsertPointQuery),
-  SQLiteDBLocation (..),
   SQLInsertPlan (..),
   SQLRollbackPlan (..),
+  SQLiteDBLocation (..),
   SQLiteIndexer (..),
   SetLastStablePointQuery (SetLastStablePointQuery, getSetLastStablePointQuery),
   ToRow (..),
@@ -626,7 +626,7 @@ import Marconi.Core.Indexer.SQLiteIndexer (
   mkSqliteIndexer,
   parseDBLocation,
   querySQLiteIndexerWith,
-  querySyncedOnlySQLiteIndexerWith
+  querySyncedOnlySQLiteIndexerWith,
  )
 import Marconi.Core.Preprocessor (
   Preprocessor,

--- a/marconi-core/src/Marconi/Core.hs
+++ b/marconi-core/src/Marconi/Core.hs
@@ -267,6 +267,7 @@ module Marconi.Core (
   GetLastStablePointQuery (GetLastStablePointQuery, getLastStablePointQuery),
   SetLastStablePointQuery (SetLastStablePointQuery, getSetLastStablePointQuery),
   InsertPointQuery (InsertPointQuery),
+  SQLiteDBLocation (Memory, Storage),
   -- | Start a new indexer or resume an existing SQLite indexer
   --
   -- The main difference with 'SQLiteIndexer' is
@@ -278,6 +279,8 @@ module Marconi.Core (
   --
   -- It is monomorphic restriction of 'mkSqliteIndexer'
   mkSingleInsertSqliteIndexer,
+  inMemoryDB,
+  parseDBLocation,
   connection,
   SQLInsertPlan (SQLInsertPlan, planExtractor, planInsert),
   SQLRollbackPlan (SQLRollbackPlan, tableName, pointName, pointExtractor),
@@ -300,6 +303,8 @@ module Marconi.Core (
   -- | An indexer that serialise the event to disk
   FileIndexer (FileIndexer),
   FileStorageConfig (FileStorageConfig),
+  FileCleanup,
+  withPartition,
   FileBuilder (FileBuilder),
   EventBuilder (EventBuilder),
   EventInfo (fileMetadata),
@@ -387,6 +392,7 @@ module Marconi.Core (
   traverseMaybeEvent,
   scanEvent,
   scanEventM,
+  scanMaybeEvent,
   scanMaybeEventM,
   preprocessor,
   preprocessorM,
@@ -572,9 +578,11 @@ import Marconi.Core.Indexer.FileIndexer (
   EventBuilder (EventBuilder),
   EventInfo (fileMetadata),
   FileBuilder (FileBuilder),
+  FileCleanup,
   FileIndexer (FileIndexer),
   FileStorageConfig (FileStorageConfig),
   mkFileIndexer,
+  withPartition,
  )
 import Marconi.Core.Indexer.LastEventIndexer (
   GetLastQuery (GetLastQuery),
@@ -604,6 +612,7 @@ import Marconi.Core.Indexer.SQLiteAggregateQuery (
 import Marconi.Core.Indexer.SQLiteIndexer (
   GetLastStablePointQuery (GetLastStablePointQuery, getLastStablePointQuery),
   InsertPointQuery (InsertPointQuery),
+  SQLiteDBLocation (..),
   SQLInsertPlan (..),
   SQLRollbackPlan (..),
   SQLiteIndexer (..),
@@ -612,10 +621,12 @@ import Marconi.Core.Indexer.SQLiteIndexer (
   connection,
   dbLastSync,
   handleSQLErrors,
+  inMemoryDB,
   mkSingleInsertSqliteIndexer,
   mkSqliteIndexer,
+  parseDBLocation,
   querySQLiteIndexerWith,
-  querySyncedOnlySQLiteIndexerWith,
+  querySyncedOnlySQLiteIndexerWith
  )
 import Marconi.Core.Preprocessor (
   Preprocessor,
@@ -625,6 +636,7 @@ import Marconi.Core.Preprocessor (
   preprocessorM,
   scanEvent,
   scanEventM,
+  scanMaybeEvent,
   scanMaybeEventM,
   traverseEvent,
   traverseMaybeEvent,

--- a/marconi-core/src/Marconi/Core/Coordinator.hs
+++ b/marconi-core/src/Marconi/Core/Coordinator.hs
@@ -157,7 +157,7 @@ step
   -> ProcessedInput (Point input) input
   -> m (indexer input)
 step indexer = \case
-  Index e -> index e indexer
+  Index e -> seq e $ index e indexer
   IndexAllDescending es -> indexAllDescending es indexer
   Rollback p -> rollback p indexer
   StableAt p -> setLastStablePoint p indexer

--- a/marconi-core/src/Marconi/Core/Indexer/FileIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Indexer/FileIndexer.hs
@@ -461,7 +461,7 @@ instance (MonadIO m, MonadError IndexerError m) => Closeable m (FileIndexer meta
   {- If we've got a write token it means a write is occurring asynchronously.
      We need to wait for it to finish before closing. -}
   close :: FileIndexer meta event -> m ()
-  close indexer =
+  close indexer = do
     case indexer ^. fileIndexerWriteEnv of
       Just fileWriteEnv -> do
         res <-
@@ -472,8 +472,10 @@ instance (MonadIO m, MonadError IndexerError m) => Closeable m (FileIndexer meta
         unless (isJust res) (throwError IndexerCloseTimeoutError)
       Nothing -> pure ()
 
--- * File writing | TODO https://input-output.atlassian.net/browse/PLT-7809
+-- * File writing
+
 writeFileSync :: (MonadIO m) => FilePath -> Builder -> m ()
+-- TODO https://input-output.atlassian.net/browse/PLT-7809
 writeFileSync filepath content = liftIO $ BS.Builder.writeFile filepath content
 
 writeFileAsync :: (MonadIO m) => AsyncWriteFileConfig -> FilePath -> Builder -> m ()

--- a/marconi-core/src/Marconi/Core/Indexer/FileIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Indexer/FileIndexer.hs
@@ -10,6 +10,8 @@ events we keep or to use it for sparse events.
 module Marconi.Core.Indexer.FileIndexer (
   FileIndexer (FileIndexer),
   FileStorageConfig (..),
+  FileCleanup,
+  withPartition,
   FileBuilder (FileBuilder),
   EventBuilder (EventBuilder),
   mkFileIndexer,
@@ -28,29 +30,36 @@ module Marconi.Core.Indexer.FileIndexer (
   fileIndexerLastSyncPoint,
   fullPath,
   getDirectoryMetadata,
+  eventsMetadata,
   EventInfo (..),
 ) where
 
-import Control.Concurrent (forkIO)
 import Control.Concurrent.QSem (QSem)
 import Control.Concurrent.QSem qualified as Con
 import Control.Exception (Exception (displayException), bracket_, handle)
+import Control.Lens (Traversal')
 import Control.Lens qualified as Lens
-import Control.Lens.Operators ((.~), (^.))
-import Control.Monad (forM_, join, unless, void, when)
+import Control.Lens.Operators ((%~), (.=), (.~), (?~), (^.))
+import Control.Monad (forM_, join, unless, when)
 import Control.Monad.Except (ExceptT (ExceptT), MonadError (throwError), runExceptT)
 import Control.Monad.IO.Class (MonadIO (liftIO))
-import Data.ByteString (ByteString)
-import Data.ByteString qualified as BS
+import Control.Monad.State (State)
+import Control.Monad.State qualified as State
+import Data.ByteString.Builder (Builder)
+import Data.ByteString.Builder qualified as BS.Builder
+import Data.ByteString.Lazy (ByteString)
+import Data.ByteString.Lazy qualified as BS
 import Data.Foldable (Foldable (toList), traverse_)
 import Data.Function ((&))
+import Data.List qualified as List
 import Data.Maybe (fromMaybe, isJust)
+import Data.Ord (Down (Down))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Marconi.Core.Class (
   Closeable (close),
   HasGenesis (genesis),
-  IsIndex (index, indexAllDescending, rollback, setLastStablePoint),
+  IsIndex (index, indexAll, indexAllDescending, rollback, setLastStablePoint),
   IsSync (lastStablePoint, lastSyncPoint),
  )
 import Marconi.Core.Type (
@@ -61,7 +70,7 @@ import Marconi.Core.Type (
   event,
   point,
  )
-import System.Directory (createDirectoryIfMissing, doesFileExist, listDirectory, removeFile)
+import System.Directory qualified as Directory
 import System.FilePath ((</>))
 import System.FilePath qualified as FilePath
 import System.Timeout (timeout)
@@ -76,8 +85,8 @@ data FileBuilder meta event = FileBuilder
   -- ^ The suffix used in the filename of the events
   , _fileEventIdentifier :: Timed (Point event) (Maybe event) -> [Text]
   -- ^ build a list of identifier used in the filename of an event
-  , _serialiseEvent :: event -> ByteString
-  , _serialisePoint :: Point event -> ByteString
+  , _serialiseEvent :: event -> Builder
+  , _serialisePoint :: Point event -> Builder
   }
 
 Lens.makeLenses ''FileBuilder
@@ -107,6 +116,31 @@ data EventInfo meta = EventInfo
 
 deriving stock instance (Show meta) => Show (EventInfo meta)
 
+data FileCleanup meta event = FileCleanUp
+  { _eventsInfo :: [EventInfo meta]
+  -- ^ store the events info of the current files
+  , _partitionEvents
+      :: Timed (Point event) (Maybe event)
+      -> [EventInfo meta]
+      -> ([EventInfo meta], [EventInfo meta])
+  -- ^ The first part are the kept events, the second the removed events
+  }
+
+Lens.makeLenses ''FileCleanup
+
+withPartition
+  :: (Timed (Point event) (Maybe event) -> [EventInfo meta] -> ([EventInfo meta], [EventInfo meta]))
+  -> Maybe (FileCleanup meta event)
+withPartition = Just . FileCleanUp []
+
+decideCleanUp
+  :: Timed (Point event) (Maybe event) -> State (FileCleanup meta event) [EventInfo meta]
+decideCleanUp evt = do
+  s <- State.get
+  let (keep, remove) = (s ^. partitionEvents $ evt) (s ^. eventsInfo)
+  eventsInfo .= keep
+  pure remove
+
 {- | The datatype used to configure the way we store files, including:
 
       - control over which events are saved
@@ -118,8 +152,8 @@ deriving stock instance (Show meta) => Show (EventInfo meta)
 data FileStorageConfig meta event = FileStorageConfig
   { _keepEmptyEvent :: Bool
   -- ^ Do we create a file for empty event
-  , _eventsToRemove :: Timed (Point event) (Maybe event) -> [EventInfo meta] -> [EventInfo meta]
-  -- ^ Filtering unction used to decide which events must be removed
+  , _cleanupConfig :: Maybe (FileCleanup meta event)
+  -- ^ Filtering function used to decide which events must be removed
   , _fileComparison :: meta -> meta -> Ordering
   -- ^ Function used to sort event files, based on their metadata
   }
@@ -163,6 +197,22 @@ data FileIndexer meta event = FileIndexer
 
 Lens.makeLenses ''FileIndexer
 
+eventsMetadata :: Traversal' (FileIndexer meta event) [EventInfo meta]
+eventsMetadata = storageConfig . cleanupConfig . traverse . eventsInfo
+
+timedEventInfo
+  :: FileIndexer meta event
+  -> Timed (Point event) (Maybe event)
+  -> Maybe (EventInfo meta)
+timedEventInfo indexer evt =
+  let meta =
+        (indexer ^. eventBuilder . deserialiseMeta)
+          . (indexer ^. fileBuilder . fileEventIdentifier)
+          $ evt
+      hasContent = isJust $ evt ^. event
+      path = toFilename indexer evt
+   in (\m -> EventInfo hasContent m path) <$> meta
+
 compareMeta
   :: FileIndexer meta event
   -> meta
@@ -183,8 +233,8 @@ mkFileIndexer
   -> FileBuilder meta event
   -> EventBuilder meta event
   -> m (FileIndexer meta event)
-mkFileIndexer path writeFilesAsyncTimeout storageCfg filenameBuilder' eventBuilder' = do
-  liftIO $ createDirectoryIfMissing True path
+mkFileIndexer path' writeFilesAsyncTimeout storageCfg filenameBuilder' eventBuilder' = do
+  liftIO $ Directory.createDirectoryIfMissing True path'
   fileWriteTokens <-
     case writeFilesAsyncTimeout of
       Just timeoutValue -> liftIO $ do
@@ -193,7 +243,7 @@ mkFileIndexer path writeFilesAsyncTimeout storageCfg filenameBuilder' eventBuild
       Nothing -> pure Nothing
   let indexer =
         FileIndexer
-          path
+          path'
           storageCfg
           filenameBuilder'
           eventBuilder'
@@ -201,23 +251,29 @@ mkFileIndexer path writeFilesAsyncTimeout storageCfg filenameBuilder' eventBuild
           genesis
           fileWriteTokens
   lastStablePoint' <- fromMaybe genesis <$> readCurrentStable indexer
+  unsortedMetadata <- runExceptT $ getDirectoryMetadata indexer
+  let metadata = case unsortedMetadata of
+        Left _err -> []
+        Right xs -> List.sortOn (Down . (eventBuilder' ^. extractPoint) . fileMetadata) xs
   let indexer' =
         indexer
           & fileIndexerLastSyncPoint .~ lastStablePoint'
           & fileIndexerLastStablePoint .~ lastStablePoint'
+          & eventsMetadata .~ metadata
   rollback lastStablePoint' indexer'
 
-toFilename :: FilePath -> FileBuilder meta event -> Timed (Point event) (Maybe event) -> FilePath
-toFilename dir indexer evt =
-  let eventId = (indexer ^. fileEventIdentifier) evt
+toFilename :: FileIndexer meta event -> Timed (Point event) (Maybe event) -> FilePath
+toFilename indexer evt =
+  let dir = indexer ^. eventDirectory
+      eventId = (indexer ^. fileBuilder . fileEventIdentifier) evt
       contentFlag = case evt ^. event of
         Just _ -> "just"
         Nothing -> "nothing"
       filename =
         Text.unpack $
-          (Text.intercalate "_" $ indexer ^. eventPrefix : contentFlag : eventId)
+          (Text.intercalate "_" $ indexer ^. fileBuilder . eventPrefix : contentFlag : eventId)
             <> "."
-            <> (indexer ^. eventSuffix)
+            <> (indexer ^. fileBuilder . eventSuffix)
    in dir </> filename
 
 handleIOErrors :: (MonadIO m, MonadError IndexerError m) => IO a -> m a
@@ -251,7 +307,7 @@ extractEventsInfo expectedPrefix metaExtractor eventDir =
             pure [EventInfo hasContent' meta path]
           _other -> pure []
    in do
-        files <- liftIO $ listDirectory eventDir
+        files <- liftIO $ Directory.listDirectory eventDir
         join <$> traverse extractEventInfo files
 
 getDirectoryMetadata
@@ -288,38 +344,40 @@ writeTimedEvent
   :: (MonadIO m, MonadError IndexerError m)
   => Timed (Point event) (Maybe event)
   -> FileIndexer meta event
-  -> m ()
-writeTimedEvent timedEvent indexer =
-  let filename = toFilename (indexer ^. eventDirectory) (indexer ^. fileBuilder) timedEvent
-      write :: (MonadIO m, MonadError IndexerError m) => FilePath -> ByteString -> m ()
+  -> m (FileIndexer meta event)
+writeTimedEvent timedEvent indexer = do
+  let filename = toFilename indexer timedEvent
+      eventInfo = timedEventInfo indexer timedEvent
+      write :: (MonadIO m, MonadError IndexerError m) => FilePath -> Builder -> m ()
       write filepath = handleIOErrors . writeIndexer indexer filepath
-   in case timedEvent ^. event of
-        Nothing -> when (indexer ^. storageConfig . keepEmptyEvent) $ write filename ""
-        Just evt -> write filename (indexer ^. fileBuilder . serialiseEvent $ evt)
+  case timedEvent ^. event of
+    Nothing -> when (indexer ^. storageConfig . keepEmptyEvent) $ write filename ""
+    Just evt -> write filename (indexer ^. fileBuilder . serialiseEvent $ evt)
+  pure $ indexer & maybe id addInfo eventInfo
 
 cleanEvents
-  :: (MonadIO m, MonadError IndexerError m)
+  :: (MonadIO io)
   => Timed (Point event) (Maybe event)
   -> FileIndexer meta event
-  -> m ()
-cleanEvents timedEvent indexer = do
-  dirMetadataE <- runExceptT $ getDirectoryMetadata indexer
-  case dirMetadataE of
-    Left _err -> throwError $ IndexerInternalError "Can't read directory content"
-    Right dirMetadata -> do
-      let removeFilter = indexer ^. storageConfig . eventsToRemove
-          toRemove = removeFilter timedEvent dirMetadata
-      liftIO $ traverse_ removeFile (fullPath indexer <$> toRemove)
+  -> io (FileIndexer meta event)
+cleanEvents timedEvent indexer =
+  let cleanupConfigM = indexer ^. storageConfig . cleanupConfig
+   in case cleanupConfigM of
+        Nothing -> pure indexer
+        Just cleanupConfig' -> do
+          let (toRemove, cleanupConfig'') = State.runState (decideCleanUp timedEvent) cleanupConfig'
+          liftIO $ traverse_ Directory.removeFile (fullPath indexer <$> toRemove)
+          pure $ indexer & storageConfig . cleanupConfig ?~ cleanupConfig''
 
-instance (MonadIO m, MonadError IndexerError m) => IsIndex m event (FileIndexer meta) where
+instance (MonadIO io, MonadError IndexerError io) => IsIndex io event (FileIndexer meta) where
   index timedEvent indexer = do
     let currentPoint = timedEvent ^. point
         setLastSync ix = ix & fileIndexerLastSyncPoint .~ currentPoint
-    cleanEvents timedEvent indexer
-    writeTimedEvent timedEvent indexer
-    pure $ setLastSync indexer
+    indexer' <- cleanEvents timedEvent indexer
+    indexer'' <- writeTimedEvent timedEvent indexer'
+    pure $ setLastSync indexer''
 
-  indexAllDescending timedEvents indexer =
+  indexAll timedEvents indexer =
     case toList timedEvents of
       [] -> pure indexer
       x : _ -> do
@@ -328,16 +386,20 @@ instance (MonadIO m, MonadError IndexerError m) => IsIndex m event (FileIndexer 
         traverse_ (flip writeTimedEvent indexer) timedEvents
         pure $ setLastSync indexer
 
+  indexAllDescending = indexAll . reverse . toList
+
   rollback p indexer = do
-    filesWithMetadata <- runExceptT $ getDirectoryMetadata indexer
-    case filesWithMetadata of
-      Left _err -> throwError $ IndexerInternalError "can't parse directory content"
-      Right xs -> forM_ xs $ \eventFile -> do
-        let pt = indexer ^. eventBuilder . extractPoint $ fileMetadata eventFile
-        when (pt > p) $ do
-          let filename = fullPath indexer eventFile
-          liftIO $ removeFile filename
-    pure $ indexer & fileIndexerLastSyncPoint .~ p
+    let filesWithMetadata = indexer ^. eventsMetadata
+        extractPoint' = indexer ^. eventBuilder . extractPoint
+        (keep, remove) = List.partition ((<= p) . extractPoint' . fileMetadata) filesWithMetadata
+    forM_ remove $ \eventFile -> do
+      let filename = fullPath indexer eventFile
+      liftIO $ Directory.removeFile filename
+    let indexer' =
+          indexer
+            & fileIndexerLastSyncPoint .~ p
+            & eventsMetadata .~ keep
+    pure indexer'
 
   setLastStablePoint p indexer = do
     let currentStable = indexer ^. fileIndexerLastStablePoint
@@ -346,6 +408,9 @@ instance (MonadIO m, MonadError IndexerError m) => IsIndex m event (FileIndexer 
         indexer' <- writeStable p indexer
         pure $ indexer' & fileIndexerLastStablePoint .~ p
       else pure indexer
+
+addInfo :: EventInfo meta -> FileIndexer meta event -> FileIndexer meta event
+addInfo info indexer = indexer & eventsMetadata %~ (info :)
 
 lastStableFilename :: FileIndexer meta event -> FilePath
 lastStableFilename indexer =
@@ -362,7 +427,7 @@ readCurrentStable
 readCurrentStable indexer = do
   let f = lastStableFilename indexer
       deserialise = indexer ^. eventBuilder . deserialisePoint
-  fileExists <- liftIO $ doesFileExist f
+  fileExists <- liftIO $ Directory.doesFileExist f
   if fileExists
     then do
       res <- deserialise <$> liftIO (BS.readFile f)
@@ -371,17 +436,15 @@ readCurrentStable indexer = do
         Right r -> pure $ Just r
     else pure Nothing
 
-writeIndexer :: (MonadIO m) => FileIndexer meta event -> FilePath -> ByteString -> m ()
+writeIndexer :: (MonadIO m) => FileIndexer meta event -> FilePath -> Builder -> m ()
 writeIndexer indexer =
-  {- `isJust (indexer ^. fileIndexerWriteTokens) == True` means that we need to write the file
+  {- `isJust (indexer ^. fileIndexerWriteEnv) == True` means that we need to write the file
    asynchronously.
 
    It carries a semaphore which we wait on during the action. This means that, elsewhere in the
    program (given a termination command for example), we can determine when the write has
    finished. -}
-  case indexer ^. fileIndexerWriteEnv of
-    Just fileWriteEnv -> writeFileAsync fileWriteEnv
-    Nothing -> writeFileSync
+  maybe writeFileSync writeFileAsync (indexer ^. fileIndexerWriteEnv)
 
 writeStable
   :: (MonadIO m)
@@ -410,15 +473,14 @@ instance (MonadIO m, MonadError IndexerError m) => Closeable m (FileIndexer meta
       Nothing -> pure ()
 
 -- * File writing | TODO https://input-output.atlassian.net/browse/PLT-7809
-writeFileSync :: (MonadIO m) => FilePath -> ByteString -> m ()
-writeFileSync filepath content = liftIO $ BS.writeFile filepath content
+writeFileSync :: (MonadIO m) => FilePath -> Builder -> m ()
+writeFileSync filepath content = liftIO $ BS.Builder.writeFile filepath content
 
-writeFileAsync :: (MonadIO m) => AsyncWriteFileConfig -> FilePath -> ByteString -> m ()
-writeFileAsync fileWriteEnv filepath content =
+writeFileAsync :: (MonadIO m) => AsyncWriteFileConfig -> FilePath -> Builder -> m ()
+writeFileAsync fileWriteEnv filepath content = do
   let sem = fileWriteEnv ^. fileWriteEnvSem
-   in liftIO . void $
-        forkIO $
-          bracket_
-            (Con.waitQSem sem)
-            (Con.signalQSem sem)
-            (BS.writeFile filepath content)
+  liftIO $
+    bracket_
+      (Con.waitQSem sem)
+      (Con.signalQSem sem)
+      (BS.Builder.writeFile filepath content)

--- a/marconi-core/src/Marconi/Core/Indexer/SQLiteIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Indexer/SQLiteIndexer.hs
@@ -10,9 +10,7 @@
 -}
 module Marconi.Core.Indexer.SQLiteIndexer (
   SQLiteIndexer (SQLiteIndexer),
-  SQLiteDBLocation,
-  pattern Memory,
-  pattern Storage,
+  SQLiteDBLocation (Memory, Storage),
   ExpectedPersistentDB (..),
   inMemoryDB,
   parseDBLocation,
@@ -69,27 +67,20 @@ import Marconi.Core.Type (
  )
 
 data SQLiteDBLocation
-  = Memory_
-  | Storage_ !FilePath
-
-pattern Memory :: SQLiteDBLocation
-pattern Memory <- Memory_
-
-pattern Storage :: FilePath -> SQLiteDBLocation
-pattern Storage fp <- Storage_ fp
-{-# COMPLETE Memory, Storage #-}
+  = Memory
+  | Storage !FilePath
 
 unparseDBLocation :: SQLiteDBLocation -> String
 unparseDBLocation Memory = ":memory:"
 unparseDBLocation (Storage path) = path
 
 parseDBLocation :: String -> SQLiteDBLocation
-parseDBLocation "" = Memory_
-parseDBLocation ":memory:" = Memory_
-parseDBLocation str = Storage_ str
+parseDBLocation "" = Memory
+parseDBLocation ":memory:" = Memory
+parseDBLocation str = Storage str
 
 inMemoryDB :: SQLiteDBLocation
-inMemoryDB = Memory_
+inMemoryDB = Memory
 
 data ExpectedPersistentDB = ExpectedPersistentDB
   deriving (Show)

--- a/marconi-core/src/Marconi/Core/Preprocessor/Resume.hs
+++ b/marconi-core/src/Marconi/Core/Preprocessor/Resume.hs
@@ -108,9 +108,9 @@ drainAllDescending
   -> m (Maybe (ProcessedInput (Point event) event))
 drainAllDescending lastPoint timedEvents =
   case NonEmpty.span ((> lastPoint) . Lens.view point) timedEvents of
-    ([], _) -> pure Nothing
-    ([x], _) -> put ResumeDone $> Just (Index x)
-    (x : xs, _) -> put ResumeDone $> Just (IndexAllDescending (x :| xs))
+    ([], _) -> pure Nothing -- No indexing is more recent
+    ([x], _) -> put ResumeDone $> Just (Index x) -- One more recent indexing
+    (x : xs, _) -> put ResumeDone $> Just (IndexAllDescending (x :| xs)) -- Several more recent
 
 drainIndex
   :: ( Ord (Point event)

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1728,21 +1728,22 @@ propWithStreamTBQueue = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabil
      such that the client can consume from the socket as a stream.
 -}
 propWithStreamSocket :: Property
-propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstability $ \args -> do
-  (_, (actual, expected)) <- liftIO
-    $ Tmp.withSystemTempDirectory
-      mempty
-    $ \dir -> do
-      let chainSubset = take (chainSizeSubset args) (eventGenerator args)
-          -- We need to make the filename as short as possible, because we're very limited by path
-          -- length
-          fileName = dir </> "f"
-      serverStarted <- newQSem 1
-      concurrently
-        (server fileName chainSubset serverStarted)
-        (client fileName chainSubset serverStarted)
+propWithStreamSocket = monadicExceptTIO @() $
+  GenM.forAllM genChainWithInstability $ \args -> do
+    (_, (actual, expected)) <- liftIO
+      $ Tmp.withSystemTempDirectory
+        mempty
+      $ \dir -> do
+        let chainSubset = take (chainSizeSubset args) (eventGenerator args)
+            -- We need to make the filename as short as possible, because we're very limited by path
+            -- length
+            fileName = dir </> "f"
+        serverStarted <- newQSem 1
+        concurrently
+          (server fileName chainSubset serverStarted)
+          (client fileName chainSubset serverStarted)
 
-  GenM.stop (actual == expected)
+    GenM.stop (actual == expected)
   where
     server socketPath chainSubset serverStarted = bracket (runUnixSocketServer socketPath) close $ \s -> do
       signalQSem serverStarted

--- a/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/CLI.hs
+++ b/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/CLI.hs
@@ -12,6 +12,7 @@ module Marconi.Sidechain.Experimental.CLI (
 import Cardano.Api qualified as C
 import Data.Aeson (FromJSON, ToJSON)
 import Data.List.NonEmpty (NonEmpty)
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import Marconi.Cardano.ChainIndex.CLI qualified as Cli
 import Marconi.Cardano.Core.Orphans ()
@@ -35,6 +36,8 @@ data CliArgs = CliArgs
   -- ^ TCP/IP port number for JSON-RPC http server
   , networkId :: !C.NetworkId
   -- ^ cardano network id
+  , batchSize :: Word64
+  -- ^ Size of the batches sent to the indexers
   , targetAddresses :: !(Maybe TargetAddresses)
   -- ^ white-space sepparated list of Bech32 Cardano Shelley addresses
   , targetAssets :: !(Maybe (NonEmpty (C.PolicyId, Maybe C.AssetName)))
@@ -67,6 +70,7 @@ parserCliArgs =
     <*> Cli.commonDbDirParser
     <*> Cli.commonPortParser
     <*> Cli.commonNetworkIdParser
+    <*> Cli.commonBatchSizeParser
     <*> Cli.commonMaybeTargetAddressParser
     <*> Cli.commonMaybeTargetAssetParser
     <*> Cli.commonRetryConfigParser

--- a/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/Env.hs
+++ b/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/Env.hs
@@ -10,7 +10,7 @@ import Cardano.BM.Backend.Switchboard qualified as BM
 import Cardano.BM.Setup qualified as BM
 import Cardano.BM.Trace (Trace, logError)
 import Control.Lens (makeLenses, (^.))
-import Control.Monad (unless)
+import Control.Monad (guard, unless)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Data.Aeson (toJSON)
 import Data.List.NonEmpty qualified as NEList
@@ -19,15 +19,20 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Void (Void)
 import Marconi.Cardano.ChainIndex.Api.Types qualified as ChainIndex.Types
+import Marconi.Cardano.ChainIndex.Indexers qualified as Indexers
 import Marconi.Cardano.ChainIndex.Utils qualified as ChainIndex.Utils
-import Marconi.Cardano.Core.Extract.WithDistance (getEvent)
+import Marconi.Cardano.Core.Extract.WithDistance (chainDistance, getEvent)
 import Marconi.Cardano.Core.Logger (mkMarconiTrace)
 import Marconi.Cardano.Core.Node.Client.Retry (withNodeConnectRetry)
 import Marconi.Cardano.Core.Runner qualified as ChainIndex.Runner
 import Marconi.Cardano.Core.Types (SecurityParam)
+import Marconi.Cardano.Indexers.EpochNonce qualified as EpochNonce
+import Marconi.Cardano.Indexers.EpochSDD qualified as EpochSDD
 import Marconi.Cardano.Indexers.ExtLedgerStateCoordinator (
+  ExtLedgerStateEvent (extLedgerState),
   ExtLedgerStateWorkerConfig (ExtLedgerStateWorkerConfig),
  )
+import Marconi.Cardano.Indexers.ExtLedgerStateCoordinator qualified as ExtLedgerState
 import Marconi.Cardano.Indexers.MintTokenEvent (MintTokenEventConfig (MintTokenEventConfig))
 import Marconi.Cardano.Indexers.Utxo (UtxoIndexerConfig (UtxoIndexerConfig), trackedAddresses)
 import Marconi.Core qualified as Core
@@ -37,6 +42,7 @@ import Marconi.Sidechain.Experimental.Api.Types (
 import Marconi.Sidechain.Experimental.CLI (
   CliArgs (
     CliArgs,
+    batchSize,
     dbDir,
     httpPort,
     networkId,
@@ -92,9 +98,25 @@ mkSidechainBuildIndexersConfig trace CliArgs{..} securityParam =
         (map C.AddressShelley . NEList.toList . NESet.toList)
         targetAddresses
     -- Hard-coded with the same values as chain-index
-    catchupConfig = Core.mkCatchupConfig 5000 100
+    catchupConfig = Core.mkCatchupConfig batchSize 100
+    -- Extract useful information from the Ledger event and blocks
+    extLedgerStateAsEvent previousLedgerStateEvent ledgerStateEvent _blockEvent = do
+      previousEpochNo <- ExtLedgerState.getEpochNo $ extLedgerState previousLedgerStateEvent
+      epochNo <- ExtLedgerState.getEpochNo $ extLedgerState ledgerStateEvent
+      guard $ epochNo /= previousEpochNo
+      let sdd = EpochSDD.getEpochSDD ledgerStateEvent
+          nonce = EpochNonce.getEpochNonce ledgerStateEvent
+      pure $ Indexers.EpochEvent epochNo sdd nonce
     -- Snapshot config hard-coded as in chain-index
-    epochStateConfig = ExtLedgerStateWorkerConfig getEvent trace nodeConfigPath 100 securityParam
+    epochStateConfig =
+      ExtLedgerStateWorkerConfig
+        getEvent
+        chainDistance
+        trace
+        nodeConfigPath
+        100000
+        securityParam
+        extLedgerStateAsEvent
     mintBurnConfig = MintTokenEventConfig targetAssets
     -- Explicitly does not include the script.
     utxoConfig = UtxoIndexerConfig filteredAddresses False

--- a/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/Env.hs
+++ b/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/Env.hs
@@ -112,7 +112,6 @@ mkSidechainBuildIndexersConfig trace CliArgs{..} securityParam =
       ExtLedgerStateWorkerConfig
         getEvent
         chainDistance
-        trace
         nodeConfigPath
         100000
         securityParam

--- a/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/Indexers.hs
+++ b/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/Indexers.hs
@@ -43,7 +43,7 @@ data SidechainBuildIndexersConfig = SidechainBuildIndexersConfig
   , _sidechainBuildIndexersCatchupConfig :: !CatchupConfig
   , _sidechainBuildIndexersDbPath :: !FilePath
   , _sidechainBuildIndexersEpochStateConfig
-      :: !(EpochState.ExtLedgerStateWorkerConfig IO EpochEvent (WithDistance BlockEvent))
+      :: !(EpochState.ExtLedgerStateWorkerConfig EpochEvent (WithDistance BlockEvent))
   , _sidechainBuildIndexersMintTokenEventConfig :: !MintTokenEvent.MintTokenEventConfig
   , _sidechainBuildIndexersUtxoConfig :: !Utxo.UtxoIndexerConfig
   }

--- a/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/Indexers.hs
+++ b/marconi-sidechain-experimental/src/Marconi/Sidechain/Experimental/Indexers.hs
@@ -10,7 +10,11 @@ import Control.Monad.Except (runExceptT)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (ReaderT, ask)
 import Data.Text (Text)
-import Marconi.Cardano.ChainIndex.Indexers (MarconiCardanoQueryables, SyncStatsCoordinator)
+import Marconi.Cardano.ChainIndex.Indexers (
+  EpochEvent,
+  MarconiCardanoQueryables,
+  SyncStatsCoordinator,
+ )
 import Marconi.Cardano.ChainIndex.Indexers qualified as ChainIndex.Indexers
 import Marconi.Cardano.Core.Extract.WithDistance (WithDistance)
 import Marconi.Cardano.Core.Logger (mkMarconiTrace)
@@ -39,7 +43,7 @@ data SidechainBuildIndexersConfig = SidechainBuildIndexersConfig
   , _sidechainBuildIndexersCatchupConfig :: !CatchupConfig
   , _sidechainBuildIndexersDbPath :: !FilePath
   , _sidechainBuildIndexersEpochStateConfig
-      :: !(EpochState.ExtLedgerStateWorkerConfig IO (WithDistance BlockEvent))
+      :: !(EpochState.ExtLedgerStateWorkerConfig IO EpochEvent (WithDistance BlockEvent))
   , _sidechainBuildIndexersMintTokenEventConfig :: !MintTokenEvent.MintTokenEventConfig
   , _sidechainBuildIndexersUtxoConfig :: !Utxo.UtxoIndexerConfig
   }

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddress-MissingBech32Prefix.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddress-MissingBech32Prefix.golden
@@ -3,7 +3,7 @@ option --addresses-to-index: Invalid address (not a valid Bech32 address represe
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddress-badFormat.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddress-badFormat.golden
@@ -3,7 +3,7 @@ option --addresses-to-index: Invalid address (not a valid Bech32 address represe
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddressPrefix-stake1.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddressPrefix-stake1.golden
@@ -3,7 +3,7 @@ option --addresses-to-index: Invalid address (not a valid Bech32 address represe
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddressPrefix-stake_test.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddressPrefix-stake_test.golden
@@ -3,7 +3,7 @@ option --addresses-to-index: Invalid address (not a valid Bech32 address represe
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddress_1CharShort.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAddress_1CharShort.golden
@@ -3,7 +3,7 @@ option --addresses-to-index: Invalid address (not a valid Bech32 address represe
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-invalidBase16Format.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-invalidBase16Format.golden
@@ -3,7 +3,7 @@ option --match-asset-id: Expected Base16-encoded bytestring, but got 0000notATok
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-invalidBase16Length.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-invalidBase16Length.golden
@@ -3,7 +3,7 @@ option --match-asset-id: Expected Base16-encoded bytestring, but got deadbeeef; 
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-tooLong.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-assetName-tooLong.golden
@@ -3,7 +3,7 @@ option --match-asset-id: Failed to deserialise deadbeef0000000000000000000000000
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1ByteLong.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1ByteLong.golden
@@ -3,7 +3,7 @@ option --match-asset-id: Failed to deserialise 1cdc58c3b6d1ab11dd047ac9e3a2ec26a
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1ByteShort.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1ByteShort.golden
@@ -3,7 +3,7 @@ option --match-asset-id: Failed to deserialise 1cdc58c3b6d1ab11dd047ac9e3a2ec26a
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1HexCharLong.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1HexCharLong.golden
@@ -3,7 +3,7 @@ option --match-asset-id: Expected Base16-encoded bytestring, but got 1cdc58c3b6d
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1HexCharShort.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-1HexCharShort.golden
@@ -3,7 +3,7 @@ option --match-asset-id: Expected Base16-encoded bytestring, but got 1cdc58c3b6d
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-badBase16Format.golden
+++ b/marconi-sidechain-experimental/test/Spec/Golden/CLIInputValidation/invalidAssetId-policyId-badBase16Format.golden
@@ -3,7 +3,7 @@ option --match-asset-id: Expected Base16-encoded bytestring, but got 00aPolicyId
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Golden/Cli/marconi-sidechain___help.help
+++ b/marconi-sidechain-experimental/test/Spec/Golden/Cli/marconi-sidechain___help.help
@@ -27,7 +27,7 @@ Available options:
   --http-port INT          JSON-RPC http port number (default: 3000)
   --mainnet                Use the mainnet magic id.
   --testnet-magic NATURAL  Specify a testnet magic id.
-  --batch-size INT         Number of blocks send as a batch to the indexers
+  --batch-size INT         Number of blocks sent as a batch to the indexers
                            (default: 3000)
   -a,--addresses-to-index BECH32-ADDRESS
                            Bech32 Shelley addresses to index. i.e

--- a/marconi-sidechain-experimental/test/Spec/Golden/Cli/marconi-sidechain___help.help
+++ b/marconi-sidechain-experimental/test/Spec/Golden/Cli/marconi-sidechain___help.help
@@ -4,7 +4,7 @@ querying the Cardano blockchain
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 
@@ -27,6 +27,8 @@ Available options:
   --http-port INT          JSON-RPC http port number (default: 3000)
   --mainnet                Use the mainnet magic id.
   --testnet-magic NATURAL  Specify a testnet magic id.
+  --batch-size INT         Number of blocks send as a batch to the indexers
+                           (default: 3000)
   -a,--addresses-to-index BECH32-ADDRESS
                            Bech32 Shelley addresses to index. i.e
                            "--addresses-to-index address-1 --addresses-to-index

--- a/marconi-sidechain-experimental/test/Spec/Golden/Cli/marconi-sidechain___socket.help
+++ b/marconi-sidechain-experimental/test/Spec/Golden/Cli/marconi-sidechain___socket.help
@@ -3,7 +3,7 @@ Invalid option `--socket'
 Usage: marconi-sidechain-experimental 
          [--version] [--debug] (-s|--socket-path FILE-PATH)
          --node-config-path ARG (-d|--db-dir DIR) [--http-port INT] 
-         (--mainnet | --testnet-magic NATURAL) 
+         (--mainnet | --testnet-magic NATURAL) [--batch-size INT] 
          [(-a|--addresses-to-index BECH32-ADDRESS)] 
          [(--match-asset-id POLICY_ID[.ASSET_NAME])] 
          [--initial-retry-time NATURAL] 

--- a/marconi-sidechain-experimental/test/Spec/Marconi/Sidechain/Experimental/Utils.hs
+++ b/marconi-sidechain-experimental/test/Spec/Marconi/Sidechain/Experimental/Utils.hs
@@ -87,6 +87,7 @@ initTestingCliArgs =
     ""
     3000
     C.Mainnet
+    1000
     Nothing
     Nothing
     retryConfig

--- a/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
+++ b/marconi-sidechain/src/Marconi/Sidechain/Concurrency.hs
@@ -20,8 +20,8 @@ import System.Exit (ExitCode (ExitFailure), exitWith)
 {- These purpose of these functions is as follows:
 
   If we try to naively exit with a different exit code than that of the received signal, our new
-	exit code will be ignored, We can work around this by using `installHandler`; catching the
-	signal and setting our own exit code.
+  exit code will be ignored, We can work around this by using `installHandler`; catching the
+  signal and setting our own exit code.
 
   We can use exceptions to map our domain failures to these exit codes.
 
@@ -34,11 +34,11 @@ import System.Exit (ExitCode (ExitFailure), exitWith)
   we exit with whatever signal (SIGINT or SIGTERM) requested shutdown. -}
 
 {- | A data type representing an action with explicit instructions as to whether concurrent
-		 operations should attempt to map any exceptions it throws to Unix exit codes.
+     operations should attempt to map any exceptions it throws to Unix exit codes.
 
-		It has two type parameters:
+    It has two type parameters:
 
-		* @e@ the exception type, 'Void' in the unhandled case
+    * @e@ the exception type, 'Void' in the unhandled case
 
     * @a@ the type returned by the action
 -}
@@ -48,10 +48,10 @@ data HandledAction e a where
 
 {- | Perform two actions, with explicit handling instructions, concurrently (with the chosen scheme)
 
-		Returns whatever the concurrent operation would, if called plainly.
+    Returns whatever the concurrent operation would, if called plainly.
 
-		If the program is already shutting as a result of `SIGINT` or `SIGTERM`, any handled actions
-		will have their exceptions caught and mapped to an exit code.
+    If the program is already shutting as a result of `SIGINT` or `SIGTERM`, any handled actions
+    will have their exceptions caught and mapped to an exit code.
 -}
 concOpSignalHandled
   :: forall e1 e2 a b f
@@ -82,11 +82,11 @@ concOpSignalHandled concOp hleft hright = do
 
 {- | Race two actions, with explicit handling instructions, concurrently.
 
-		Takes two `HandledAction`s (the mechanism to explicitly specify handling instructions), and
-		returns whatever `race` would, if called directly.
+    Takes two `HandledAction`s (the mechanism to explicitly specify handling instructions), and
+    returns whatever `race` would, if called directly.
 
-		If the program is already shutting as a result of `SIGINT` or `SIGTERM`, any handled actions
-		will have their exceptions caught and mapped to an exit code.
+    If the program is already shutting as a result of `SIGINT` or `SIGTERM`, any handled actions
+    will have their exceptions caught and mapped to an exit code.
 -}
 raceSignalHandled
   :: forall e1 e2 a b

--- a/marconi-starter/src/Marconi/Starter/Indexers.hs
+++ b/marconi-starter/src/Marconi/Starter/Indexers.hs
@@ -18,7 +18,6 @@ import Marconi.Cardano.Core.Runner (
 import Marconi.Cardano.Core.Runner qualified as Runner
 import Marconi.Cardano.Core.Types (SecurityParam)
 import Marconi.Core qualified as Core
-import Marconi.Core.Indexer.SQLiteIndexer qualified as Core
 import Marconi.Starter.CLI qualified as CLI
 import Marconi.Starter.Env (Env, envCliArgs, envStdoutTrace)
 import Marconi.Starter.Env qualified as Env


### PR DESCRIPTION
Several memory/speed improvement:

- Store volatile ledger states in memory (faster rollback)
- Use Builder instead of Bytestring for serialisation
- Save LedgerState less often, and always save it on close.
- Add a `--batch-size` flag

<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [x] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [x] Self-reviewed the diff
    - [x] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [x] Reviewer requested
