### PR TITLE
Introduce connection pools for sql queries

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 
 -- See CONTRIBUTING.adoc for how to update index-state
 index-state:
-  , hackage.haskell.org 2023-12-07T00:29:14Z
+  , hackage.haskell.org 2024-01-22T23:05:20Z
   , cardano-haskell-packages 2023-12-06T19:40:56Z
 packages: legacy/marconi-core-legacy
           legacy/marconi-chain-index-legacy

--- a/doc/read-the-docs-site/doc/marconi-as-a-library/tutorials/BasicApp.hs
+++ b/doc/read-the-docs-site/doc/marconi-as-a-library/tutorials/BasicApp.hs
@@ -387,7 +387,9 @@ instance SQL.ToRow (Core.Timed C.ChainPoint BlockInfoEvent) where
 
 -- | Query the SQLite indexer
 instance
-  (MonadIO m)
+  ( MonadError (Core.QueryError GetBlockInfoFromBlockNoQuery) m
+  , MonadIO m
+  )
   => Core.Queryable
       m
       BlockInfoEvent -- The event type of the indexer

--- a/marconi-cardano-chain-index/test-lib/Test/Marconi/Cardano/ChainIndex/Indexers.hs
+++ b/marconi-cardano-chain-index/test-lib/Test/Marconi/Cardano/ChainIndex/Indexers.hs
@@ -15,8 +15,6 @@ import Control.Monad ((>=>))
 import Control.Monad.Except (ExceptT)
 import Control.Monad.Trans (lift)
 import Data.List.NonEmpty (NonEmpty)
-import Data.Text (Text)
-import Data.Text qualified as Text
 import Marconi.Cardano.ChainIndex.Indexers (EpochEvent)
 import Marconi.Cardano.ChainIndex.Indexers qualified as Indexers
 import Marconi.Cardano.Core.Extract.WithDistance (WithDistance)

--- a/marconi-cardano-core/src/Marconi/Cardano/Core/Transformer/WithSyncStats.hs
+++ b/marconi-cardano-core/src/Marconi/Cardano/Core/Transformer/WithSyncStats.hs
@@ -47,6 +47,8 @@ import Marconi.Core.Transformer.Class (IndexerTrans, unwrap)
 import Marconi.Core.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
   indexVia,
+  queryLatestVia,
+  queryVia,
   rollbackVia,
   setLastStablePointVia,
   wrappedIndexer,
@@ -100,10 +102,12 @@ deriving via
   instance
     (IsSync m event indexer) => IsSync m event (WithSyncStats indexer)
 
