### PR TITLE
PLT-9260 Intermittent withStreamSocket test failures

### DIFF
--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1768,6 +1768,7 @@ propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabili
 
     client socketPath chainSubset serverStarted = do
       waitQSem serverStarted
+
       -- We need to delay because otherwise we might try to connect before @accept s@ runs
       threadDelay 5000
       bracket (runUnixSocketClient socketPath) close $ \s -> do

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1768,7 +1768,6 @@ propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabili
 
     client socketPath chainSubset serverStarted = do
       waitQSem serverStarted
-
       -- We need to delay because otherwise we might try to connect before @accept s@ runs
       threadDelay 5000
       bracket (runUnixSocketClient socketPath) close $ \s -> do

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1770,7 +1770,7 @@ propWithStreamSocket = monadicExceptTIO @() $ GenM.forAllM genChainWithInstabili
       waitQSem serverStarted
 
       -- We need to delay because otherwise we might try to connect before @accept s@ runs
-      threadDelay 100
+      threadDelay 5000
       bracket (runUnixSocketClient socketPath) close $ \s -> do
         let testEvents :: [TestEvent] = chainSubset ^.. traversed . _Insert . _2 . _Just
             stream :: Stream (Of Int) IO () = streamFrom s


### PR DESCRIPTION
This is another guess at a "fix" for intermittent failures on Darwin for the named test. The proposed "fix" is based on previous error messages. But it is difficult to analyze, so we might need to do another round to fix the problem for good.

Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [X] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [X] Self-reviewed the diff
    - [X] Useful pull request description
    - [X] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [X] Reviewer requested
