### PR TITLE
PLT-9261 possible fix and debug for intermittent darwin failure

### DIFF
--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1728,22 +1728,21 @@ propWithStreamTBQueue = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabil
      such that the client can consume from the socket as a stream.
 -}
 propWithStreamSocket :: Property
-propWithStreamSocket = monadicExceptTIO @() $
-  GenM.forAllM genChainWithInstability $ \args -> do
-    (_, (actual, expected)) <- liftIO
-      $ Tmp.withSystemTempDirectory
-        mempty
-      $ \dir -> do
-        let chainSubset = take (chainSizeSubset args) (eventGenerator args)
-            -- We need to make the filename as short as possible, because we're very limited by path
-            -- length
-            fileName = dir </> "f"
-        serverStarted <- newQSem 1
-        concurrently
-          (server fileName chainSubset serverStarted)
-          (client fileName chainSubset serverStarted)
+propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstability $ \args -> do
+  (_, (actual, expected)) <- liftIO
+    $ Tmp.withSystemTempDirectory
+      "a"
+    $ \dir -> do
+      let chainSubset = take (chainSizeSubset args) (eventGenerator args)
+          -- We need to make the filename as short as possible, because we're very limited by path
+          -- length
+          fileName = dir </> "f"
+      serverStarted <- newQSem 1
+      concurrently
+        (server fileName chainSubset serverStarted)
+        (client fileName chainSubset serverStarted)
 
-    GenM.stop (actual == expected)
+  GenM.stop (actual == expected)
   where
     server socketPath chainSubset serverStarted = bracket (runUnixSocketServer socketPath) close $ \s -> do
       signalQSem serverStarted

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -131,7 +131,7 @@ import Control.Concurrent.STM (
   TBQueue,
   newTBQueueIO,
  )
-import Control.Exception (bracket)
+import Control.Exception (SomeException, bracket, try)
 import Control.Lens (
   Getter,
   Lens',
@@ -156,6 +156,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.State (StateT, evalStateT, gets)
 import Control.Tracer qualified as Tracer
+import Data.Bifunctor (first)
 import Data.ByteString qualified as BS
 import Data.Either (fromRight)
 import Data.Foldable (Foldable (foldl'), find)
@@ -1729,21 +1730,32 @@ propWithStreamTBQueue = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabil
 -}
 propWithStreamSocket :: Property
 propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstability $ \args -> do
-  (_, (actual, expected)) <- liftIO
-    $ Tmp.withSystemTempDirectory
-      "a"
-    $ \dir -> do
-      let chainSubset = take (chainSizeSubset args) (eventGenerator args)
-          -- We need to make the filename as short as possible, because we're very limited by path
-          -- length
-          fileName = dir </> "f"
-      serverStarted <- newQSem 1
-      concurrently
-        (server fileName chainSubset serverStarted)
-        (client fileName chainSubset serverStarted)
+  res <- liftIO $ Tmp.withSystemTempDirectory "a" $ \dir -> do
+    -- We need to make the filename as short as possible, because we're very limited by socket
+    -- path length.
+    let
+      fileName = dir </> "f"
+      failMsg = "Socket path: " <> fileName
 
-  GenM.stop (actual == expected)
+    first (const failMsg) <$> try @SomeException (runTestWithSocketFile args fileName)
+
+  -- Swallowing the error and letting the test fail with the socket path message
+  -- is a workaround to enable reporting the path when the test throws an exception before
+  -- completion. 'GenM.monitor' or other failure reporting tools don't fire if an
+  -- exception is thrown first, but it can't be put within 'withSystemTempDirectory' since
+  -- PropertyM m is not 'MonadMask'. Temporary measure to support PLT-9260.
+  case res of
+    Left msg -> GenM.assertWith False msg
+    Right (actual, expected) -> GenM.stop (actual === expected)
   where
+    runTestWithSocketFile args fileName = do
+      let chainSubset = take (chainSizeSubset args) (eventGenerator args)
+      serverStarted <- newQSem 1
+      snd
+        <$> concurrently
+          (server fileName chainSubset serverStarted)
+          (client fileName chainSubset serverStarted)
+
     server socketPath chainSubset serverStarted = bracket (runUnixSocketServer socketPath) close $ \s -> do
       signalQSem serverStarted
       (conn, _) <- accept s

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1735,9 +1735,9 @@ propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabili
     -- path length.
     let
       fileName = dir </> "f"
-      failMsg = "Socket path: " <> fileName
+      failMsg = "\nSocket path: " <> fileName
 
-    first (const failMsg) <$> try @SomeException (runTestWithSocketFile args fileName)
+    first ((<> failMsg) . show) <$> try @SomeException (runTestWithSocketFile args fileName)
 
   -- Swallowing the error and letting the test fail with the socket path message
   -- is a workaround to enable reporting the path when the test throws an exception before


### PR DESCRIPTION
* Use a non-empty temp directory prefix. This is a guess at a fix for a somewhat rare failure on darwin, from the socket path not being found in `propWithStreamSocket` from `marconi-core-test`.
* Reports the socket path on failure -- swallowing the original exception and failing the test after reporting the socket path. See the code note on this workaround.

The second item is to help find a real fix for this intermittent problem if needed. See PLT-9260.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [X] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [X] Targeting main unless this is a cherry-pick backport
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [X] Reviewer requested