-deriving via
-  (IndexTransformer WithSyncStatsConfig indexer)
-  instance
-    (Queryable m event query indexer) => Queryable m event query (WithSyncStats indexer)
+instance
+  (Queryable m event query indexer, IsSync m event indexer)
+  => Queryable m event query (WithSyncStats indexer)
+  where
+  query = queryVia unwrap
+  queryLatest = queryLatestVia unwrap
 
 deriving via
   (IndexTransformer WithSyncStatsConfig indexer)

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/BlockInfo.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/BlockInfo.hs
@@ -1,11 +1,10 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- | An Indexer that stores BlockInfo
 module Marconi.Cardano.Indexers.BlockInfo (
@@ -39,9 +38,8 @@ import Cardano.BM.Data.Trace (Trace)
 import Cardano.BM.Tracing qualified as BM
 import Control.Lens ((&), (?~), (^.))
 import Control.Lens qualified as Lens
-import Control.Monad (when)
-import Control.Monad.Except (MonadError (throwError))
-import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Monad.Except (MonadError)
+import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson.TH qualified as Aeson
 import Data.Maybe (listToMaybe, mapMaybe)
 import Data.String (fromString)
@@ -191,6 +189,15 @@ type instance Core.Result (BlockInfoBySlotNoQuery event) = Maybe event
 
 newtype BlockInfoBySlotNoQuery event = BlockInfoBySlotNoQuery C.SlotNo
 
+lastBlockInfoQuery :: SQL.Query
+lastBlockInfoQuery =
+  [sql|
+  SELECT blockNo, blockTimestamp, epochNo
+  FROM blockInfo
+  ORDER BY slotNo DESC
+  LIMIT 1
+  |]
+
 blockInfoBySlotNoQuery :: SQL.Query
 blockInfoBySlotNoQuery =
   [sql|
@@ -204,31 +211,17 @@ instance
   (MonadIO m, MonadError (Core.QueryError (BlockInfoBySlotNoQuery BlockInfo)) m)
   => Core.Queryable m BlockInfo (BlockInfoBySlotNoQuery BlockInfo) Core.SQLiteIndexer
   where
-  query p q@(BlockInfoBySlotNoQuery sn) =
-    querySyncedOnlySQLiteIndexerBySlotNoWith
-      (\s -> pure [":slotNo" := s])
+  query =
+    Core.querySyncedOnlySQLiteIndexerWith
+      (const $ \(BlockInfoBySlotNoQuery sn) -> [":slotNo" := sn])
       (const blockInfoBySlotNoQuery)
       (const listToMaybe)
-      sn
-    where
-      -- This isn't in core because we don't want to encourage this operation in the general case
-      querySyncedOnlySQLiteIndexerBySlotNoWith
-        :: (C.SlotNo -> BlockInfoBySlotNoQuery BlockInfo -> [NamedParam])
-        -> (BlockInfoBySlotNoQuery BlockInfo -> SQL.Query)
-        -> ( BlockInfoBySlotNoQuery BlockInfo
-             -> [BlockInfo]
-             -> Maybe BlockInfo
-           )
-        -> C.SlotNo
-        -> Core.SQLiteIndexer BlockInfo
-        -> m (Maybe BlockInfo)
-      querySyncedOnlySQLiteIndexerBySlotNoWith toNamedParam sqlQuery fromRows slotNo indexer =
-        do
-          let c = indexer ^. Core.connection
-          when (p > indexer ^. Core.dbLastSync) $
-            throwError (Core.AheadOfLastSync Nothing)
-          res <- liftIO $ SQL.queryNamed c (sqlQuery q) (toNamedParam slotNo q)
-          pure $ fromRows q res
+
+  queryLatest =
+    Core.queryLatestSQLiteIndexerWith
+      (\(BlockInfoBySlotNoQuery s) -> [":slotNo" := s])
+      (const blockInfoBySlotNoQuery)
+      (const listToMaybe)
 
 instance
   (MonadIO m, MonadError (Core.QueryError (Core.EventAtQuery BlockInfo)) m)
@@ -239,52 +232,104 @@ instance
       (\cp -> pure [":slotNo" := C.chainPointToSlotNo cp])
       (const blockInfoBySlotNoQuery)
       (const listToMaybe)
+  queryLatest =
+    Core.queryLatestSQLiteIndexerWith
+      (pure [])
+      (const lastBlockInfoQuery)
+      (const listToMaybe)
+
+queryClosestBlockInfo
+  :: ( MonadIO m
+     , MonadError (Core.QueryError (Core.EventsMatchingQuery BlockInfo)) m
+     )
+  => Maybe C.ChainPoint
+  -> Core.EventsMatchingQuery BlockInfo
+  -> Core.SQLiteIndexer BlockInfo
+  -> m (Core.Result (Core.EventsMatchingQuery BlockInfo))
+queryClosestBlockInfo =
+  let queryPrefix :: SQL.Query
+      queryPrefix =
+        [sql|
+        SELECT blockNo, blockTimestamp, epochNo,
+               slotNo, blockHeaderHash
+        FROM blockInfo
+        |]
+      queryLatest :: SQL.Query
+      queryLatest = queryPrefix
+      querySpecific :: SQL.Query
+      querySpecific = queryPrefix <> [sql| WHERE slotNo <= :slotNo |]
+      parseResult
+        :: (a -> Maybe a)
+        -> [Core.Timed C.ChainPoint a]
+        -> [Core.Timed C.ChainPoint a]
+      parseResult = mapMaybe . traverse
+   in \case
+        Nothing ->
+          Core.queryLatestSQLiteIndexerWith
+            (pure [])
+            (const queryLatest)
+            (\(Core.EventsMatchingQuery p) -> parseResult p)
+        Just point ->
+          Core.querySyncedOnlySQLiteIndexerWith
+            (\cp -> pure [":slotNo" := C.chainPointToSlotNo cp])
+            (const querySpecific)
+            (\(Core.EventsMatchingQuery p) -> parseResult p)
+            point
 
 instance
   (MonadIO m, MonadError (Core.QueryError (Core.EventsMatchingQuery BlockInfo)) m)
   => Core.Queryable m BlockInfo (Core.EventsMatchingQuery BlockInfo) Core.SQLiteIndexer
   where
-  query =
-    let blockInfoBeforeOrAtSlotNoQuery :: SQL.Query
-        blockInfoBeforeOrAtSlotNoQuery =
-          [sql|
+  query = queryClosestBlockInfo . Just
+  queryLatest = queryClosestBlockInfo Nothing
+
+queryLatestBlockInfo
+  :: ( MonadIO m
+     , MonadError (Core.QueryError (Core.LatestEventsQuery BlockInfo)) m
+     )
+  => Maybe C.ChainPoint
+  -> Core.LatestEventsQuery BlockInfo
+  -> Core.SQLiteIndexer BlockInfo
+  -> m (Core.Result (Core.LatestEventsQuery BlockInfo))
+queryLatestBlockInfo =
+  let queryPrefix :: SQL.Query
+      queryPrefix =
+        [sql|
           SELECT blockNo, blockTimestamp, epochNo,
                  slotNo, blockHeaderHash
           FROM blockInfo
-          WHERE slotNo <= :slotNo
-          |]
-
-        parseResult
-          :: (a -> Maybe a)
-          -> [Core.Timed C.ChainPoint a]
-          -> [Core.Timed C.ChainPoint a]
-        parseResult = mapMaybe . traverse
-     in Core.querySyncedOnlySQLiteIndexerWith
-          (\cp -> pure [":slotNo" := C.chainPointToSlotNo cp])
-          (const blockInfoBeforeOrAtSlotNoQuery)
-          (\(Core.EventsMatchingQuery p) -> parseResult p)
+        |]
+      extraParts :: SQL.Query
+      extraParts =
+        [sql|
+          ORDER BY slotNo DESC
+          LIMIT :n
+        |]
+      queryLatest :: SQL.Query
+      queryLatest = queryPrefix <> extraParts
+      querySpecific :: SQL.Query
+      querySpecific = queryPrefix <> [sql| WHERE slotNo <= :slotNo |] <> extraParts
+   in \case
+        Nothing ->
+          Core.queryLatestSQLiteIndexerWith
+            (\(Core.LatestEventsQuery n) -> [":n" := n])
+            (const queryLatest)
+            (const id)
+        Just point ->
+          Core.querySyncedOnlySQLiteIndexerWith
+            ( \cp (Core.LatestEventsQuery n) ->
+                [":slotNo" := C.chainPointToSlotNo cp, ":n" := n]
+            )
+            (const querySpecific)
+            (const id)
+            point
 
 instance
   (MonadIO m, MonadError (Core.QueryError (Core.LatestEventsQuery BlockInfo)) m)
   => Core.Queryable m BlockInfo (Core.LatestEventsQuery BlockInfo) Core.SQLiteIndexer
   where
-  query =
-    let blockInfoBeforeOrAtSlotNoQuery :: SQL.Query
-        blockInfoBeforeOrAtSlotNoQuery =
-          [sql|
-          SELECT blockNo, blockTimestamp, epochNo,
-                 slotNo, blockHeaderHash
-          FROM blockInfo
-          WHERE slotNo <= :slotNo
-          ORDER BY slotNo DESC
-          LIMIT :n
-          |]
-     in Core.querySyncedOnlySQLiteIndexerWith
-          ( \cp (Core.LatestEventsQuery n) ->
-              [":slotNo" := C.chainPointToSlotNo cp, ":n" := n]
-          )
-          (const blockInfoBeforeOrAtSlotNoQuery)
-          (const id)
+  query = queryLatestBlockInfo . Just
+  queryLatest = queryLatestBlockInfo Nothing
 
 extractBlockInfo :: BlockEvent -> BlockInfo
 extractBlockInfo (BlockEvent (C.BlockInMode b _) eno t) =

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/BlockInfo.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/BlockInfo.hs
@@ -254,8 +254,6 @@ queryClosestBlockInfo =
                slotNo, blockHeaderHash
         FROM blockInfo
         |]
-      queryLatest :: SQL.Query
-      queryLatest = queryPrefix
       querySpecific :: SQL.Query
       querySpecific = queryPrefix <> [sql| WHERE slotNo <= :slotNo |]
       parseResult
@@ -267,7 +265,7 @@ queryClosestBlockInfo =
         Nothing ->
           Core.queryLatestSQLiteIndexerWith
             (pure [])
-            (const queryLatest)
+            (const queryPrefix)
             (\(Core.EventsMatchingQuery p) -> parseResult p)
         Just point ->
           Core.querySyncedOnlySQLiteIndexerWith

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/CurrentSyncPointQuery.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/CurrentSyncPointQuery.hs
@@ -98,7 +98,10 @@ instance
         runExceptT @(Core.QueryError (Core.LatestEventsQuery BlockInfo)) $
           Core.query point Core.latestEvent blockInfoIndexer'
     chainTipIndexer' <- liftIO $ Con.readMVar chainTipIndexerMvar
-    tips <- toSyncPointError $ runExceptT $ Core.queryLatest Core.GetLastQuery chainTipIndexer'
+    tips <-
+      toSyncPointError $
+        runExceptT @(Core.QueryError (Core.GetLastQuery C.ChainTip)) $
+          Core.queryLatest Core.GetLastQuery chainTipIndexer'
     case (blockInfos, tips) of
       ([timedBlockInfo], Just tip) -> do
         let blockInfo = timedBlockInfo ^. Core.event

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Datum.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Datum.hs
@@ -195,8 +195,6 @@ queryMatchingData =
                slotNo, blockHeaderHash
         FROM datum
         |]
-      queryLatest :: SQL.Query
-      queryLatest = queryPrefix
       querySpecific :: SQL.Query
       querySpecific = queryPrefix <> [sql| WHERE slotNo <= :slotNo |]
       groupEvents
@@ -214,7 +212,7 @@ queryMatchingData =
         Nothing ->
           Core.queryLatestSQLiteIndexerWith
             (pure [])
-            (const queryLatest)
+            (const queryPrefix)
             (\(Core.EventsMatchingQuery p) -> parseResult p)
         Just point ->
           Core.querySyncedOnlySQLiteIndexerWith

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/MintTokenEvent.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/MintTokenEvent.hs
@@ -423,7 +423,7 @@ mkMintTokenIndexer dbPath = do
               , redeemerHash BLOB
               , redeemerData BLOB
               )|]
-  let mintEventInsertQuery :: SQL.Query
+      mintEventInsertQuery :: SQL.Query
       mintEventInsertQuery =
         [sql|INSERT
                INTO minting_policy_events (

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/MintTokenEventQuery.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/MintTokenEventQuery.hs
@@ -29,7 +29,7 @@ import Marconi.Cardano.Indexers.MintTokenEvent (
 import Marconi.Core qualified as Core
 
 {- If at any point we move to another database backend, we might want to consider changing this to
-	use SQLiteAggregateQuery to avoid opening more than one connection -}
+   use SQLiteAggregateQuery to avoid opening more than one connection -}
 
 -- | The inner state of the 'MintTokenIndexerQuery'
 data MintTokenEventIndexerQuery event = MintTokenEventIndexerQuery

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/MintTokenEventQuery.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/MintTokenEventQuery.hs
@@ -101,9 +101,9 @@ instance
     let fromError :: Core.QueryError a -> Core.QueryError b
         fromError = \case
           Core.NotStoredAnymore -> Core.NotStoredAnymore
-          (Core.IndexerQueryError t) -> Core.IndexerQueryError t
-          (Core.AheadOfLastSync _) -> Core.IndexerQueryError "Upper slot no. ahead of last sync"
-          (Core.SlotNoBoundsInvalid r) -> Core.SlotNoBoundsInvalid r
+          Core.IndexerQueryError t -> Core.IndexerQueryError t
+          Core.AheadOfLastSync _ -> Core.IndexerQueryError "Upper slot no. ahead of last sync"
+          Core.SlotNoBoundsInvalid r -> Core.SlotNoBoundsInvalid r
 
     withStab <-
       case upperSlotNo of

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Spent.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Spent.hs
@@ -235,8 +235,6 @@ queryMatchingSpent =
                slotNo, blockHeaderHash
         FROM spent
         |]
-      queryLatest :: SQL.Query
-      queryLatest = queryPrefix
       querySpecific :: SQL.Query
       querySpecific = queryPrefix <> [sql| WHERE slotNo <= :slotNo |]
       groupEvents
@@ -254,7 +252,7 @@ queryMatchingSpent =
         Nothing ->
           Core.queryLatestSQLiteIndexerWith
             (pure [])
-            (const queryLatest)
+            (const queryPrefix)
             (\(Core.EventsMatchingQuery p) -> parseResult p)
         Just point ->
           Core.querySyncedOnlySQLiteIndexerWith

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Spent.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/Spent.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -218,6 +219,50 @@ instance
           (const spentInfoQuery)
           (const NonEmpty.nonEmpty)
 
+queryMatchingSpent
+  :: ( MonadIO m
+     , MonadError (Core.QueryError (Core.EventsMatchingQuery SpentInfoEvent)) m
+     )
+  => Maybe C.ChainPoint
+  -> Core.EventsMatchingQuery SpentInfoEvent
+  -> Core.SQLiteIndexer SpentInfoEvent
+  -> m (Core.Result (Core.EventsMatchingQuery SpentInfoEvent))
+queryMatchingSpent =
+  let queryPrefix :: SQL.Query
+      queryPrefix =
+        [sql|
+        SELECT txId, txIx, spentAtTxId,
+               slotNo, blockHeaderHash
+        FROM spent
+        |]
+      queryLatest :: SQL.Query
+      queryLatest = queryPrefix
+      querySpecific :: SQL.Query
+      querySpecific = queryPrefix <> [sql| WHERE slotNo <= :slotNo |]
+      groupEvents
+        :: NonEmpty (Core.Timed point a)
+        -> Core.Timed point (NonEmpty a)
+      groupEvents xs@(x :| _) = Core.Timed (x ^. Core.point) (Lens.view Core.event <$> xs)
+      parseResult
+        :: (NonEmpty a -> Maybe (NonEmpty a))
+        -> [Core.Timed C.ChainPoint a]
+        -> [Core.Timed C.ChainPoint (NonEmpty a)]
+      parseResult p =
+        mapMaybe (traverse p . groupEvents)
+          . NonEmpty.groupBy ((==) `on` Lens.view Core.point)
+   in \case
+        Nothing ->
+          Core.queryLatestSQLiteIndexerWith
+            (pure [])
+            (const queryLatest)
+            (\(Core.EventsMatchingQuery p) -> parseResult p)
+        Just point ->
+          Core.querySyncedOnlySQLiteIndexerWith
+            (\cp -> pure [":slotNo" := C.chainPointToSlotNo cp])
+            (const querySpecific)
+            (\(Core.EventsMatchingQuery p) -> parseResult p)
+            point
+
 instance
   (MonadIO m, MonadError (Core.QueryError (Core.EventsMatchingQuery SpentInfoEvent)) m)
   => Core.Queryable
@@ -226,30 +271,8 @@ instance
       (Core.EventsMatchingQuery SpentInfoEvent)
       Core.SQLiteIndexer
   where
-  query =
-    let spentQuery :: SQL.Query
-        spentQuery =
-          [sql|
-          SELECT txId, txIx, spentAtTxId,
-                 slotNo, blockHeaderHash
-          FROM spent
-          WHERE slotNo <= :slotNo
-          |]
-        groupEvents
-          :: NonEmpty (Core.Timed point a)
-          -> Core.Timed point (NonEmpty a)
-        groupEvents xs@(x :| _) = Core.Timed (x ^. Core.point) (Lens.view Core.event <$> xs)
-        parseResult
-          :: (NonEmpty a -> Maybe (NonEmpty a))
-          -> [Core.Timed C.ChainPoint a]
-          -> [Core.Timed C.ChainPoint (NonEmpty a)]
-        parseResult p =
-          mapMaybe (traverse p . groupEvents)
-            . NonEmpty.groupBy ((==) `on` Lens.view Core.point)
-     in Core.querySyncedOnlySQLiteIndexerWith
-          (\cp -> pure [":slotNo" := C.chainPointToSlotNo cp])
-          (const spentQuery)
-          (\(Core.EventsMatchingQuery p) -> parseResult p)
+  query = queryMatchingSpent . Just
+  queryLatest = queryMatchingSpent Nothing
 
 getInputs :: C.TxBody era -> [SpentInfo]
 getInputs

--- a/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/UtxoQuery.hs
+++ b/marconi-cardano-indexers/src/Marconi/Cardano/Indexers/UtxoQuery.hs
@@ -324,4 +324,5 @@ instance
                 <> sqlFilters
                 <> " GROUP BY u.txId, u.txIx"
                 <> " ORDER BY u.slotNo ASC"
-     in liftIO $ SQL.queryNamed (indexer ^. Core.aggregateConnection) query params
+     in liftIO $ Core.withResource (indexer ^. Core.aggregateConnection) $ \con ->
+          SQL.queryNamed con query params

--- a/marconi-cardano-indexers/test-lib/Test/Marconi/Cardano/DbSyncComparison/Common.hs
+++ b/marconi-cardano-indexers/test-lib/Test/Marconi/Cardano/DbSyncComparison/Common.hs
@@ -96,7 +96,8 @@ eraToString =
  the information which was accumulated from the snapshot.
 -}
 queryIndexerOnSnapshot
-  :: ( Core.IsIndex (ExceptT Core.IndexerError IO) event indexer
+  :: forall event indexer query
+   . ( Core.IsIndex (ExceptT Core.IndexerError IO) event indexer
      , Core.Closeable IO indexer
      , Core.Point event ~ C.ChainPoint
      , Core.Queryable (ExceptT (Core.QueryError query) IO) event query indexer
@@ -121,7 +122,7 @@ queryIndexerOnSnapshot nodeType subChainPath dbPath config point query indexer =
   withAsync runIndexer $ \runner -> do
     finalState <- wait runner >>= readMVar
     toRuntimeException $
-      maybe Core.queryLatest Core.query point query finalState
+      maybe (Core.queryLatest @(ExceptT (Core.QueryError query) IO)) Core.query point query finalState
 
 {- | The path to a data directory containing configuration files
 is set to an environment variable. This function retrieves the right

--- a/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/UtxoQuery.hs
+++ b/marconi-cardano-indexers/test/Spec/Marconi/Cardano/Indexers/UtxoQuery.hs
@@ -8,7 +8,7 @@ module Spec.Marconi.Cardano.Indexers.UtxoQuery (
 import Cardano.Api qualified as C
 import Control.Lens ((^.), (^..), (^?))
 import Control.Lens qualified as Lens
-import Control.Monad (void, when)
+import Control.Monad (unless, void)
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Aeson qualified as Aeson
 import Data.List qualified as List
@@ -85,10 +85,10 @@ propAllUnspentWhenPointGenesis = Hedgehog.property $ do
       Test.Utxo.getTimedUtxosEvents $
         Test.Mockchain.mockchainWithInfoAsMockchain events
     utxos = utxoEvents ^.. Lens.folded . Core.event . Lens.folded . Lens.folded
-    hasUtxoEvents = not $ null utxos
+    hasNoUtxoEvents = null utxos
 
-  Hedgehog.cover 90 "Has at least one UTxO" hasUtxoEvents
-  when hasUtxoEvents $ do
+  Hedgehog.cover 90 "Has at least one UTxO" (not hasNoUtxoEvents)
+  unless hasNoUtxoEvents $ do
     -- Take the last UTxO to guarantee the result should
     -- have at least one element.
     let

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -111,6 +111,7 @@ library
     , mtl
     , network
     , prettyprinter
+    , resource-pool
     , sqlite-simple
     , stm
     , streaming

--- a/marconi-core/marconi-core.cabal
+++ b/marconi-core/marconi-core.cabal
@@ -103,6 +103,7 @@ library
     , bytestring
     , comonad
     , containers
+    , direct-sqlite
     , directory
     , filepath
     , foldl

--- a/marconi-core/src/Marconi/Core.hs
+++ b/marconi-core/src/Marconi/Core.hs
@@ -204,7 +204,6 @@ module Marconi.Core (
   Closeable (..),
   Queryable (..),
   queryEither,
-  queryLatest,
   queryLatestEither,
   AppendResult (..),
 
@@ -289,6 +288,7 @@ module Marconi.Core (
   ToRow (..),
   dbLastSync,
   querySQLiteIndexerWith,
+  queryLatestSQLiteIndexerWith,
   querySyncedOnlySQLiteIndexerWith,
   handleSQLErrors,
   SQLiteAggregateQuery (SQLiteAggregateQuery),
@@ -297,6 +297,10 @@ module Marconi.Core (
   SQLiteSourceProvider (SQLiteSourceProvider),
   IsSourceProvider,
   HasDatabasePath (getDatabasePath),
+
+  -- **** Connection utilities
+  readOnlyConnection,
+  readWriteConnection,
 
   -- *** On file
 
@@ -625,8 +629,11 @@ import Marconi.Core.Indexer.SQLiteIndexer (
   mkSingleInsertSqliteIndexer,
   mkSqliteIndexer,
   parseDBLocation,
+  queryLatestSQLiteIndexerWith,
   querySQLiteIndexerWith,
   querySyncedOnlySQLiteIndexerWith,
+  readOnlyConnection,
+  readWriteConnection,
  )
 import Marconi.Core.Preprocessor (
   Preprocessor,

--- a/marconi-core/src/Marconi/Core.hs
+++ b/marconi-core/src/Marconi/Core.hs
@@ -280,7 +280,8 @@ module Marconi.Core (
   mkSingleInsertSqliteIndexer,
   inMemoryDB,
   parseDBLocation,
-  connection,
+  writeConnection,
+  readConnectionPool,
   SQLInsertPlan (SQLInsertPlan, planExtractor, planInsert),
   SQLRollbackPlan (SQLRollbackPlan, tableName, pointName, pointExtractor),
 
@@ -622,7 +623,6 @@ import Marconi.Core.Indexer.SQLiteIndexer (
   SQLiteIndexer (..),
   SetLastStablePointQuery (SetLastStablePointQuery, getSetLastStablePointQuery),
   ToRow (..),
-  connection,
   dbLastSync,
   handleSQLErrors,
   inMemoryDB,
@@ -632,8 +632,10 @@ import Marconi.Core.Indexer.SQLiteIndexer (
   queryLatestSQLiteIndexerWith,
   querySQLiteIndexerWith,
   querySyncedOnlySQLiteIndexerWith,
+  readConnectionPool,
   readOnlyConnection,
   readWriteConnection,
+  writeConnection,
  )
 import Marconi.Core.Preprocessor (
   Preprocessor,

--- a/marconi-core/src/Marconi/Core.hs
+++ b/marconi-core/src/Marconi/Core.hs
@@ -295,6 +295,7 @@ module Marconi.Core (
   SQLiteAggregateQuery (SQLiteAggregateQuery),
   aggregateConnection,
   mkSQLiteAggregateQuery,
+  withResource,
   SQLiteSourceProvider (SQLiteSourceProvider),
   IsSourceProvider,
   HasDatabasePath (getDatabasePath),
@@ -613,6 +614,7 @@ import Marconi.Core.Indexer.SQLiteAggregateQuery (
   SQLiteSourceProvider (..),
   aggregateConnection,
   mkSQLiteAggregateQuery,
+  withResource,
  )
 import Marconi.Core.Indexer.SQLiteIndexer (
   GetLastStablePointQuery (GetLastStablePointQuery, getLastStablePointQuery),

--- a/marconi-core/src/Marconi/Core/Indexer/SQLiteAggregateQuery.hs
+++ b/marconi-core/src/Marconi/Core/Indexer/SQLiteAggregateQuery.hs
@@ -82,7 +82,7 @@ mkSQLiteAggregateQuery
   -- ^ A map of indexers. The keys are used as an alias int the attach statement
   -> IO (SQLiteAggregateQuery m point event)
 mkSQLiteAggregateQuery sources = do
-  con <- liftIO $ SQL.open ":memory:"
+  con <- SQLite.readOnlyConnection SQLite.inMemoryDB
   let databaseFromSource :: SQLiteSourceProvider m point -> IO FilePath
       databaseFromSource (SQLiteSourceProvider ix) = Con.withMVar ix (pure . expectPersistentDB . getDatabasePath)
       attachDb name src =

--- a/marconi-core/src/Marconi/Core/Indexer/SQLiteIndexer.hs
+++ b/marconi-core/src/Marconi/Core/Indexer/SQLiteIndexer.hs
@@ -140,9 +140,9 @@ data SQLiteIndexer event = SQLiteIndexer
   { _databasePath :: SQLiteDBLocation
   -- ^ The location of the database
   , _writeConnection :: SQL.Connection
-  -- ^ The connection used to interact with the database
+  -- ^ The connection used to index events into the database (write)
   , _readConnectionPool :: Pool SQL.Connection
-  -- ^ The connection used to interact with the database
+  -- ^ The connection pool used to query the database (read)
   , _insertPlan :: [[SQLInsertPlan event]]
   -- ^ A plan is a list of lists : each 'SQLInsertPlan' in a list is executed concurrently.
   -- The different @[SQLInsertPlan]@ are executed in sequence.

--- a/marconi-core/src/Marconi/Core/Transformer/IndexTransformer.hs
+++ b/marconi-core/src/Marconi/Core/Transformer/IndexTransformer.hs
@@ -25,7 +25,6 @@ module Marconi.Core.Transformer.IndexTransformer (
 ) where
 
 import Control.Lens (Getter, Lens', makeLenses, view)
-import Control.Monad.Except (MonadError)
 import Marconi.Core.Class (
   Closeable (close),
   IsIndex (index, indexAllDescending, rollback, setLastStablePoint),
@@ -38,7 +37,7 @@ import Marconi.Core.Class (
 import Marconi.Core.Indexer.SQLiteAggregateQuery (HasDatabasePath (getDatabasePath))
 import Marconi.Core.Indexer.SQLiteIndexer (SQLiteDBLocation)
 import Marconi.Core.Transformer.Class (IndexerTrans (unwrap))
-import Marconi.Core.Type (Point, QueryError, Result, Timed)
+import Marconi.Core.Type (Point, Result, Timed)
 
 {- | This datatype is meant to be use inside a new type by any indexer transformer.
 It wraps an indexer and attach to it a "config" (which may be stateful) used in the logic added
@@ -181,7 +180,7 @@ queryVia l p q = query p q . view l
 -}
 queryLatestVia
   :: ( Queryable m event query indexer
-     , MonadError (QueryError query) m
+     , Monad m
      , Ord (Point event)
      , IsSync m event indexer
      )

--- a/marconi-core/src/Marconi/Core/Transformer/WithAction.hs
+++ b/marconi-core/src/Marconi/Core/Transformer/WithAction.hs
@@ -24,12 +24,13 @@ import Marconi.Core.Class (
   Closeable,
   IsIndex (index, rollback, setLastStablePoint),
   IsSync,
-  Queryable,
+  Queryable (query),
  )
 import Marconi.Core.Transformer.Class (IndexerTrans, unwrap)
 import Marconi.Core.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
   indexVia,
+  queryVia,
   rollbackVia,
   setLastStablePointVia,
   wrappedIndexer,
@@ -54,10 +55,11 @@ deriving via
   instance
     (IsSync m event indexer) => IsSync m event (WithAction indexer)
 
-deriving via
-  (IndexTransformer WithActionConfig indexer)
-  instance
-    (Queryable m event query indexer) => Queryable m event query (WithAction indexer)
+instance
+  (Queryable m event query indexer)
+  => Queryable m event query (WithAction indexer)
+  where
+  query = queryVia unwrap
 
 deriving via
   (IndexTransformer WithActionConfig indexer)

--- a/marconi-core/src/Marconi/Core/Transformer/WithCache.hs
+++ b/marconi-core/src/Marconi/Core/Transformer/WithCache.hs
@@ -168,7 +168,8 @@ onForward = cacheWrapper . wrapperConfig . configOnForward
  If you want to add several indexers at the same time, use @traverse@.
 -}
 addCacheFor
-  :: (Queryable (ExceptT (QueryError query) m) event query indexer)
+  :: forall query m event indexer
+   . (Queryable (ExceptT (QueryError query) m) event query indexer)
   => (IsSync (ExceptT (QueryError query) m) event indexer)
   => (HasCacheConfig query indexer)
   => (Monad m)
@@ -179,7 +180,7 @@ addCacheFor
   -> indexer event
   -> m (indexer event)
 addCacheFor q indexer = do
-  initialResult <- runExceptT $ queryLatest q indexer
+  initialResult <- runExceptT $ queryLatest @(ExceptT (QueryError query) m) q indexer
   case initialResult of
     Left _err -> throwError $ OtherIndexError "Can't create cache"
     Right result -> pure $ indexer & cache %~ Map.insert q result

--- a/marconi-core/src/Marconi/Core/Transformer/WithCatchup.hs
+++ b/marconi-core/src/Marconi/Core/Transformer/WithCatchup.hs
@@ -30,7 +30,7 @@ import Marconi.Core.Class (
   Closeable,
   IsIndex (index, rollback, setLastStablePoint),
   IsSync,
-  Queryable,
+  Queryable (query),
   Resetable (reset),
  )
 import Marconi.Core.Indexer.SQLiteAggregateQuery (HasDatabasePath)
@@ -42,6 +42,7 @@ import Marconi.Core.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
   indexAllDescendingVia,
   indexVia,
+  queryVia,
   resetVia,
   rollbackVia,
   setLastStablePointVia,
@@ -130,10 +131,11 @@ deriving via
   instance
     (Closeable m indexer) => Closeable m (WithCatchup indexer)
 
-deriving via
-  (IndexTransformer CatchupContext indexer)
-  instance
-    (Queryable m event query indexer) => Queryable m event query (WithCatchup indexer)
+instance
+  (Queryable m event query indexer)
+  => Queryable m event query (WithCatchup indexer)
+  where
+  query = queryVia unwrap
 
 caughtUpIndexer :: Lens.Lens' (WithCatchup indexer event) (indexer event)
 caughtUpIndexer = catchupWrapper . wrappedIndexer

--- a/marconi-core/src/Marconi/Core/Transformer/WithDelay.hs
+++ b/marconi-core/src/Marconi/Core/Transformer/WithDelay.hs
@@ -26,7 +26,7 @@ import Marconi.Core.Class (
   Closeable,
   IsIndex (index, rollback, setLastStablePoint),
   IsSync,
-  Queryable,
+  Queryable (query),
   Resetable (reset),
  )
 import Marconi.Core.Indexer.SQLiteAggregateQuery (HasDatabasePath)
@@ -37,6 +37,7 @@ import Marconi.Core.Transformer.Class (
 import Marconi.Core.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
   indexVia,
+  queryVia,
   resetVia,
   rollbackVia,
   setLastStablePointVia,
@@ -90,10 +91,11 @@ deriving via
   instance
     (Closeable m indexer) => Closeable m (WithDelay indexer)
 
-deriving via
-  (IndexTransformer DelayConfig indexer)
-  instance
-    (Queryable m event query indexer) => Queryable m event query (WithDelay indexer)
+instance
+  (Queryable m event query indexer)
+  => Queryable m event query (WithDelay indexer)
+  where
+  query = queryVia delayedIndexer
 
 instance IndexerTrans WithDelay where
   unwrap = delayedIndexer

--- a/marconi-core/src/Marconi/Core/Transformer/WithPruning.hs
+++ b/marconi-core/src/Marconi/Core/Transformer/WithPruning.hs
@@ -34,7 +34,7 @@ import Marconi.Core.Class (
   HasGenesis,
   IsIndex (index, rollback, setLastStablePoint),
   IsSync,
-  Queryable,
+  Queryable (query),
   Resetable (reset),
  )
 import Marconi.Core.Indexer.MixedIndexer (MixedIndexer, inDatabase)
@@ -45,6 +45,7 @@ import Marconi.Core.Transformer.Class (
 import Marconi.Core.Transformer.IndexTransformer (
   IndexTransformer (IndexTransformer),
   indexVia,
+  queryVia,
   resetVia,
   rollbackVia,
   setLastStablePointVia,
@@ -153,10 +154,11 @@ deriving via
   instance
     (IsSync m event indexer) => IsSync m event (WithPruning indexer)
 
-deriving via
-  (IndexTransformer PruningConfig indexer)
-  instance
-    (Queryable m event query indexer) => Queryable m event query (WithPruning indexer)
+instance
+  (Queryable m event query indexer)
+  => Queryable m event query (WithPruning indexer)
+  where
+  query = queryVia unwrap
 
 deriving via
   (IndexTransformer PruningConfig indexer)

--- a/marconi-core/test/Marconi/CoreSpec.hs
+++ b/marconi-core/test/Marconi/CoreSpec.hs
@@ -1323,10 +1323,10 @@ resumeLastSyncProperty rehydrate gen =
     file <- lift $ Tmp.withSystemTempDirectory "testResume" pure
     indexer <- lift $ rehydrate file
     indexer' <- GenM.run $ foldM (flip process) indexer chain
-    indexer'' <- GenM.run $ rehydrate file
     origSyncPoint <- GenM.run $ Core.lastStablePoint indexer'
-    resumedSyncPoint <- GenM.run $ Core.lastStablePoint indexer''
     lift $ Core.close indexer'
+    indexer'' <- GenM.run $ rehydrate file
+    resumedSyncPoint <- GenM.run $ Core.lastStablePoint indexer''
     lift $ Core.close indexer''
     pure $ origSyncPoint === resumedSyncPoint
 

--- a/marconi-sidechain-experimental/test/Spec/Marconi/Sidechain/Experimental/Api/JsonRpc/Endpoint/BurnTokenEvent.hs
+++ b/marconi-sidechain-experimental/test/Spec/Marconi/Sidechain/Experimental/Api/JsonRpc/Endpoint/BurnTokenEvent.hs
@@ -79,21 +79,15 @@ propQueryMintingPolicyWithMockchain events = Test.Helpers.workspace "." $ \tmp -
 
   unless hasNoBurnEvent $ do
     policy <- Hedgehog.forAll $ getPolicyId <$> Hedgehog.Gen.element burnEvents
-
-    let
-      burnEventsWithPolicy = filter ((== policy) . getPolicyId) burnEvents
-
     configPath <- Hedgehog.evalIO Utils.getNodeConfigPath
 
-    let
-      args =
-        Utils.initTestingCliArgs
-          { CLI.dbDir = tmp
-          , CLI.nodeConfigPath = configPath
-          }
-
-    let
-      params = Sidechain.GetBurnTokenEventsParams policy Nothing Nothing Nothing
+    let burnEventsWithPolicy = filter ((== policy) . getPolicyId) burnEvents
+        args =
+          Utils.initTestingCliArgs
+            { CLI.dbDir = tmp
+            , CLI.nodeConfigPath = configPath
+            }
+        params = Sidechain.GetBurnTokenEventsParams policy Nothing Nothing Nothing
 
     -- Index then query via JSON-RPC handler
     actual <-

--- a/marconi-sidechain-experimental/test/Spec/Marconi/Sidechain/Experimental/Api/JsonRpc/Endpoint/BurnTokenEvent.hs
+++ b/marconi-sidechain-experimental/test/Spec/Marconi/Sidechain/Experimental/Api/JsonRpc/Endpoint/BurnTokenEvent.hs
@@ -8,7 +8,7 @@ module Spec.Marconi.Sidechain.Experimental.Api.JsonRpc.Endpoint.BurnTokenEvent w
 import Cardano.Api qualified as C
 import Control.Lens ((^.), (^..))
 import Control.Lens qualified as Lens
-import Control.Monad (when)
+import Control.Monad (unless)
 import Hedgehog ((===))
 import Hedgehog qualified
 import Hedgehog.Gen qualified
@@ -73,11 +73,11 @@ propQueryMintingPolicyWithMockchain events = Test.Helpers.workspace "." $ \tmp -
           . MintTokenEvent.mintTokenEvents
           . Lens.folded
           . Lens.filtered isBurn
-    hasBurnEvents = not (null burnEvents)
+    hasNoBurnEvent = null burnEvents
 
-  Hedgehog.cover 10 "At least one burn event" hasBurnEvents
+  Hedgehog.cover 10 "At least one burn event" (not hasNoBurnEvent)
 
-  when hasBurnEvents $ do
+  unless hasNoBurnEvent $ do
     policy <- Hedgehog.forAll $ getPolicyId <$> Hedgehog.Gen.element burnEvents
 
     let

--- a/marconi-sidechain-experimental/test/Spec/Marconi/Sidechain/Experimental/Utils.hs
+++ b/marconi-sidechain-experimental/test/Spec/Marconi/Sidechain/Experimental/Utils.hs
@@ -55,7 +55,6 @@ mkTestSidechainConfigsFromCliArgs cliArgs = do
         (config ^. Indexers.sidechainBuildIndexersUtxoConfig)
         (config ^. Indexers.sidechainBuildIndexersMintTokenEventConfig)
         (config ^. Indexers.sidechainBuildIndexersEpochStateConfig)
-        trace
         (mkMarconiTrace trace)
         (config ^. Indexers.sidechainBuildIndexersDbPath)
 

--- a/marconi-starter/src/Marconi/Starter/Indexers/AddressCount.hs
+++ b/marconi-starter/src/Marconi/Starter/Indexers/AddressCount.hs
@@ -22,9 +22,10 @@ module Marconi.Starter.Indexers.AddressCount where
 
 import Cardano.Api qualified as C
 import Cardano.BM.Trace (nullTracer)
+import Control.Exception (throwIO)
 import Control.Lens (at, filtered, folded, sumOf, to, (^.))
 import Control.Lens qualified as Lens
-import Control.Monad.Except (MonadError)
+import Control.Monad.Except (MonadError, runExceptT)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson (FromJSON)
 import Data.Map (Map)

--- a/marconi-starter/src/Marconi/Starter/Indexers/AddressCount.hs
+++ b/marconi-starter/src/Marconi/Starter/Indexers/AddressCount.hs
@@ -219,12 +219,12 @@ mkAddressCountSqliteIndexer dbPath = do
     addressCountInsertQuery :: SQL.Query -- AddressCount table SQL statement
     addressCountInsertQuery =
       [sql|INSERT
-               INTO address_count (
-                 address,
-                 count,
-                 slotNo,
-                 blockHeaderHash
-              ) VALUES (?, ?, ?, ?)|]
+        INTO address_count (
+          address,
+          count,
+          slotNo,
+          blockHeaderHash
+        ) VALUES (?, ?, ?, ?)|]
 
 -- | Make a SQLiteIndexer
 mkAddressCountMixedIndexer


### PR DESCRIPTION
- Use an SQL connection pool to deal with sqlite indexer queries
- Don't lock indexer on update (we don't take the indexer mvar anymore while updating it, we read it instead)
- Put `queryLatest` in the `Queryable` interface to allow queries that don't do slot comparison if it isn't needed


<!--
Here are some checklists you may like to use. Use your judgement.

This is just a checklist, all the normative suggestions are covered in more detail in CONTRIBUTING.
-->
Pre-submit checklist:
- Branch
    - [ ] Tests are provided (if possible)
    - [ ] Commit sequence broadly makes sense and have useful messages
    - [ ] Important changes are reflected in changelog.d of the affected packages
    - [ ] Relevant tickets are mentioned in commit messages
- PR
    - [ ] (For external contributions) Corresponding issue exists and is linked in the description
    - [ ] Targeting main unless this is a cherry-pick backport
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description
    - [ ] If relevant, reference the ADR in the PR and reference the PR in the ADR
    - [ ] Reviewer requested
